### PR TITLE
Add missing requirement to discord-bot

### DIFF
--- a/discord-bot/requirements.txt
+++ b/discord-bot/requirements.txt
@@ -6,6 +6,6 @@ hikari-lightbulb    # command handler
 hikari-miru         # modals and buttons
 hikari[speedups]
 loguru
-pydantic
+pydantic[dotenv]
 
 uvloop; os_name != 'nt'  # Faster drop-in replacement for asyncio event loop


### PR DESCRIPTION
When starting container with nonempty envs , python was missing `pydantic[dotenv]`