### PR TITLE
Add oasst-shared folder to discord-bot container

### DIFF
--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -12,9 +12,17 @@ If you are unfamiliar with `hikari`, `lightbulb`, or `miru`, please refer to the
 
 ### Setup
 
-To run the bot
+To run the bot:
+
+Install dependency module `oasst-shared`
+
+```
+cd oasst-shared
+pip install -e .
+```
 
 ```bash
+cd ../discord-bot
 cp .env.example .env
 
 python -V  # 3.10

--- a/discord-bot/README.md
+++ b/discord-bot/README.md
@@ -16,7 +16,7 @@ To run the bot:
 
 Install dependency module `oasst-shared`
 
-```
+```bash
 cd oasst-shared
 pip install -e .
 ```

--- a/docker/Dockerfile.discord-bot
+++ b/docker/Dockerfile.discord-bot
@@ -1,7 +1,7 @@
 FROM python:3.10-slim-bullseye
 RUN mkdir /app
-COPY ./discord-bot/requirements.txt /requirements.txt
-RUN pip install -r requirements.txt
 WORKDIR /app
 COPY ./discord-bot /app
-CMD ["python", "bot.py"]
+COPY ./oasst-shared/oasst_shared /app/oasst_shared
+RUN pip install -r requirements.txt
+CMD ["python","-m","bot"]


### PR DESCRIPTION
Container was missing oasst-shared folder, thus was failing, due to missing package error.

Fixes #240