### PR TITLE
Add context to compose file so it runs in older "docker-compose"

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,13 +181,3 @@ Upon making a release on GitHub, all docker images are automatically built and
 pushed to ghcr.io. The docker images are tagged with the release version, and
 the `latest` tag. Further, the ansible playbook in `ansible/dev.yaml` is run to
 automatically deploy the built release to the dev machine.
-
-### Problems and Solutions
-
-- **I am on Ubuntu and getting
-  `ERROR: The Compose file is invalid because:Service backend has neither an image nor a build context specified. At least one must be provided.`**
-
-  Make sure you have an up-to-date version of docker installed, and also install
-  `docker-compose-plugin`. See
-  [here](https://github.com/LAION-AI/Open-Assistant/issues/208) for more
-  details.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -87,6 +87,7 @@ services:
   backend:
     build:
       dockerfile: docker/Dockerfile.backend
+      context: .
     image: oasst-backend
     environment:
       - POSTGRES_HOST=db
@@ -103,6 +104,7 @@ services:
   web:
     build:
       dockerfile: docker/Dockerfile.website
+      context: .
     image: oasst-web
     environment:
       - DATABASE_URL=postgres://postgres:postgres@webdb/oasst_web


### PR DESCRIPTION
Looks like the reason it was failing in the older `docker-compose` tool but not `docker compose` is because recent versions use the current working dir as a default build context, while older versions need it to be explicitly defined.

This should fix running it on machines or in tools that haven't upgraded to `docker compose` and still call `docker-compose` instead.