### PR TITLE
feat: handle OasstError in OasstApiClient

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -26,8 +26,13 @@ app = fastapi.FastAPI(title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V
 @app.exception_handler(OasstError)
 async def oasst_exception_handler(request: fastapi.Request, ex: OasstError):
     logger.error(f"{request.method} {request.url} failed: {repr(ex)}")
+
     return fastapi.responses.JSONResponse(
-        status_code=int(ex.http_status_code), content={"message": ex.message, "error_code": ex.error_code}
+        status_code=int(ex.http_status_code),
+        content=protocol_schema.OasstErrorResponse(
+            message=ex.message,
+            error_code=OasstErrorCode(ex.error_code),
+        ).dict(),
     )
 
 

--- a/discord-bot/requirements.txt
+++ b/discord-bot/requirements.txt
@@ -1,5 +1,3 @@
-aiohttp             # http client
-aiohttp[speedups]   # speedups for aiohttp
 aiosqlite           # database
 hikari              # discord framework
 hikari-lightbulb    # command handler

--- a/docs/data_schemas.md
+++ b/docs/data_schemas.md
@@ -92,3 +92,111 @@ conversations, we should use a row-major format.
   Avro files and protobufs. Keep in mind that column-major files are better for
   reading, filtering, and aggregating, but row-major files are better for
   writing.
+
+# Task-Specific Data Schemas
+
+The main tasks are a) generation of response text and b) ranking of responses.
+The following sections describe the data schemas for each of these tasks. Both
+should be implementable in parquet files.
+
+## Common Data Structures
+
+```python
+
+class Message:
+  text: str # The text of the message
+  role: Literal['prompter', 'assistant'] # Whether the message is a user prompt/follow-up or an assistant response
+
+class Thread:
+  messages: list[Message] # The messages in the conversation
+
+```
+
+The corresponding parquet schemas are:
+
+```parquet
+message Message {
+  required binary text (UTF8);
+  required binary role (UTF8);
+}
+
+message Thread {
+  required group messages (LIST) {
+    repeated group list {
+      required group element {
+        required binary text (UTF8);
+        required binary role (UTF8);
+      }
+    }
+  }
+}
+
+```
+
+## Generation
+
+```python
+
+class GenerationExample:
+  thread: Thread # The conversation thread before the message to be generated
+  message: Message # The message to be generated
+
+```
+
+The corresponding parquet schema is:
+
+```parquet
+message GenerationExample {
+  required group thread (LIST) {
+    repeated group list {
+      required group element {
+        required binary text (UTF8);
+        required binary role (UTF8);
+      }
+    }
+  }
+  required group message (LIST) {
+    repeated group list {
+      required group element {
+        required binary text (UTF8);
+        required binary role (UTF8);
+      }
+    }
+  }
+}
+
+```
+
+## Ranking
+
+```python
+
+class RankingExample:
+  thread: Thread # The conversation thread before the message to be ranked
+  messages: list[Message] # The messages to be ranked, in oder of decreasing preference
+
+```
+
+The corresponding parquet schema is:
+
+```parquet
+message RankingExample {
+  required group thread (LIST) {
+    repeated group list {
+      required group element {
+        required binary text (UTF8);
+        required binary role (UTF8);
+      }
+    }
+  }
+  required group messages (LIST) {
+    repeated group list {
+      required group element {
+        required binary text (UTF8);
+        required binary role (UTF8);
+      }
+    }
+  }
+}
+
+```

--- a/oasst-shared/oasst_shared/api_client.py
+++ b/oasst-shared/oasst_shared/api_client.py
@@ -70,7 +70,7 @@ class OasstApiClient:
         if response.status >= 300:
             data = await response.json()
             try:
-                oasst_error = protocol_schema.OasstErrorResponse(**data)
+                oasst_error = protocol_schema.OasstErrorResponse(**(data or {}))
                 raise OasstError(
                     error_code=oasst_error.error_code,
                     message=oasst_error.message,

--- a/oasst-shared/oasst_shared/api_client.py
+++ b/oasst-shared/oasst_shared/api_client.py
@@ -86,6 +86,10 @@ class OasstApiClient:
                     OasstErrorCode.GENERIC_ERROR,
                     HTTPStatus(response.status),
                 )
+
+        if response.status == 204:
+            # No content
+            return None
         return await response.json()
 
     def _parse_task(self, data: Optional[dict[str, t.Any]]) -> protocol_schema.Task:

--- a/oasst-shared/oasst_shared/schemas/protocol.py
+++ b/oasst-shared/oasst_shared/schemas/protocol.py
@@ -4,6 +4,7 @@ from typing import List, Literal, Optional, Union
 from uuid import UUID, uuid4
 
 import pydantic
+from oasst_shared.exceptions import OasstErrorCode
 from pydantic import BaseModel, Field
 
 
@@ -293,3 +294,10 @@ class UserScore(BaseModel):
 
 class LeaderboardStats(BaseModel):
     leaderboard: List[UserScore]
+
+
+class OasstErrorResponse(BaseModel):
+    """The format of an error response from the OASST API."""
+
+    error_code: OasstErrorCode
+    message: str

--- a/oasst-shared/setup.py
+++ b/oasst-shared/setup.py
@@ -11,5 +11,7 @@ setup(
     author="OASST Team",
     install_requires=[
         "pydantic==1.9.1",
+        "aiohttp",
+        "aiohttp[speedups]",
     ],
 )

--- a/oasst-shared/setup.py
+++ b/oasst-shared/setup.py
@@ -11,7 +11,7 @@ setup(
     author="OASST Team",
     install_requires=[
         "pydantic==1.9.1",
-        "aiohttp",
+        "aiohttp==3.8.3",
         "aiohttp[speedups]",
     ],
 )

--- a/oasst-shared/tests/test_oasst_api_client.py
+++ b/oasst-shared/tests/test_oasst_api_client.py
@@ -106,3 +106,23 @@ async def test_can_handle_oasst_error_from_api(
 
     with pytest.raises(OasstError):
         await oasst_api_client_fake_http.post("/some-path", data={})
+
+
+@pytest.mark.asyncio
+async def test_can_handle_unknown_error_from_api(
+    oasst_api_client_fake_http: OasstApiClient,
+    mock_http_session: MockClientSession,
+):
+    response_body = "Internal Server Error"
+    status_code = 500
+
+    mock_http_session.set_response(
+        mock.AsyncMock(
+            status=status_code,
+            text=mock.AsyncMock(return_value=response_body),
+            json=mock.AsyncMock(return_value=None),
+        )
+    )
+
+    with pytest.raises(OasstError):
+        await oasst_api_client_fake_http.post("/some-path", data={})

--- a/scripts/oasst-shared-development/test.sh
+++ b/scripts/oasst-shared-development/test.sh
@@ -4,6 +4,8 @@ parent_path=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
 # switch to backend directory
 pushd "$parent_path/../../oasst-shared"
 
+set -xe
+
 pytest .
 
 popd


### PR DESCRIPTION
Fixes step 3 of #243

- feat: add OasstErrorResponse to protocols
- feat: handle OasstError in OasstApiClient
- test: add test for handling OasstError
- test: add test for unhandled api error

Embarrassingly, failed tests were not surfacing in CI, so that's fixed in 789593b. This issue effectively hid the fact that the tests were failing to run because of a missing dependency in oasst-shared, and that's fixed in fbcb0a0. 



