### PR TITLE
Fix linter warnings

### DIFF
--- a/website/.eslintrc.json
+++ b/website/.eslintrc.json
@@ -6,19 +6,9 @@
     "next/core-web-vitals"
   ],
   "rules": {
-    "simple-import-sort/imports": "error",
-    "simple-import-sort/exports": "error",
-    "@typescript-eslint/no-unused-vars": "off",
-    "unused-imports/no-unused-imports": "error",
-    "unused-imports/no-unused-vars": [
-      "warn",
-      {
-        "vars": "all",
-        "varsIgnorePattern": "^_",
-        "args": "after-used",
-        "argsIgnorePattern": "^_"
-      }
-    ]
+    "unused-imports/no-unused-imports": "warn",
+    "simple-import-sort/imports": "warn",
+    "simple-import-sort/exports": "warn"
   },
   "plugins": ["simple-import-sort", "unused-imports"]
 }

--- a/website/.eslintrc.json
+++ b/website/.eslintrc.json
@@ -6,6 +6,19 @@
     "next/core-web-vitals"
   ],
   "rules": {
-    "sort-imports": "warn"
-  }
+    "simple-import-sort/imports": "error",
+    "simple-import-sort/exports": "error",
+    "@typescript-eslint/no-unused-vars": "off",
+    "unused-imports/no-unused-imports": "error",
+    "unused-imports/no-unused-vars": [
+      "warn",
+      {
+        "vars": "all",
+        "varsIgnorePattern": "^_",
+        "args": "after-used",
+        "argsIgnorePattern": "^_"
+      }
+    ]
+  },
+  "plugins": ["simple-import-sort", "unused-imports"]
 }

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -24,6 +24,7 @@
         "clsx": "^1.2.1",
         "eslint": "8.29.0",
         "eslint-config-next": "13.0.6",
+        "eslint-plugin-simple-import-sort": "^8.0.0",
         "focus-visible": "^5.2.0",
         "framer-motion": "^6.5.1",
         "next": "13.0.6",
@@ -57,6 +58,7 @@
         "cypress": "^12.2.0",
         "cypress-image-diff-js": "^1.23.0",
         "eslint-plugin-storybook": "^0.6.8",
+        "eslint-plugin-unused-imports": "^2.0.0",
         "prettier": "2.8.1",
         "prisma": "^4.7.1",
         "typescript": "4.9.4"
@@ -16344,6 +16346,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/eslint-plugin-simple-import-sort": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz",
+      "integrity": "sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==",
+      "peerDependencies": {
+        "eslint": ">=5.0.0"
+      }
+    },
     "node_modules/eslint-plugin-storybook": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.8.tgz",
@@ -16369,6 +16379,36 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.15"
+      }
+    },
+    "node_modules/eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "dependencies": {
+        "eslint-rule-composer": "^0.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^5.0.0",
+        "eslint": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -40976,6 +41016,12 @@
       "integrity": "sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==",
       "requires": {}
     },
+    "eslint-plugin-simple-import-sort": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz",
+      "integrity": "sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==",
+      "requires": {}
+    },
     "eslint-plugin-storybook": {
       "version": "0.6.8",
       "resolved": "https://registry.npmjs.org/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.8.tgz",
@@ -40998,6 +41044,21 @@
           }
         }
       }
+    },
+    "eslint-plugin-unused-imports": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz",
+      "integrity": "sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==",
+      "dev": true,
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
+    "eslint-rule-composer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz",
+      "integrity": "sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",

--- a/website/package.json
+++ b/website/package.json
@@ -13,9 +13,9 @@
     "cypress": "cypress open",
     "cypress:run": "cypress run",
     "cypress:image-baseline": "cypress-image-diff -u",
-    "fix:lint": "eslint --fix src/",
+    "fix:lint": "eslint --fix src/ --ext .js,.jsx,.ts,.tsx",
     "fix:format": "prettier --write ./src",
-    "fix": "npm run fix:lint && npm run fix:format"
+    "fix": "npm run fix:format && npm run fix:lint"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.4.4",

--- a/website/package.json
+++ b/website/package.json
@@ -12,7 +12,10 @@
     "build-storybook": "build-storybook",
     "cypress": "cypress open",
     "cypress:run": "cypress run",
-    "cypress:image-baseline": "cypress-image-diff -u"
+    "cypress:image-baseline": "cypress-image-diff -u",
+    "fix:lint": "eslint --fix src/",
+    "fix:format": "prettier --write ./src",
+    "fix": "npm run fix:lint && npm run fix:format"
   },
   "dependencies": {
     "@chakra-ui/react": "^2.4.4",
@@ -31,6 +34,7 @@
     "clsx": "^1.2.1",
     "eslint": "8.29.0",
     "eslint-config-next": "13.0.6",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
     "focus-visible": "^5.2.0",
     "framer-motion": "^6.5.1",
     "next": "13.0.6",
@@ -64,6 +68,7 @@
     "cypress": "^12.2.0",
     "cypress-image-diff-js": "^1.23.0",
     "eslint-plugin-storybook": "^0.6.8",
+    "eslint-plugin-unused-imports": "^2.0.0",
     "prettier": "2.8.1",
     "prisma": "^4.7.1",
     "typescript": "4.9.4"

--- a/website/src/components/Container.cy.tsx
+++ b/website/src/components/Container.cy.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Container } from "./Container";
 
 describe("<Container />", () => {

--- a/website/src/components/Faq.tsx
+++ b/website/src/components/Faq.tsx
@@ -1,5 +1,3 @@
-import Link from "next/link";
-
 import { Container } from "./Container";
 
 const faqs = [

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+
 import { Container } from "./Container";
 
 export function Footer() {

--- a/website/src/components/Header/Header.stories.jsx
+++ b/website/src/components/Header/Header.stories.jsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import { Header } from "./Header";
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   title: "Header/Header",
   component: Header,

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -1,14 +1,13 @@
 import { Button } from "@chakra-ui/react";
 import { Popover } from "@headlessui/react";
+import clsx from "clsx";
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
-
-import { signOut, useSession } from "next-auth/react";
-import { FaUser, FaSignOutAlt } from "react-icons/fa";
-import clsx from "clsx";
-
+import { useSession } from "next-auth/react";
+import { FaUser } from "react-icons/fa";
 import { Container } from "src/components/Container";
+
 import { NavLinks } from "./NavLinks";
 import { UserMenu } from "./UserMenu";
 

--- a/website/src/components/Header/NavLinks.stories.jsx
+++ b/website/src/components/Header/NavLinks.stories.jsx
@@ -1,5 +1,6 @@
 import { NavLinks } from "./NavLinks";
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   title: "Header/NavLinks",
   component: NavLinks,

--- a/website/src/components/Header/NavLinks.tsx
+++ b/website/src/components/Header/NavLinks.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
-import Link from "next/link";
 import { AnimatePresence, motion } from "framer-motion";
+import Link from "next/link";
+import { useState } from "react";
 
 export function NavLinks(): JSX.Element {
   const [hoveredIndex, setHoveredIndex] = useState(null);

--- a/website/src/components/Header/UserMenu.stories.jsx
+++ b/website/src/components/Header/UserMenu.stories.jsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import UserMenu from "./UserMenu";
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   title: "Header/UserMenu",
   component: UserMenu,

--- a/website/src/components/Header/UserMenu.tsx
+++ b/website/src/components/Header/UserMenu.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { signOut, useSession } from "next-auth/react";
-import Image from "next/image";
 import { Popover } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
+import Image from "next/image";
+import { signOut, useSession } from "next-auth/react";
+import React from "react";
 import { FaCog, FaSignOutAlt } from "react-icons/fa";
 
 export function UserMenu() {

--- a/website/src/components/Header/UserMenu.tsx
+++ b/website/src/components/Header/UserMenu.tsx
@@ -12,7 +12,6 @@ export function UserMenu() {
     return <></>;
   }
   if (session && session.user) {
-    const email = session.user.email;
     const accountOptions = [
       {
         name: "Account Settings",

--- a/website/src/components/Header/index.ts
+++ b/website/src/components/Header/index.ts
@@ -1,3 +1,3 @@
 export { Header } from "./Header";
-export { UserMenu } from "./UserMenu";
 export { NavLinks } from "./NavLinks";
+export { UserMenu } from "./UserMenu";

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -1,5 +1,5 @@
-import { useId } from "react";
 import Image from "next/image";
+import { useId } from "react";
 
 import { Container } from "./Container";
 

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -1,9 +1,9 @@
 // https://nextjs.org/docs/basic-features/layouts
 
 import type { NextPage } from "next";
+import { Header } from "src/components/Header";
 
 import { Footer } from "./Footer";
-import { Header } from "src/components/Header";
 
 export type NextPageWithLayout<P = unknown, IP = P> = NextPage<P, IP> & {
   getLayout?: (page: React.ReactElement) => React.ReactNode;

--- a/website/src/components/Loading/Loading.stories.jsx
+++ b/website/src/components/Loading/Loading.stories.jsx
@@ -1,5 +1,6 @@
 import { LoadingScreen } from "./LoadingScreen";
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   title: "Example/LoadingScreen",
   component: LoadingScreen,

--- a/website/src/components/RankItem.tsx
+++ b/website/src/components/RankItem.tsx
@@ -2,8 +2,8 @@ const RankItem = ({ username, score }) => {
   return (
     <div className="flex flex-row justify-between p-6 border-2 border-slate-100 text-left font-semibold hover:bg-sky-50">
       <div>1</div>
-      <div>@username</div>
-      <div>20.5</div>
+      <div>{username}</div>
+      <div>{score}</div>
       <div>gold</div>
     </div>
   );

--- a/website/src/components/RatingRadioGroup.tsx
+++ b/website/src/components/RatingRadioGroup.tsx
@@ -1,7 +1,7 @@
 import { Box, HStack, useRadio, useRadioGroup } from "@chakra-ui/react";
 
 const RatingRadioButton = (props) => {
-  const { state, getInputProps, getCheckboxProps } = useRadio(props);
+  const { getInputProps, getCheckboxProps } = useRadio(props);
 
   const input = getInputProps();
   const checkbox = getCheckboxProps();

--- a/website/src/components/Sortable/Sortable.tsx
+++ b/website/src/components/Sortable/Sortable.tsx
@@ -1,8 +1,9 @@
-import { DndContext, PointerSensor, TouchSensor, closestCenter, useSensor, useSensors } from "@dnd-kit/core";
-import { ReactNode, useEffect, useState } from "react";
-import { SortableContext, arrayMove, verticalListSortingStrategy } from "@dnd-kit/sortable";
-import type { DragEndEvent } from "@dnd-kit/core/dist/types/events";
 import { Flex } from "@chakra-ui/react";
+import { closestCenter, DndContext, PointerSensor, TouchSensor, useSensor, useSensors } from "@dnd-kit/core";
+import type { DragEndEvent } from "@dnd-kit/core/dist/types/events";
+import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import { ReactNode, useEffect, useState } from "react";
+
 import { SortableItem } from "./SortableItem";
 
 export interface SortableProps {

--- a/website/src/components/Sortable/SortableItem.tsx
+++ b/website/src/components/Sortable/SortableItem.tsx
@@ -1,6 +1,6 @@
+import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { PropsWithChildren } from "react";
-import { useSortable } from "@dnd-kit/sortable";
 
 export const SortableItem = ({ children, id }: PropsWithChildren<{ id: number }>) => {
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id });

--- a/website/src/components/TaskInfo/TaskInfo.tsx
+++ b/website/src/components/TaskInfo/TaskInfo.tsx
@@ -1,4 +1,4 @@
-export const TaskInfo = ({ id, output }: { id: string; output: any }) => {
+export const TaskInfo = ({ id, output }: { id: string; output: string }) => {
   return (
     <div className="grid grid-cols-[min-content_auto] gap-x-2 text-gray-700">
       <b>Prompt</b>

--- a/website/src/components/TaskSelection/TaskSelection.tsx
+++ b/website/src/components/TaskSelection/TaskSelection.tsx
@@ -1,7 +1,8 @@
-import React from "react";
-import { TaskOptions } from "./TaskOptions";
 import { Flex } from "@chakra-ui/react";
+import React from "react";
+
 import { TaskOption } from "./TaskOption";
+import { TaskOptions } from "./TaskOptions";
 
 export const TaskSelection = () => {
   return (

--- a/website/src/components/TaskSelection/index.ts
+++ b/website/src/components/TaskSelection/index.ts
@@ -1,3 +1,3 @@
-export { TaskSelection } from "./TaskSelection";
-export { TaskOptions } from "./TaskOptions";
 export { TaskOption } from "./TaskOption";
+export { TaskOptions } from "./TaskOptions";
+export { TaskSelection } from "./TaskSelection";

--- a/website/src/pages/404.tsx
+++ b/website/src/pages/404.tsx
@@ -1,8 +1,4 @@
-import { useSession } from "next-auth/react";
-import { Footer } from "../components/Footer";
-import { Header } from "src/components/Header";
 import Head from "next/head";
-import Link from "next/link";
 
 export default function Error() {
   return (

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -1,13 +1,12 @@
-import { ChakraProvider } from "@chakra-ui/react";
-import { SessionProvider } from "next-auth/react";
-import { Inter } from "@next/font/google";
-import { extendTheme } from "@chakra-ui/react";
-import type { AppProps } from "next/app";
-
-import { NextPageWithLayout, getDefaultLayout } from "src/components/Layout";
-
 import "../styles/globals.css";
 import "focus-visible";
+
+import { ChakraProvider } from "@chakra-ui/react";
+import { extendTheme } from "@chakra-ui/react";
+import { Inter } from "@next/font/google";
+import type { AppProps } from "next/app";
+import { SessionProvider } from "next-auth/react";
+import { getDefaultLayout, NextPageWithLayout } from "src/components/Layout";
 
 const inter = Inter({
   subsets: ["latin"],

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -8,6 +8,7 @@ import type { AppProps } from "next/app";
 import { SessionProvider } from "next-auth/react";
 import { getDefaultLayout, NextPageWithLayout } from "src/components/Layout";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const inter = Inter({
   subsets: ["latin"],
   variable: "--font-inter",

--- a/website/src/pages/account/edit.tsx
+++ b/website/src/pages/account/edit.tsx
@@ -1,8 +1,8 @@
-import React, { useState } from "react";
-import { useSession } from "next-auth/react";
-import { Button, Input, InputGroup, Stack } from "@chakra-ui/react";
+import { Button, Input, InputGroup } from "@chakra-ui/react";
 import Head from "next/head";
 import Router from "next/router";
+import { useSession } from "next-auth/react";
+import React, { useState } from "react";
 
 export default function Account() {
   const { data: session } = useSession();

--- a/website/src/pages/account/index.tsx
+++ b/website/src/pages/account/index.tsx
@@ -1,8 +1,8 @@
+import { Button } from "@chakra-ui/react";
 import Head from "next/head";
 import Link from "next/link";
-import React, { useState } from "react";
 import { useSession } from "next-auth/react";
-import { Button } from "@chakra-ui/react";
+import React, { useState } from "react";
 
 export default function Account() {
   const { data: session } = useSession();

--- a/website/src/pages/account/index.tsx
+++ b/website/src/pages/account/index.tsx
@@ -8,6 +8,7 @@ export default function Account() {
   const { data: session } = useSession();
   const [username, setUsername] = useState("null");
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const handleUpdate = async () => {
     const response = await fetch("../api/update", {
       method: "POST",

--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -1,12 +1,10 @@
-import type { AuthOptions } from "next-auth";
-import NextAuth from "next-auth";
-import { NextApiHandler } from "next";
-import DiscordProvider from "next-auth/providers/discord";
-import EmailProvider from "next-auth/providers/email";
-import CredentialsProvider from "next-auth/providers/credentials";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { boolean } from "boolean";
-
+import type { AuthOptions } from "next-auth";
+import NextAuth from "next-auth";
+import CredentialsProvider from "next-auth/providers/credentials";
+import DiscordProvider from "next-auth/providers/discord";
+import EmailProvider from "next-auth/providers/email";
 import prisma from "src/lib/prismadb";
 
 const providers = [];

--- a/website/src/pages/api/new_task/[task_type].ts
+++ b/website/src/pages/api/new_task/[task_type].ts
@@ -1,7 +1,5 @@
 import { getToken } from "next-auth/jwt";
-
 import prisma from "src/lib/prismadb";
-import { authOptions } from "src/pages/api/auth/[...nextauth]";
 
 /**
  * Returns a new task created from the Task Backend.  We do a few things here:

--- a/website/src/pages/api/new_task/[task_type].ts
+++ b/website/src/pages/api/new_task/[task_type].ts
@@ -63,7 +63,7 @@ const handler = async (req, res) => {
       message_id: registeredTask.id,
     }),
   });
-  const ack = await ackRes.json();
+  await ackRes.json();
 
   // Send the results to the client.
   res.status(200).json(registeredTask);

--- a/website/src/pages/api/update_task.ts
+++ b/website/src/pages/api/update_task.ts
@@ -1,7 +1,5 @@
 import { getToken } from "next-auth/jwt";
-
 import prisma from "src/lib/prismadb";
-import { authOptions } from "src/pages/api/auth/[...nextauth]";
 
 /**
  * Stores the task interaction with the Task Backend and then returns the next task generated.

--- a/website/src/pages/api/username.tsx
+++ b/website/src/pages/api/username.tsx
@@ -1,6 +1,4 @@
 import { getSession } from "next-auth/react";
-import { Prisma } from "@prisma/client";
-import Email from "next-auth/providers/email";
 
 // POST /api/post
 // Required fields in body: title

--- a/website/src/pages/api/username.tsx
+++ b/website/src/pages/api/username.tsx
@@ -5,7 +5,6 @@ import { getSession } from "next-auth/react";
 // Optional fields in body: content
 export default async function handle(req, res) {
   const { username } = req.body;
-  const { email } = req.body;
 
   const session = await getSession({ req });
   const result = await prisma.user.update({

--- a/website/src/pages/auth/signin.tsx
+++ b/website/src/pages/auth/signin.tsx
@@ -1,10 +1,9 @@
 import { Button, Input, Stack } from "@chakra-ui/react";
 import Head from "next/head";
-import { FaDiscord, FaEnvelope, FaGithub, FaBug } from "react-icons/fa";
+import Link from "next/link";
 import { getCsrfToken, getProviders, signIn } from "next-auth/react";
 import React, { useRef } from "react";
-import Link from "next/link";
-
+import { FaBug, FaDiscord, FaEnvelope, FaGithub } from "react-icons/fa";
 import { AuthLayout } from "src/components/AuthLayout";
 
 export default function Signin({ csrfToken, providers }) {

--- a/website/src/pages/auth/signin.tsx
+++ b/website/src/pages/auth/signin.tsx
@@ -6,6 +6,7 @@ import React, { useRef } from "react";
 import { FaBug, FaDiscord, FaEnvelope, FaGithub } from "react-icons/fa";
 import { AuthLayout } from "src/components/AuthLayout";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function Signin({ csrfToken, providers }) {
   const { discord, email, github, credentials } = providers;
   const emailEl = useRef(null);
@@ -104,6 +105,7 @@ export default function Signin({ csrfToken, providers }) {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function getServerSideProps(context) {
   const csrfToken = await getCsrfToken();
   const providers = await getProviders();

--- a/website/src/pages/auth/verify.tsx
+++ b/website/src/pages/auth/verify.tsx
@@ -16,6 +16,7 @@ export default function Verify() {
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export async function getServerSideProps(context) {
   const csrfToken = await getCsrfToken();
   const providers = await getProviders();

--- a/website/src/pages/auth/verify.tsx
+++ b/website/src/pages/auth/verify.tsx
@@ -1,7 +1,5 @@
 import Head from "next/head";
-import { getCsrfToken, getProviders, signIn } from "next-auth/react";
-import Link from "next/link";
-
+import { getCsrfToken, getProviders } from "next-auth/react";
 import { AuthLayout } from "src/components/AuthLayout";
 
 export default function Verify() {

--- a/website/src/pages/create/assistant_reply.tsx
+++ b/website/src/pages/create/assistant_reply.tsx
@@ -1,17 +1,15 @@
 import { Flex, Textarea } from "@chakra-ui/react";
 import { useRef, useState } from "react";
-import useSWRMutation from "swr/mutation";
-import useSWRImmutable from "swr/immutable";
-
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
-import { Messages } from "src/components/Messages";
-import { TwoColumns } from "src/components/TwoColumns";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
 import { SkipButton } from "src/components/Buttons/Skip";
 import { SubmitButton } from "src/components/Buttons/Submit";
+import { LoadingScreen } from "src/components/Loading/LoadingScreen";
+import { Messages } from "src/components/Messages";
+import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
+import { TwoColumns } from "src/components/TwoColumns";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const AssistantReply = () => {
   const [tasks, setTasks] = useState([]);

--- a/website/src/pages/create/assistant_reply.tsx
+++ b/website/src/pages/create/assistant_reply.tsx
@@ -22,7 +22,7 @@ const AssistantReply = () => {
     },
   });
 
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       setTasks((oldTasks) => [...oldTasks, newTask]);

--- a/website/src/pages/create/summarize_story.tsx
+++ b/website/src/pages/create/summarize_story.tsx
@@ -1,17 +1,15 @@
 import { Flex, Textarea } from "@chakra-ui/react";
 import Head from "next/head";
 import { useRef, useState } from "react";
-import useSWRImmutable from "swr/immutable";
-import useSWRMutation from "swr/mutation";
-
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { TwoColumns } from "src/components/TwoColumns";
-import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
 import { SkipButton } from "src/components/Buttons/Skip";
 import { SubmitButton } from "src/components/Buttons/Submit";
+import { LoadingScreen } from "src/components/Loading/LoadingScreen";
+import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
+import { TwoColumns } from "src/components/TwoColumns";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const SummarizeStory = () => {
   // Use an array of tasks that record the sequence of steps until a task is

--- a/website/src/pages/create/summarize_story.tsx
+++ b/website/src/pages/create/summarize_story.tsx
@@ -29,7 +29,7 @@ const SummarizeStory = () => {
   // Every time we submit an answer to the latest task, let the backend handle
   // all the interactions then add the resulting task to the queue.  This ends
   // when we hit the done task.
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       // This is the more efficient way to update a react state array.

--- a/website/src/pages/create/user_reply.tsx
+++ b/website/src/pages/create/user_reply.tsx
@@ -1,17 +1,15 @@
 import { Flex, Textarea } from "@chakra-ui/react";
 import { useRef, useState } from "react";
-import useSWRMutation from "swr/mutation";
-import useSWRImmutable from "swr/immutable";
-
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
+import { SkipButton } from "src/components/Buttons/Skip";
+import { SubmitButton } from "src/components/Buttons/Submit";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Messages } from "src/components/Messages";
 import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
 import { TwoColumns } from "src/components/TwoColumns";
-import { SkipButton } from "src/components/Buttons/Skip";
-import { SubmitButton } from "src/components/Buttons/Submit";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const UserReply = () => {
   const [tasks, setTasks] = useState([]);

--- a/website/src/pages/create/user_reply.tsx
+++ b/website/src/pages/create/user_reply.tsx
@@ -22,7 +22,7 @@ const UserReply = () => {
     },
   });
 
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       setTasks((oldTasks) => [...oldTasks, newTask]);

--- a/website/src/pages/evaluate/rank_assistant_replies.tsx
+++ b/website/src/pages/evaluate/rank_assistant_replies.tsx
@@ -1,17 +1,15 @@
-import { Button, Flex } from "@chakra-ui/react";
+import { Flex } from "@chakra-ui/react";
 import Head from "next/head";
 import { useState } from "react";
-import useSWRImmutable from "swr/immutable";
-import useSWRMutation from "swr/mutation";
-
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
+import { SkipButton } from "src/components/Buttons/Skip";
+import { SubmitButton } from "src/components/Buttons/Submit";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Sortable } from "src/components/Sortable/Sortable";
 import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
-import { SubmitButton } from "src/components/Buttons/Submit";
-import { SkipButton } from "src/components/Buttons/Skip";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const RankAssistantReplies = () => {
   const [tasks, setTasks] = useState([]);

--- a/website/src/pages/evaluate/rank_assistant_replies.tsx
+++ b/website/src/pages/evaluate/rank_assistant_replies.tsx
@@ -25,7 +25,7 @@ const RankAssistantReplies = () => {
     },
   });
 
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       setTasks((oldTasks) => [...oldTasks, newTask]);

--- a/website/src/pages/evaluate/rank_initial_prompts.tsx
+++ b/website/src/pages/evaluate/rank_initial_prompts.tsx
@@ -1,17 +1,15 @@
 import { Flex } from "@chakra-ui/react";
 import Head from "next/head";
 import { useState } from "react";
-import useSWRImmutable from "swr/immutable";
-import useSWRMutation from "swr/mutation";
-
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
+import { SkipButton } from "src/components/Buttons/Skip";
+import { SubmitButton } from "src/components/Buttons/Submit";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Sortable } from "src/components/Sortable/Sortable";
 import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
-import { SkipButton } from "src/components/Buttons/Skip";
-import { SubmitButton } from "src/components/Buttons/Submit";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const RankInitialPrompts = () => {
   const [tasks, setTasks] = useState([]);

--- a/website/src/pages/evaluate/rank_initial_prompts.tsx
+++ b/website/src/pages/evaluate/rank_initial_prompts.tsx
@@ -25,7 +25,7 @@ const RankInitialPrompts = () => {
     },
   });
 
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       setTasks((oldTasks) => [...oldTasks, newTask]);

--- a/website/src/pages/evaluate/rank_user_replies.tsx
+++ b/website/src/pages/evaluate/rank_user_replies.tsx
@@ -1,17 +1,15 @@
+import { Flex } from "@chakra-ui/react";
 import Head from "next/head";
 import { useState } from "react";
-import useSWRImmutable from "swr/immutable";
-import useSWRMutation from "swr/mutation";
-
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
+import { SkipButton } from "src/components/Buttons/Skip";
+import { SubmitButton } from "src/components/Buttons/Submit";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Sortable } from "src/components/Sortable/Sortable";
 import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
-import { Flex } from "@chakra-ui/react";
-import { SkipButton } from "src/components/Buttons/Skip";
-import { SubmitButton } from "src/components/Buttons/Submit";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const RankUserReplies = () => {
   const [tasks, setTasks] = useState([]);

--- a/website/src/pages/evaluate/rank_user_replies.tsx
+++ b/website/src/pages/evaluate/rank_user_replies.tsx
@@ -25,7 +25,7 @@ const RankUserReplies = () => {
     },
   });
 
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       setTasks((oldTasks) => [...oldTasks, newTask]);

--- a/website/src/pages/evaluate/rate_summary.tsx
+++ b/website/src/pages/evaluate/rate_summary.tsx
@@ -2,18 +2,16 @@ import { Flex, Textarea } from "@chakra-ui/react";
 import { QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
 import Head from "next/head";
 import { useState } from "react";
-import useSWRImmutable from "swr/immutable";
-import useSWRMutation from "swr/mutation";
-
-import RatingRadioGroup from "src/components/RatingRadioGroup";
-import fetcher from "src/lib/fetcher";
-import poster from "src/lib/poster";
-
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { TwoColumns } from "src/components/TwoColumns";
-import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
 import { SkipButton } from "src/components/Buttons/Skip";
 import { SubmitButton } from "src/components/Buttons/Submit";
+import { LoadingScreen } from "src/components/Loading/LoadingScreen";
+import RatingRadioGroup from "src/components/RatingRadioGroup";
+import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
+import { TwoColumns } from "src/components/TwoColumns";
+import fetcher from "src/lib/fetcher";
+import poster from "src/lib/poster";
+import useSWRImmutable from "swr/immutable";
+import useSWRMutation from "swr/mutation";
 
 const RateSummary = () => {
   // Use an array of tasks that record the sequence of steps until a task is

--- a/website/src/pages/evaluate/rate_summary.tsx
+++ b/website/src/pages/evaluate/rate_summary.tsx
@@ -30,7 +30,7 @@ const RateSummary = () => {
   // Every time we submit an answer to the latest task, let the backend handle
   // all the interactions then add the resulting task to the queue.  This ends
   // when we hit the done task.
-  const { trigger, isMutating } = useSWRMutation("/api/update_task", poster, {
+  const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
       // This is the more efficient way to update a react state array.

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,12 +1,11 @@
 import Head from "next/head";
 import { useSession } from "next-auth/react";
-
 import { CallToAction } from "src/components/CallToAction";
 import { Faq } from "src/components/Faq";
+import { Footer } from "src/components/Footer";
+import { Header } from "src/components/Header";
 import { Hero } from "src/components/Hero";
 import { TaskSelection } from "src/components/TaskSelection";
-import { Header } from "src/components/Header";
-import { Footer } from "src/components/Footer";
 
 const Home = () => {
   const { data: session } = useSession();

--- a/website/src/pages/leaderboard/score-leaderboard.tsx
+++ b/website/src/pages/leaderboard/score-leaderboard.tsx
@@ -1,5 +1,5 @@
-import RankItem from "src/components/RankItem";
 import { HiBarsArrowDown } from "react-icons/hi2";
+import RankItem from "src/components/RankItem";
 
 const LeaderBoard = () => {
   const PlaceHolderProps = { username: "test_user", score: 10 };


### PR DESCRIPTION
Fixed all warnings in `next build/next lint`

Added a new npm command: `npm run fix` to run format and lint code.
To make review easier I have made 2 commits, the first one adds eslint plugins to automatically handle import sort and unused import.
And a second commit which fixes the remaining warning manually, so this commit is more "opinionated" and needs more attention during the review.
(I have added some `//eslint-disable-next-line` for some part, where it seems to be the best option)

(There is a lot of changes so it might create conflicts for other people working on /website)
