### PR TITLE
fix: upsert user reaction instead of inserting

### DIFF
--- a/backend/oasst_backend/models/payload_column_type.py
+++ b/backend/oasst_backend/models/payload_column_type.py
@@ -48,6 +48,8 @@ def payload_column_type(pydantic_type):
     class PayloadJSONBType(TypeDecorator, Generic[T]):
         impl = pg.JSONB()
 
+        cache_ok = True
+
         def __init__(
             self,
             json_encoder=json,

--- a/backend/oasst_backend/prompt_repository.py
+++ b/backend/oasst_backend/prompt_repository.py
@@ -9,7 +9,7 @@ import oasst_backend.models.db_payload as db_payload
 from loguru import logger
 from oasst_backend.exceptions import OasstError, OasstErrorCode
 from oasst_backend.journal_writer import JournalWriter
-from oasst_backend.models import ApiClient, Message, MessageReaction, Task, TextLabels, User
+from oasst_backend.models import ApiClient, Journal, Message, MessageReaction, Task, TextLabels, User
 from oasst_backend.models.payload_column_type import PayloadContainer
 from oasst_shared.schemas import protocol as protocol_schema
 from oasst_shared.schemas.protocol import SystemStats
@@ -381,6 +381,10 @@ class PromptRepository:
         )
         if existing_reaction is not None:
             existing_reaction.payload = container
+            self.db.query(Journal).filter(Journal.event_payload["payload"]["task_id"].astext == str(task_id)).delete(
+                synchronize_session="fetch"
+            )
+
         else:
             new_reaction = MessageReaction(
                 task_id=task_id,


### PR DESCRIPTION
Hello, 
I played with the end to end demo and saw a bug in the `/grading/grade-output` page.  
If I submit a rating twice the second time I submit it I get the following error in the backend: 
```python
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "post_reaction_pkey"
DETAIL:  Key (post_id, person_id)=(702250a7-0f3b-4469-9e86-ab7de669e832, e5602260-05cf-4a4b-8926-7fe53f09a6dc) already exists.
```
Indeed we are trying to do an insert instead of an update.
I understand that in the end a user may not be supposed to submit a rating twice on the website (page updated once submited).

But depending on the frontend it can be nice to have an update instead (e.g. discord)
![openassistant_upsert](https://user-images.githubusercontent.com/63861105/209738129-81f0add1-b8a7-42dd-ba49-be9e12ee6e1c.gif)
(In the discord example when I try to "update" the rating it failed)

I don't know if this is also nice to have for `insert_post`, let me know if you want me to also change it.