### PR TITLE
Deleting a few links that don't go to a page we're planning to build

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -21,23 +21,20 @@ export function Footer() {
             </div>
             <nav className="flex justify-center gap-20">
               <div className="flex flex-col text-sm leading-7">
-                <b>Information</b>
-                <div className="flex flex-col leading-5">
-                  <Link href="#" aria-label="Our Team" className="hover:underline underline-offset-2">
-                    Our Team
-                  </Link>
-                  <Link href="/#join-us" aria-label="Join Us" className="hover:underline underline-offset-2">
-                    Join Us
-                  </Link>
-                </div>
-              </div>
-              <div className="flex flex-col text-sm leading-7">
                 <b>Legal</b>
                 <div className="flex flex-col leading-5">
-                  <Link href="#" aria-label="Privacy Policy" className="hover:underline underline-offset-2">
+                  <Link
+                    href="/privacy-policy"
+                    aria-label="Privacy Policy"
+                    className="hover:underline underline-offset-2"
+                  >
                     Privacy Policy
                   </Link>
-                  <Link href="#" aria-label="Terms of Service" className="hover:underline underline-offset-2">
+                  <Link
+                    href="/terms-of-service"
+                    aria-label="Terms of Service"
+                    className="hover:underline underline-offset-2"
+                  >
                     Terms of Service
                   </Link>
                 </div>

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -65,9 +65,6 @@ export function Header(props) {
               <Image src="/images/logos/logo.svg" className="mx-auto object-fill" width="50" height="50" alt="logo" />
               <span className="text-2xl font-bold ml-3">Open Assistant</span>
             </Link>
-            <div className="hidden lg:flex lg:gap-10">
-              <NavLinks />
-            </div>
           </div>
           <div className="flex items-center gap-4">
             <Popover className="lg:hidden">
@@ -102,10 +99,6 @@ export function Header(props) {
                           }}
                           className="absolute inset-x-0 top-0 z-0 origin-top rounded-b-2xl bg-white px-6 pb-6 pt-32 shadow-2xl shadow-gray-900/20"
                         >
-                          <div className="space-y-4">
-                            <MobileNavLink href="/#join-us">Join Us</MobileNavLink>
-                            <MobileNavLink href="/#faqs">FAQs</MobileNavLink>
-                          </div>
                           <div className="mt-8 flex flex-col gap-4"></div>
                         </Popover.Panel>
                       </>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -27,7 +27,6 @@ const Home = () => {
         <main>
           <Hero />
           <CallToAction />
-
           <Faq />
         </main>
       )}


### PR DESCRIPTION
This addresses issue #156 but does not close it.

We remove the `Join Us` and `FAQ` links in a few places since it's not clear what should go there.

This also makes `Privacy Policy` and `Terms of Service` links go to real pages that are currently 404s but will soon be real pages.

Not addressed:
- splitting out the signed in and signed out pages to be separate
- Creating an `/about`