### PR TITLE
ss18/enhancement0

### DIFF
--- a/scripts/postprocessing/rankings.py
+++ b/scripts/postprocessing/rankings.py
@@ -68,7 +68,7 @@ def get_winner(pairs):
 def get_ranking(pairs):
     """
     Abuses concordance property to get a (not necessarily unqiue) ranking.
-    The lack of uniqueness is due to the potential existance of multiple
+    The lack of uniqueness is due to the potential existence of multiple
     equally ranked winners. We have to pick one, which is where
     the non-uniqueness comes from
     """

--- a/scripts/postprocessing/rankings.py
+++ b/scripts/postprocessing/rankings.py
@@ -99,7 +99,7 @@ def ranked_pairs(ranks: List[List[int]]):
     tallies = tallies - tallies.T
     # print(tallies)
     # note: the resulting tally matrix should be skew-symmetric
-    # order by strenght of victory (using tideman's original method, don't think it would make a difference for us)
+    # order by strength of victory (using tideman's original method, don't think it would make a difference for us)
     sorted_majorities = []
     for i in range(len(ranks[0])):
         for j in range(len(ranks[i])):

--- a/website/.env
+++ b/website/.env
@@ -5,7 +5,7 @@ DATABASE_URL=postgres://postgres:postgres@localhost:5433/ocgpt_website
 FASTAPI_URL=http://localhost:8080
 FASTAPI_KEY=1234
 
-# A dev Auth Secret.  Can be exposed if we never use this publically.
+# A dev Auth Secret.  Can be exposed if we never use this publicly.
 NEXTAUTH_SECRET=O/M2uIbGj+lDD2oyNa8ax4jEOJqCPJzO53UbWShmq98=
 
 # The SMTP host and port found by running the jobs in /scripts/frontend-development/docker-compose.yaml


### PR DESCRIPTION
Fixed typos:
existance -> existence
publically -> publicly
strenght -> strength

Found with: https://github.com/ss18/grep-typos