### PR TITLE
Adding a specific layout for Home

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -4898,23 +4898,10 @@
         }
       }
     },
-    "node_modules/@storybook/builder-webpack4/node_modules/@types/html-minifier-terser": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@storybook/builder-webpack4/node_modules/@types/node": {
       "version": "16.18.11",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/ansi-styles": {
       "version": "3.2.1",
@@ -4992,17 +4979,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/@storybook/builder-webpack4/node_modules/clean-css": {
-      "version": "4.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
     "node_modules/@storybook/builder-webpack4/node_modules/color-convert": {
       "version": "1.9.3",
       "dev": true,
@@ -5015,14 +4991,6 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/commander": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/css-loader": {
       "version": "3.6.0",
@@ -5173,82 +5141,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/html-minifier-terser": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.1",
-        "clean-css": "^4.2.3",
-        "commander": "^4.1.1",
-        "he": "^1.2.0",
-        "param-case": "^3.0.3",
-        "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/html-minifier-terser/node_modules/terser": {
-      "version": "4.8.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/html-webpack-plugin": {
-      "version": "4.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/html-minifier-terser": "^5.0.0",
-        "@types/tapable": "^1.0.5",
-        "@types/webpack": "^4.41.8",
-        "html-minifier-terser": "^5.0.1",
-        "loader-utils": "^1.2.3",
-        "lodash": "^4.17.20",
-        "pretty-error": "^2.1.1",
-        "tapable": "^1.1.3",
-        "util.promisify": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/html-webpack-plugin/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/icss-utils": {
@@ -5482,27 +5374,6 @@
         "postcss": "^7.0.6"
       }
     },
-    "node_modules/@storybook/builder-webpack4/node_modules/pretty-error": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "renderkid": "^2.0.4"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/renderkid": {
-      "version": "2.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^4.1.3",
-        "dom-converter": "^0.2.0",
-        "htmlparser2": "^6.1.0",
-        "lodash": "^4.17.21",
-        "strip-ansi": "^3.0.1"
-      }
-    },
     "node_modules/@storybook/builder-webpack4/node_modules/semver": {
       "version": "6.3.0",
       "dev": true,
@@ -5523,17 +5394,6 @@
       "version": "0.6.1",
       "dev": true,
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/builder-webpack4/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6570,42 +6430,10 @@
         }
       }
     },
-    "node_modules/@storybook/manager-webpack4/node_modules/@types/html-minifier-terser": {
-      "version": "5.1.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@storybook/manager-webpack4/node_modules/@types/node": {
       "version": "16.18.11",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/ansi-regex": {
-      "version": "2.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/clean-css": {
-      "version": "4.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "source-map": "~0.6.0"
-      },
-      "engines": {
-        "node": ">= 4.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/commander": {
-      "version": "4.1.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/css-loader": {
       "version": "3.6.0",
@@ -6689,82 +6517,6 @@
       },
       "funding": {
         "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/html-minifier-terser": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "camel-case": "^4.1.1",
-        "clean-css": "^4.2.3",
-        "commander": "^4.1.1",
-        "he": "^1.2.0",
-        "param-case": "^3.0.3",
-        "relateurl": "^0.2.7",
-        "terser": "^4.6.3"
-      },
-      "bin": {
-        "html-minifier-terser": "cli.js"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/html-minifier-terser/node_modules/terser": {
-      "version": "4.8.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
-      },
-      "bin": {
-        "terser": "bin/terser"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/html-minifier-terser/node_modules/terser/node_modules/commander": {
-      "version": "2.20.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/html-webpack-plugin": {
-      "version": "4.5.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/html-minifier-terser": "^5.0.0",
-        "@types/tapable": "^1.0.5",
-        "@types/webpack": "^4.41.8",
-        "html-minifier-terser": "^5.0.1",
-        "loader-utils": "^1.2.3",
-        "lodash": "^4.17.20",
-        "pretty-error": "^2.1.1",
-        "tapable": "^1.1.3",
-        "util.promisify": "1.0.0"
-      },
-      "engines": {
-        "node": ">=6.9"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/html-webpack-plugin/node_modules/loader-utils": {
-      "version": "1.4.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "big.js": "^5.2.2",
-        "emojis-list": "^3.0.0",
-        "json5": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=4.0.0"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/icss-utils": {
@@ -6940,27 +6692,6 @@
         "postcss": "^7.0.6"
       }
     },
-    "node_modules/@storybook/manager-webpack4/node_modules/pretty-error": {
-      "version": "2.1.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash": "^4.17.20",
-        "renderkid": "^2.0.4"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/renderkid": {
-      "version": "2.0.7",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "css-select": "^4.1.3",
-        "dom-converter": "^0.2.0",
-        "htmlparser2": "^6.1.0",
-        "lodash": "^4.17.21",
-        "strip-ansi": "^3.0.1"
-      }
-    },
     "node_modules/@storybook/manager-webpack4/node_modules/resolve-from": {
       "version": "5.0.0",
       "dev": true,
@@ -6989,17 +6720,6 @@
       "version": "0.6.1",
       "dev": true,
       "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/strip-ansi": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-regex": "^2.0.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7038,14 +6758,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
-    },
-    "node_modules/@storybook/manager-webpack4/node_modules/tapable": {
-      "version": "1.1.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/terser-webpack-plugin": {
@@ -10579,7 +10291,8 @@
     },
     "node_modules/clsx": {
       "version": "1.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -14336,6 +14049,176 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/html-webpack-plugin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
+      "integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
+      "dev": true,
+      "dependencies": {
+        "@types/html-minifier-terser": "^5.0.0",
+        "@types/tapable": "^1.0.5",
+        "@types/webpack": "^4.41.8",
+        "html-minifier-terser": "^5.0.1",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.20",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.3",
+        "util.promisify": "1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9"
+      },
+      "peerDependencies": {
+        "webpack": "^4.0.0 || ^5.0.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/@types/html-minifier-terser": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
+      "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
+      "dev": true
+    },
+    "node_modules/html-webpack-plugin/node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/clean-css": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+      "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+      "dev": true,
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 4.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/html-minifier-terser": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+      "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+      "dev": true,
+      "dependencies": {
+        "camel-case": "^4.1.1",
+        "clean-css": "^4.2.3",
+        "commander": "^4.1.1",
+        "he": "^1.2.0",
+        "param-case": "^3.0.3",
+        "relateurl": "^0.2.7",
+        "terser": "^4.6.3"
+      },
+      "bin": {
+        "html-minifier-terser": "cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "dev": true,
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/pretty-error": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
+      "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.20",
+        "renderkid": "^2.0.4"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/renderkid": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+      "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+      "dev": true,
+      "dependencies": {
+        "css-select": "^4.1.3",
+        "dom-converter": "^0.2.0",
+        "htmlparser2": "^6.1.0",
+        "lodash": "^4.17.21",
+        "strip-ansi": "^3.0.1"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/tapable": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/terser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "dev": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/html-webpack-plugin/node_modules/terser/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
     },
     "node_modules/htmlparser2": {
       "version": "6.1.0",
@@ -25599,16 +25482,8 @@
         "webpack-virtual-modules": "^0.2.2"
       },
       "dependencies": {
-        "@types/html-minifier-terser": {
-          "version": "5.1.2",
-          "dev": true
-        },
         "@types/node": {
           "version": "16.18.11",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
           "dev": true
         },
         "ansi-styles": {
@@ -25665,13 +25540,6 @@
             "supports-color": "^5.3.0"
           }
         },
-        "clean-css": {
-          "version": "4.2.4",
-          "dev": true,
-          "requires": {
-            "source-map": "~0.6.0"
-          }
-        },
         "color-convert": {
           "version": "1.9.3",
           "dev": true,
@@ -25681,10 +25549,6 @@
         },
         "color-name": {
           "version": "1.1.3",
-          "dev": true
-        },
-        "commander": {
-          "version": "4.1.1",
           "dev": true
         },
         "css-loader": {
@@ -25787,62 +25651,6 @@
         "has-flag": {
           "version": "3.0.0",
           "dev": true
-        },
-        "html-minifier-terser": {
-          "version": "5.1.1",
-          "dev": true,
-          "requires": {
-            "camel-case": "^4.1.1",
-            "clean-css": "^4.2.3",
-            "commander": "^4.1.1",
-            "he": "^1.2.0",
-            "param-case": "^3.0.3",
-            "relateurl": "^0.2.7",
-            "terser": "^4.6.3"
-          },
-          "dependencies": {
-            "terser": {
-              "version": "4.8.1",
-              "dev": true,
-              "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-              },
-              "dependencies": {
-                "commander": {
-                  "version": "2.20.3",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "html-webpack-plugin": {
-          "version": "4.5.2",
-          "dev": true,
-          "requires": {
-            "@types/html-minifier-terser": "^5.0.0",
-            "@types/tapable": "^1.0.5",
-            "@types/webpack": "^4.41.8",
-            "html-minifier-terser": "^5.0.1",
-            "loader-utils": "^1.2.3",
-            "lodash": "^4.17.20",
-            "pretty-error": "^2.1.1",
-            "tapable": "^1.1.3",
-            "util.promisify": "1.0.0"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "1.4.2",
-              "dev": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-              }
-            }
-          }
         },
         "icss-utils": {
           "version": "4.1.1",
@@ -25997,25 +25805,6 @@
             "postcss": "^7.0.6"
           }
         },
-        "pretty-error": {
-          "version": "2.1.2",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.20",
-            "renderkid": "^2.0.4"
-          }
-        },
-        "renderkid": {
-          "version": "2.0.7",
-          "dev": true,
-          "requires": {
-            "css-select": "^4.1.3",
-            "dom-converter": "^0.2.0",
-            "htmlparser2": "^6.1.0",
-            "lodash": "^4.17.21",
-            "strip-ansi": "^3.0.1"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "dev": true
@@ -26030,13 +25819,6 @@
         "source-map": {
           "version": "0.6.1",
           "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
         },
         "style-loader": {
           "version": "1.3.0",
@@ -26772,27 +26554,8 @@
         "webpack-virtual-modules": "^0.2.2"
       },
       "dependencies": {
-        "@types/html-minifier-terser": {
-          "version": "5.1.2",
-          "dev": true
-        },
         "@types/node": {
           "version": "16.18.11",
-          "dev": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "dev": true
-        },
-        "clean-css": {
-          "version": "4.2.4",
-          "dev": true,
-          "requires": {
-            "source-map": "~0.6.0"
-          }
-        },
-        "commander": {
-          "version": "4.1.1",
           "dev": true
         },
         "css-loader": {
@@ -26848,62 +26611,6 @@
             "commondir": "^1.0.1",
             "make-dir": "^3.0.2",
             "pkg-dir": "^4.1.0"
-          }
-        },
-        "html-minifier-terser": {
-          "version": "5.1.1",
-          "dev": true,
-          "requires": {
-            "camel-case": "^4.1.1",
-            "clean-css": "^4.2.3",
-            "commander": "^4.1.1",
-            "he": "^1.2.0",
-            "param-case": "^3.0.3",
-            "relateurl": "^0.2.7",
-            "terser": "^4.6.3"
-          },
-          "dependencies": {
-            "terser": {
-              "version": "4.8.1",
-              "dev": true,
-              "requires": {
-                "commander": "^2.20.0",
-                "source-map": "~0.6.1",
-                "source-map-support": "~0.5.12"
-              },
-              "dependencies": {
-                "commander": {
-                  "version": "2.20.3",
-                  "dev": true
-                }
-              }
-            }
-          }
-        },
-        "html-webpack-plugin": {
-          "version": "4.5.2",
-          "dev": true,
-          "requires": {
-            "@types/html-minifier-terser": "^5.0.0",
-            "@types/tapable": "^1.0.5",
-            "@types/webpack": "^4.41.8",
-            "html-minifier-terser": "^5.0.1",
-            "loader-utils": "^1.2.3",
-            "lodash": "^4.17.20",
-            "pretty-error": "^2.1.1",
-            "tapable": "^1.1.3",
-            "util.promisify": "1.0.0"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "1.4.2",
-              "dev": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^3.0.0",
-                "json5": "^1.0.1"
-              }
-            }
           }
         },
         "icss-utils": {
@@ -27016,25 +26723,6 @@
             "postcss": "^7.0.6"
           }
         },
-        "pretty-error": {
-          "version": "2.1.2",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.20",
-            "renderkid": "^2.0.4"
-          }
-        },
-        "renderkid": {
-          "version": "2.0.7",
-          "dev": true,
-          "requires": {
-            "css-select": "^4.1.3",
-            "dom-converter": "^0.2.0",
-            "htmlparser2": "^6.1.0",
-            "lodash": "^4.17.21",
-            "strip-ansi": "^3.0.1"
-          }
-        },
         "resolve-from": {
           "version": "5.0.0",
           "dev": true
@@ -27054,13 +26742,6 @@
           "version": "0.6.1",
           "dev": true
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
         "style-loader": {
           "version": "1.3.0",
           "dev": true,
@@ -27079,10 +26760,6 @@
               }
             }
           }
-        },
-        "tapable": {
-          "version": "1.1.3",
-          "dev": true
         },
         "terser-webpack-plugin": {
           "version": "4.2.3",
@@ -29512,7 +29189,9 @@
       }
     },
     "clsx": {
-      "version": "1.2.1"
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "collapse-white-space": {
       "version": "1.0.6",
@@ -32091,6 +31770,141 @@
     "html-void-elements": {
       "version": "1.0.5",
       "dev": true
+    },
+    "html-webpack-plugin": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-4.5.2.tgz",
+      "integrity": "sha512-q5oYdzjKUIPQVjOosjgvCHQOv9Ett9CYYHlgvJeXG0qQvdSojnBq4vAdQBwn1+yGveAwHCoe/rMR86ozX3+c2A==",
+      "dev": true,
+      "requires": {
+        "@types/html-minifier-terser": "^5.0.0",
+        "@types/tapable": "^1.0.5",
+        "@types/webpack": "^4.41.8",
+        "html-minifier-terser": "^5.0.1",
+        "loader-utils": "^1.2.3",
+        "lodash": "^4.17.20",
+        "pretty-error": "^2.1.1",
+        "tapable": "^1.1.3",
+        "util.promisify": "1.0.0"
+      },
+      "dependencies": {
+        "@types/html-minifier-terser": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz",
+          "integrity": "sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==",
+          "dev": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
+          "dev": true
+        },
+        "clean-css": {
+          "version": "4.2.4",
+          "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-4.2.4.tgz",
+          "integrity": "sha512-EJUDT7nDVFDvaQgAo2G/PJvxmp1o/c6iXLbswsBbUFXi1Nr+AjA2cKmfbKDMjMvzEe75g3P6JkaDDAKk96A85A==",
+          "dev": true,
+          "requires": {
+            "source-map": "~0.6.0"
+          }
+        },
+        "commander": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "dev": true
+        },
+        "html-minifier-terser": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/html-minifier-terser/-/html-minifier-terser-5.1.1.tgz",
+          "integrity": "sha512-ZPr5MNObqnV/T9akshPKbVgyOqLmy+Bxo7juKCfTfnjNniTAMdy4hz21YQqoofMBJD2kdREaqPPdThoR78Tgxg==",
+          "dev": true,
+          "requires": {
+            "camel-case": "^4.1.1",
+            "clean-css": "^4.2.3",
+            "commander": "^4.1.1",
+            "he": "^1.2.0",
+            "param-case": "^3.0.3",
+            "relateurl": "^0.2.7",
+            "terser": "^4.6.3"
+          }
+        },
+        "loader-utils": {
+          "version": "1.4.2",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+          "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^3.0.0",
+            "json5": "^1.0.1"
+          }
+        },
+        "pretty-error": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/pretty-error/-/pretty-error-2.1.2.tgz",
+          "integrity": "sha512-EY5oDzmsX5wvuynAByrmY0P0hcp+QpnAKbJng2A2MPjVKXCxrDSUkzghVJ4ZGPIv+JC4gX8fPUWscC0RtjsWGw==",
+          "dev": true,
+          "requires": {
+            "lodash": "^4.17.20",
+            "renderkid": "^2.0.4"
+          }
+        },
+        "renderkid": {
+          "version": "2.0.7",
+          "resolved": "https://registry.npmjs.org/renderkid/-/renderkid-2.0.7.tgz",
+          "integrity": "sha512-oCcFyxaMrKsKcTY59qnCAtmDVSLfPbrv6A3tVbPdFMMrv5jaK10V6m40cKsoPNhAqN6rmHW9sswW4o3ruSrwUQ==",
+          "dev": true,
+          "requires": {
+            "css-select": "^4.1.3",
+            "dom-converter": "^0.2.0",
+            "htmlparser2": "^6.1.0",
+            "lodash": "^4.17.21",
+            "strip-ansi": "^3.0.1"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
+        },
+        "tapable": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+          "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+          "dev": true
+        },
+        "terser": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+          "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+          "dev": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          },
+          "dependencies": {
+            "commander": {
+              "version": "2.20.3",
+              "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+              "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+              "dev": true
+            }
+          }
+        }
+      }
     },
     "htmlparser2": {
       "version": "6.1.0",

--- a/website/src/components/Header/Header.stories.jsx
+++ b/website/src/components/Header/Header.stories.jsx
@@ -21,4 +21,4 @@ const Template = (args) => {
 };
 
 export const Default = Template.bind({});
-Default.args = { session: { data: { user: { name: "StoryBook user" } }, status: "authenticated" } };
+Default.args = { session: { data: { user: { name: "StoryBook user" } }, status: "authenticated" }, transparent: false };

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -5,6 +5,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { signOut, useSession } from "next-auth/react";
 import { FaUser, FaSignOutAlt } from "react-icons/fa";
+import clsx from "clsx";
 
 import { Container } from "src/components/Container";
 import { NavLinks } from "./NavLinks";
@@ -53,9 +54,10 @@ function AccountButton() {
   );
 }
 
-export function Header() {
+export function Header(props) {
+  const transparent = props.transparent ?? false;
   return (
-    <header className="bg-white">
+    <header className={`${clsx({'bg-transparent':transparent, 'bg-white':!transparent})}`}>
       <nav>
         <Container className="relative z-10 flex justify-between py-8">
           <div className="relative z-10 flex items-center gap-16">

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -57,7 +57,7 @@ function AccountButton() {
 export function Header(props) {
   const transparent = props.transparent ?? false;
   return (
-    <header className={`${clsx({'bg-transparent':transparent, 'bg-white':!transparent})}`}>
+    <header className={`${clsx({ "bg-transparent": transparent, "bg-white": !transparent })}`}>
       <nav>
         <Container className="relative z-10 flex justify-between py-8">
           <div className="relative z-10 flex items-center gap-16">

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -57,7 +57,7 @@ function AccountButton() {
 export function Header(props) {
   const transparent = props.transparent ?? false;
   return (
-    <header className={`${clsx({ "bg-transparent": transparent, "bg-white": !transparent })}`}>
+    <header className={clsx(!transparent && "bg-white")}>
       <nav>
         <Container className="relative z-10 flex justify-between py-8">
           <div className="relative z-10 flex items-center gap-16">

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -5,6 +5,8 @@ import { CallToAction } from "src/components/CallToAction";
 import { Faq } from "src/components/Faq";
 import { Hero } from "src/components/Hero";
 import { TaskSelection } from "src/components/TaskSelection";
+import { Header } from "src/components/Header";
+import { Footer } from "src/components/Footer";
 
 const Home = () => {
   const { data: session } = useSession();
@@ -33,5 +35,13 @@ const Home = () => {
     </>
   );
 };
+
+Home.getLayout = (page) => (
+  <div className="grid grid-rows-[min-content_1fr_min-content] h-full justify-items-stretch">
+    <Header transparent={true}/>
+    {page}
+    <Footer />
+  </div>
+);
 
 export default Home;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -38,7 +38,7 @@ const Home = () => {
 
 Home.getLayout = (page) => (
   <div className="grid grid-rows-[min-content_1fr_min-content] h-full justify-items-stretch">
-    <Header transparent={true}/>
+    <Header transparent={true} />
     {page}
     <Footer />
   </div>


### PR DESCRIPTION
* Adds a specific layout to Home page, so it can have (header / footer / grid / etc) choices independent of other pages.
* Makes the header transparent on home (it was originally transparent, and recently became white in a change aimed at making the header look better for signed-in pages)

Use this pattern any time a page needs a different layout:

`ThePage.getLayout = (page) => ( ... )`