### PR TITLE
ci: add Test API Contract workflow

### DIFF
--- a/.github/workflows/test-api-contract.yaml
+++ b/.github/workflows/test-api-contract.yaml
@@ -1,0 +1,33 @@
+name: Test API Contract
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
+
+jobs:
+  test-contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - run: cd oasst-shared && pip install -e .
+
+      - run: cd discord-bot && pip install -r requirements.txt
+
+      - run: cd discord-bot && pip install -r requirements.dev.txt
+
+      - run: ./scripts/backend-development/start-mock-server.sh
+
+      # runs the contract tests. currently the api client is
+      # found in the discord bot code, but this should be updated
+      # once the client moves into oasst-shared.
+      - name: Run contract tests
+        run: ./scripts/discord-bot-development/test.sh
+
+      - run: ./scripts/backend-development/stop-mock-server.sh

--- a/.github/workflows/test-api-contract.yaml
+++ b/.github/workflows/test-api-contract.yaml
@@ -18,6 +18,8 @@ jobs:
 
       - run: cd oasst-shared && pip install -e .
 
+      - run: cd backend && pip install -r requirements.txt
+
       - run: cd discord-bot && pip install -r requirements.txt
 
       - run: cd discord-bot && pip install -r requirements.dev.txt

--- a/scripts/backend-development/stop-mock-server.sh
+++ b/scripts/backend-development/stop-mock-server.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+docker stop oasst-mock-backend


### PR DESCRIPTION
Adds a CI workflow which calls the discord bot tests. I called this "Test API Contract" because the only tests in it are the contract tests. I imagine this workflow can also perform the contract tests for the website too. Once there are Discord bot unittests and OasstApiClient is moved into oasst-shared (#243) we can point to a new test script in this workflow and create a separate Discord bot workflow. 