### PR TITLE
saving user to the dabase when using the debug credentials provider

### DIFF
--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -43,10 +43,19 @@ if (boolean(process.env.DEBUG_LOGIN) || process.env.NODE_ENV === "development") 
         username: { label: "Username", type: "text" },
       },
       async authorize(credentials) {
-        return {
+        const user = {
           id: credentials.username,
           name: credentials.username,
         };
+        // save the user to the database
+        await prisma.user.upsert({
+          where: {
+            id: user.id,
+          },
+          update: {},
+          create: user,
+        });
+        return user;
       },
     })
   );


### PR DESCRIPTION
Solves #168 

note: a bit hacky, but next-auth makes it quite troublesome to do this in a clean way when JWT is active, and we need JWT because the credentials provider only supports that.