### PR TITLE
Refactor discord-bot to use Cogs for improved code structure

### DIFF
--- a/discord-bot/bot.py
+++ b/discord-bot/bot.py
@@ -11,7 +11,9 @@ import task_handlers
 from api_client import ApiClient, TaskType
 from bot_base import BotBase
 from discord import app_commands
+from discord.ext.commands import Bot
 from loguru import logger
+from events import OnReady, OnMessage
 from message_templates import MessageTemplates
 from oasst_shared.schemas import protocol as protocol_schema
 from utils import get_git_head_hash, utcnow
@@ -46,7 +48,10 @@ class OpenAssistantBot(BotBase):
         self.owner_id = owner_id
 
         self.bot_token = bot_token
-        client = discord.Client(intents=intents)
+        # Bot class inherits from discord.Client
+        # this improves code structure for bigger projects
+        bot = Bot(intents=intents)
+        client = bot # to be compatible with the old code
         self.client = client
         self.loop = client.loop
 

--- a/discord-bot/events/__init__.py
+++ b/discord-bot/events/__init__.py
@@ -1,0 +1,2 @@
+from .on_ready import OnReady
+from .on_message import OnMessage

--- a/discord-bot/events/on_message.py
+++ b/discord-bot/events/on_message.py
@@ -1,0 +1,40 @@
+from discord.ext.commands import Cog
+from discord import Message, MessageType, Thread
+
+class OnMessage(Cog):
+    def __init__(self, client, logger):
+        self.client = client
+        self.logger = logger
+
+    @Cog.listener()
+    async def on_message(self, message):
+        """ Called when a message is sent to a channel the bot has access to. """
+        # ignore own messages
+        if message.author != self.client.user:
+            await self.handle_message(message)
+            
+    async def handle_message(self, message: Message):
+        if not self.recipient_filter(message):
+            return
+
+        user_id = message.author.id
+        user_display_name = message.author.name
+
+        self.logger.debug(
+            f"{message.type} {message.channel.type} from ({user_display_name}) {user_id}: {message.content} ({type(message.content)})"
+        )
+
+        command_prefix = "!"
+        if message.type == MessageType.default and message.content.startswith(command_prefix):
+            is_owner = self.owner_id and user_id == self.owner_id
+            await self.handle_command(message, is_owner)
+
+        if isinstance(message.channel, Thread):
+            handler = self.reply_handlers.get(message.channel.id)
+            if handler and not handler.handler.completed:
+                handler.handler.on_reply(message)
+
+        if message.reference:
+            handler = self.reply_handlers.get(message.reference.message_id)
+            if handler and not handler.handler.completed:
+                handler.handler.on_reply(message)

--- a/discord-bot/events/on_ready.py
+++ b/discord-bot/events/on_ready.py
@@ -1,0 +1,24 @@
+from discord.ext.commands import Cog
+
+
+class OnReady(Cog):
+    def __init__(self, client, logger, bot_channel_name):
+        self.client = client
+        self.logger = logger
+        self.bot_channel_name = bot_channel_name
+        
+    @Cog.listener()
+    async def on_ready(self):
+        """
+        Called when the client is done preparing the data received from Discord.
+        Usually after login is successful and the Client.guilds and co. are filled up.
+        """
+        self.bot_channel = self.get_text_channel_by_name(self.bot_channel_name)
+        self.logger.info(f"{self.client.user} is now running!")
+
+        await self.delete_all_old_bot_messages()
+        # if self.debug:
+        #    await self.post_boot_message()
+        await self.post_welcome_message()
+
+        self.client.loop.create_task(self.background_timer(), name="OpenAssistantBot.background_timer()")


### PR DESCRIPTION
Hello,

I am submitting this pull request to improve the code structure of the discord-bot. To do this, I refactored the main instance from Client to Bot, which inherits from Client. This allows us to use .add_cog(), which helps to outsource code by organizing it into Cogs.
(more info: [Client vs Bot](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#bot), [Cogs](https://discordpy.readthedocs.io/en/stable/ext/commands/api.html#cogs) )

I have created Cogs for the following events:
- on_ready()
- on_message()
Using Cogs will allow us to better structure and organize the code in the future, particularly for larger features like the CommandTree and its associated commands.

I hope this makes sense and I would welcome any feedback on how to improve this workflow or my commits. This is my first contribution to an open source project, so I am excited to learn and improve my skills.

Thanks for considering this pull request!