### PR TITLE
Add warning + advice to .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,31 @@
+# WARNING!
+#
+# When making changes to auto-formatters used in pre-commit hooks, you are
+# likely to cause merge conflicts with main and/or other pull requests.
+# Fixing them might revert other people's work. Expect pain!
+# To avoid accidental reversions and keep it easy to review, please make sure
+# that changes here are in a pull request by themselves, that it consists of
+# two commits:
+#
+# 1. The changes to this file
+# 2. Changes made by running `python3 -m pre_commit run --all-files`.
+#
+# Then each time your pull request is blocked by a merge conflict, do the
+# following steps:
+#
+#    git reset HEAD^1 && git checkout -f    # discard the change commit
+#    git rebase main                        # re-apply other people's changes
+#    python3 -m pre_commit run --all-files  # re-run the rules
+#    git add .                              # add the newly changed files
+#    git commit -m 'apply pre-commit'       # commit it
+#    git push -f                            # force push back to your branch
+#
+# Keep in mind you may have to do this a few times, as changes here may impact
+# other pull requests. Try to keep it up-to-date so they can go in when it'll
+# cause least disruption.
+#
+# /WARNING!
+
 exclude: "build|stubs|^bot/templates/|^notebooks/.*\\.ipynb$"
 
 default_language_version:


### PR DESCRIPTION
As per discussion on #212, I've added a warning about changes to `.pre-commit-config.yaml` and how to avoid the pain and risks of merge conflicts.