### PR TITLE
fix: typo in EssayInstructions.md and EssayRevision.md

### DIFF
--- a/notebooks/data-argumentation/EssayInstructions.md
+++ b/notebooks/data-argumentation/EssayInstructions.md
@@ -1,11 +1,11 @@
 # Essay Instructions
 
-Essay Instructions is a notebook that takes an essay as an input and genrates
+Essay Instructions is a notebook that takes an essay as an input and generates
 instructions on how to generate that essay. This will be very useful for data
 collecting for the model
 
 ## Contributing
 
 Feel free to contribute to this notebook, it's nowhere near perfect but it's a
-good start. If you want to contribute fidning a new model that better suits this
+good start. If you want to contribute finding a new model that better suits this
 task would be great. Hugginface has a lot of models that could help.

--- a/notebooks/data-argumentation/EssayRevision.md
+++ b/notebooks/data-argumentation/EssayRevision.md
@@ -1,11 +1,11 @@
 # Essay Revision
 
 Essay Revision is a notebook that generates data for improving essays. It does
-that by taking a "good" essay, making it worse step by step and the fidning
+that by taking a "good" essay, making it worse step by step and the finding
 instructions for making it better. This will be useful for generating data for
 the model.
 
 ## Contributing
 
 Feel free to contribute to this notebook. It's not perfect but it is quite good.
-Finding a better way to make gramatical errors may be a good place to start.
+Finding a better way to make grammatical errors may be a good place to start.


### PR DESCRIPTION
Since the notebooks section was to correct grammatical errors. Fixed some of the trivial typos. 