### PR TITLE
Fix for missing dependency for DNDKit on evaluation pages

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@chakra-ui/react": "^2.4.4",
+        "@dnd-kit/core": "^6.0.6",
         "@dnd-kit/sortable": "^7.0.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
@@ -3332,7 +3333,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
       "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -3344,7 +3344,6 @@
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.6.tgz",
       "integrity": "sha512-kHcD80IsYV+NpNl68zX4BEj5ZeReIq2OhjFXlg8MDqQP0tHot1GFwITke1W33pNoXOf55WMRt/O3UzNtwILU8Q==",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.0.0",
         "@dnd-kit/utilities": "^3.2.1",
@@ -30852,7 +30851,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz",
       "integrity": "sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==",
-      "peer": true,
       "requires": {
         "tslib": "^2.0.0"
       }
@@ -30861,7 +30859,6 @@
       "version": "6.0.6",
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.0.6.tgz",
       "integrity": "sha512-kHcD80IsYV+NpNl68zX4BEj5ZeReIq2OhjFXlg8MDqQP0tHot1GFwITke1W33pNoXOf55WMRt/O3UzNtwILU8Q==",
-      "peer": true,
       "requires": {
         "@dnd-kit/accessibility": "^3.0.0",
         "@dnd-kit/utilities": "^3.2.1",

--- a/website/package.json
+++ b/website/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@chakra-ui/react": "^2.4.4",
+    "@dnd-kit/core": "^6.0.6",
     "@dnd-kit/sortable": "^7.0.1",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",


### PR DESCRIPTION
DNDKit was missing the core module and causing crashes on the evaluation pages of the website