### PR TITLE
Stop users from starting more than one task at a time

### DIFF
--- a/discord-bot/bot/bot.py
+++ b/discord-bot/bot/bot.py
@@ -35,6 +35,9 @@ async def on_starting(event: hikari.StartingEvent):
 
     bot.d.oasst_api = OasstApiClient(settings.oasst_api_url, settings.oasst_api_key)
 
+    # A set of user id's that are currently doing work.
+    bot.d.currently_working = set()
+
 
 @bot.listen()
 async def on_stopping(event: hikari.StoppingEvent):

--- a/discord-bot/bot/extensions/work.py
+++ b/discord-bot/bot/extensions/work.py
@@ -35,12 +35,25 @@ MAX_TASK_ACCEPT_TIME = 60  # 1 minute
 @lightbulb.implements(lightbulb.SlashCommand)
 async def work(ctx: lightbulb.SlashContext):
     """Create and handle a task."""
+    # make sure the user isn't currently doing a task
+    currently_working: set[hikari.Snowflakeish] = ctx.bot.d.currently_working
+    if ctx.author.id in currently_working:
+        await ctx.respond(
+            "You are already performing a task. Please complete that one first.", flags=hikari.MessageFlag.EPHEMERAL
+        )
+        return
+
+    currently_working.add(ctx.author.id)
+
     task_type: TaskRequestType = TaskRequestType(ctx.options.type.split(".")[-1])
 
     await ctx.respond("Sending you a task, check your DMs", flags=hikari.MessageFlag.EPHEMERAL)
     logger.debug(f"Starting task_type: {task_type!r}")
 
     await _handle_task(ctx, task_type)
+
+    # TODO: make sure that the user gets removed even if the command errors
+    currently_working.remove(ctx.author.id)
 
 
 async def _handle_task(ctx: lightbulb.SlashContext, task_type: TaskRequestType) -> None:

--- a/discord-bot/bot/extensions/work.py
+++ b/discord-bot/bot/extensions/work.py
@@ -50,9 +50,10 @@ async def work(ctx: lightbulb.SlashContext):
     await ctx.respond("Sending you a task, check your DMs", flags=hikari.MessageFlag.EPHEMERAL)
     logger.debug(f"Starting task_type: {task_type!r}")
 
-    await _handle_task(ctx, task_type)
-
-    currently_working.remove(ctx.author.id)
+    try:
+        await _handle_task(ctx, task_type)
+    finally:
+        currently_working.remove(ctx.author.id)
 
 
 async def _handle_task(ctx: lightbulb.SlashContext, task_type: TaskRequestType) -> None:

--- a/discord-bot/bot/extensions/work.py
+++ b/discord-bot/bot/extensions/work.py
@@ -52,7 +52,6 @@ async def work(ctx: lightbulb.SlashContext):
 
     await _handle_task(ctx, task_type)
 
-    # TODO: make sure that the user gets removed even if the command errors
     currently_working.remove(ctx.author.id)
 
 


### PR DESCRIPTION
The bot now keeps a `set` of user ID's for everyone currently doing a task. This gets removed after a user times out or doesn't want to do another task.