### PR TITLE
Bth5032/78 blackcat trainer

### DIFF
--- a/model/reward/instructor/configs/rankgen-t5-base-fp16.yml
+++ b/model/reward/instructor/configs/rankgen-t5-base-fp16.yml
@@ -1,11 +1,8 @@
 model_name: kalpeshk2011/rankgen-t5-base-all
-# model_name: kalpeshk2011/rankgen-t5-xl-all
-# model_name: kalpeshk2011/rankgen-t5-xl-pg19
-# model_name: kalpeshk2011/rankgen-t5-large-all
 tokenizer_name: google/t5-v1_1-base
 learning_rate: 6e-6
 gradient_checkpointing: false
-fp16: false
+fp16: true
 gradient_accumulation_steps: 16
 per_device_train_batch_size: 2
 warmup_steps: 600

--- a/model/reward/instructor/configs/rankgen-t5-base.yml
+++ b/model/reward/instructor/configs/rankgen-t5-base.yml
@@ -2,8 +2,9 @@ model_name: kalpeshk2011/rankgen-t5-base-all
 tokenizer_name: google/t5-v1_1-base
 learning_rate: 6e-6
 gradient_checkpointing: false
+fp16: false
 gradient_accumulation_steps: 16
-per_device_train_batch_size: 3
+per_device_train_batch_size: 2
 warmup_steps: 600
 freeze_layer: 20
 eval_steps: 200

--- a/model/reward/instructor/configs/rankgen-t5-base.yml
+++ b/model/reward/instructor/configs/rankgen-t5-base.yml
@@ -1,0 +1,15 @@
+model_name: kalpeshk2011/rankgen-t5-base-all
+tokenizer_name: google/t5-v1_1-base
+learning_rate: 6e-6
+gradient_checkpointing: false
+gradient_accumulation_steps: 16
+per_device_train_batch_size: 3
+warmup_steps: 600
+freeze_layer: 20
+eval_steps: 200
+save_steps: 500
+max_length: 400
+num_train_epochs: 2
+datasets:
+  - webgpt
+  - hfsummary

--- a/model/reward/instructor/models.py
+++ b/model/reward/instructor/models.py
@@ -1,0 +1,22 @@
+import torch
+from transformers import AutoModel
+
+class RankGenModel(torch.nn.Module):
+  def __init__(self, model_name):
+    super().__init__()
+    self.rankgen_hf_hub = model_name
+    assert model_name in ["kalpeshk2011/rankgen-t5-xl-all", 
+                      "kalpeshk2011/rankgen-t5-xl-pg19", 
+                      "kalpeshk2011/rankgen-t5-base-all", 
+                      "kalpeshk2011/rankgen-t5-large-all"]
+    self.model = AutoModel.from_pretrained(self.rankgen_hf_hub, trust_remote_code=True)
+
+  def forward(self, prefixes, suffixes):
+    embedded_prefixes = self.model(**prefixes)
+    embedded_suffixes = self.model(**suffixes)
+    # take dot product of each row independently
+    dot_products = torch.sum(embedded_prefixes * embedded_suffixes, dim=1)
+    
+    print(f"{prefixes=}, {suffixes=}, {embedded_prefixes=}, {embedded_suffixes=}, {dot_products=}")
+
+    return dot_products

--- a/model/reward/instructor/models.py
+++ b/model/reward/instructor/models.py
@@ -1,24 +1,28 @@
+# -*- coding: utf-8 -*-
 import torch
 from transformers import AutoModel
 
-class RankGenModel(torch.nn.Module):
-  def __init__(self, model_name):
-    super().__init__()
-    self.rankgen_hf_hub = model_name
-    assert model_name in ["kalpeshk2011/rankgen-t5-xl-all", 
-                      "kalpeshk2011/rankgen-t5-xl-pg19", 
-                      "kalpeshk2011/rankgen-t5-base-all", 
-                      "kalpeshk2011/rankgen-t5-large-all"]
-    self.model = AutoModel.from_pretrained(self.rankgen_hf_hub, trust_remote_code=True)
 
-  def forward(self, prefixes, suffixes):
-    # print(list(self.model.parameters()))
-    # raise Exception("stop")
-    embedded_prefixes = self.model(**prefixes)
-    embedded_suffixes = self.model(**suffixes)
-    # take dot product of each row independently
-    dot_products = torch.sum(embedded_prefixes * embedded_suffixes, dim=1)
-    
-    # print(f"{embedded_prefixes.shape=}, {embedded_suffixes.shape=}, {prefixes['input_ids'].shape=}, {suffixes['input_ids'].shape=}, {embedded_prefixes=}, {embedded_suffixes=}, {dot_products=}")
-    # raise Exception("stop")
-    return dot_products
+class RankGenModel(torch.nn.Module):
+    def __init__(self, model_name):
+        super().__init__()
+        self.rankgen_hf_hub = model_name
+        assert model_name in [
+            "kalpeshk2011/rankgen-t5-xl-all",
+            "kalpeshk2011/rankgen-t5-xl-pg19",
+            "kalpeshk2011/rankgen-t5-base-all",
+            "kalpeshk2011/rankgen-t5-large-all",
+        ]
+        self.model = AutoModel.from_pretrained(self.rankgen_hf_hub, trust_remote_code=True)
+
+    def forward(self, prefixes, suffixes):
+        # print(list(self.model.parameters()))
+        # raise Exception("stop")
+        embedded_prefixes = self.model(**prefixes)
+        embedded_suffixes = self.model(**suffixes)
+        # take dot product of each row independently
+        dot_products = torch.sum(embedded_prefixes * embedded_suffixes, dim=1)
+
+        # print(f"{embedded_prefixes.shape=}, {embedded_suffixes.shape=}, {prefixes['input_ids'].shape=}, {suffixes['input_ids'].shape=}, {embedded_prefixes=}, {embedded_suffixes=}, {dot_products=}")
+        # raise Exception("stop")
+        return dot_products

--- a/model/reward/instructor/models.py
+++ b/model/reward/instructor/models.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import torch
 from transformers import AutoModel
 

--- a/model/reward/instructor/models.py
+++ b/model/reward/instructor/models.py
@@ -12,11 +12,13 @@ class RankGenModel(torch.nn.Module):
     self.model = AutoModel.from_pretrained(self.rankgen_hf_hub, trust_remote_code=True)
 
   def forward(self, prefixes, suffixes):
+    # print(list(self.model.parameters()))
+    # raise Exception("stop")
     embedded_prefixes = self.model(**prefixes)
     embedded_suffixes = self.model(**suffixes)
     # take dot product of each row independently
     dot_products = torch.sum(embedded_prefixes * embedded_suffixes, dim=1)
     
-    print(f"{prefixes=}, {suffixes=}, {embedded_prefixes=}, {embedded_suffixes=}, {dot_products=}")
-
+    # print(f"{embedded_prefixes.shape=}, {embedded_suffixes.shape=}, {prefixes['input_ids'].shape=}, {suffixes['input_ids'].shape=}, {embedded_prefixes=}, {embedded_suffixes=}, {dot_products=}")
+    # raise Exception("stop")
     return dot_products

--- a/model/reward/instructor/rank_datasets.py
+++ b/model/reward/instructor/rank_datasets.py
@@ -24,9 +24,32 @@ from typing import Optional, Union
 
 import numpy as np
 from datasets import load_dataset
+import torch
 from torch.utils.data import Dataset
 from transformers.tokenization_utils_base import PaddingStrategy, PreTrainedTokenizerBase
 
+@dataclass
+class RankGenCollator():    
+    tokenizer: PreTrainedTokenizerBase
+    padding: Union[bool, str, PaddingStrategy] = True
+    max_length: Optional[int] = None
+
+    def __call__(self, batch : list[dict[str, str]]) -> dict[str, torch.Tensor]:
+        prefixes = []
+        better_answers = []
+        worse_answers = []
+        for question, pairs in batch:
+            for (pos, neg) in pairs:
+                prefixes.append("pre " + question)
+                better_answers.append("suffi " + pos)
+                worse_answers.append("suffi " + neg)
+                
+        tokenized_prefixes = self.tokenizer(prefixes, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True)
+        tokenized_pos = self.tokenizer(better_answers, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True)
+        tokenized_neg = self.tokenizer(worse_answers, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True)
+        return {"prefix" : tokenized_prefixes, 
+                "positive": tokenized_pos, 
+                "negative": tokenized_neg}
 
 @dataclass
 class DataCollatorForPairRank:

--- a/model/reward/instructor/rank_datasets.py
+++ b/model/reward/instructor/rank_datasets.py
@@ -33,6 +33,7 @@ class RankGenCollator():
     tokenizer: PreTrainedTokenizerBase
     padding: Union[bool, str, PaddingStrategy] = True
     max_length: Optional[int] = None
+    max_examples: Optional[int] = None
 
     def __call__(self, batch : list[dict[str, str]]) -> dict[str, torch.Tensor]:
         prefixes = []

--- a/model/reward/instructor/rank_datasets.py
+++ b/model/reward/instructor/rank_datasets.py
@@ -23,19 +23,20 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 import numpy as np
-from datasets import load_dataset
 import torch
+from datasets import load_dataset
 from torch.utils.data import Dataset
 from transformers.tokenization_utils_base import PaddingStrategy, PreTrainedTokenizerBase
 
+
 @dataclass
-class RankGenCollator():    
+class RankGenCollator:
     tokenizer: PreTrainedTokenizerBase
     padding: Union[bool, str, PaddingStrategy] = True
     max_length: Optional[int] = None
     max_examples: Optional[int] = None
 
-    def __call__(self, batch : list[dict[str, str]]) -> dict[str, torch.Tensor]:
+    def __call__(self, batch: list[dict[str, str]]) -> dict[str, torch.Tensor]:
         prefixes = []
         better_answers = []
         worse_answers = []
@@ -44,13 +45,18 @@ class RankGenCollator():
                 prefixes.append("pre " + question)
                 better_answers.append("suffi " + pos)
                 worse_answers.append("suffi " + neg)
-                
-        tokenized_prefixes = self.tokenizer(prefixes, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True)
-        tokenized_pos = self.tokenizer(better_answers, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True)
-        tokenized_neg = self.tokenizer(worse_answers, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True)
-        return {"prefix" : tokenized_prefixes, 
-                "positive": tokenized_pos, 
-                "negative": tokenized_neg}
+
+        tokenized_prefixes = self.tokenizer(
+            prefixes, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True
+        )
+        tokenized_pos = self.tokenizer(
+            better_answers, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True
+        )
+        tokenized_neg = self.tokenizer(
+            worse_answers, return_tensors="pt", padding=self.padding, max_length=self.max_length, truncation=True
+        )
+        return {"prefix": tokenized_prefixes, "positive": tokenized_pos, "negative": tokenized_neg}
+
 
 @dataclass
 class DataCollatorForPairRank:

--- a/model/reward/instructor/requirements.txt
+++ b/model/reward/instructor/requirements.txt
@@ -1,6 +1,7 @@
 datasets==2.8.0
 evaluate==0.4.0
 scikit-learn==1.2.0
-torch==1.12.1+cu116
+torch>=1.12.1
 transformers==4.25.1
 wandb==0.13.7
+sentencepiece==0.1.97

--- a/model/reward/instructor/requirements.txt
+++ b/model/reward/instructor/requirements.txt
@@ -1,7 +1,7 @@
 datasets==2.8.0
 evaluate==0.4.0
 scikit-learn==1.2.0
+sentencepiece==0.1.97
 torch>=1.12.1
 transformers==4.25.1
 wandb==0.13.7
-sentencepiece==0.1.97

--- a/model/reward/instructor/trainer.py
+++ b/model/reward/instructor/trainer.py
@@ -50,7 +50,6 @@ class RankLoss(nn.Module):
 
     def forward(self, pos, neg):
         loss = -self.log_sigmoid(pos - neg + self.eps).mean()
-        print(f"in loss {pos=}, {neg=}, {loss=}")
         return loss
 
 
@@ -90,7 +89,6 @@ class RankTrainer(Trainer):
     def compute_loss(self, model, inputs, return_outputs=False):
         # forward pass
         if "rankgen" in self.model_name:
-            print(f"{inputs=}")
             positive_outputs = model(inputs["prefix"], inputs["positive"])
             negative_outputs = model(inputs["prefix"], inputs["negative"])
             if self.loss_function == "rank":
@@ -171,7 +169,7 @@ if __name__ == "__main__":
         loss_function=training_conf["loss"],
         learning_rate=training_conf["learning_rate"],
         # half_precision_backend="apex",
-        fp16=True,
+        fp16=training_conf["fp16"] if "fp16" in training_conf else True,
         gradient_checkpointing=training_conf["gradient_checkpointing"],
         gradient_accumulation_steps=training_conf["gradient_accumulation_steps"],
         per_device_train_batch_size=training_conf["per_device_train_batch_size"],

--- a/model/reward/instructor/trainer.py
+++ b/model/reward/instructor/trainer.py
@@ -168,7 +168,7 @@ if __name__ == "__main__":
         loss_function=training_conf["loss"],
         learning_rate=training_conf["learning_rate"],
         # half_precision_backend="apex",
-        fp16=training_conf["fp16"] if "fp16" in training_conf else True,
+        fp16=training_conf["fp16"],
         gradient_checkpointing=training_conf["gradient_checkpointing"],
         gradient_accumulation_steps=training_conf["gradient_accumulation_steps"],
         per_device_train_batch_size=training_conf["per_device_train_batch_size"],
@@ -180,7 +180,7 @@ if __name__ == "__main__":
         evaluation_strategy="steps",
         eval_steps=training_conf["eval_steps"],
         save_steps=1000,
-        report_to="wandb",
+        report_to="local",
     )
     train_datasets, evals = [], {}
     if "webgpt" in training_conf["datasets"]:
@@ -196,10 +196,7 @@ if __name__ == "__main__":
         evals["hfsummary"] = sum_eval
     train = ConcatDataset(train_datasets)
 
-    if "tokenizer_name" in training_conf:
-        tokenizer = get_tokenizer(training_conf["tokenizer_name"])
-    else:
-        tokenizer = get_tokenizer(model_name)
+    tokenizer = get_tokenizer(training_conf["tokenizer_name"])
 
     if "rankgen" in model_name:
         collate_fn = RankGenCollator(tokenizer, max_length=training_conf["max_length"])

--- a/model/reward/instructor/utils.py
+++ b/model/reward/instructor/utils.py
@@ -4,7 +4,7 @@ import re
 import yaml
 from sklearn.model_selection import train_test_split
 from torch.utils.data import Subset
-from transformers import AutoTokenizer
+from transformers import AutoTokenizer, T5Tokenizer
 
 re_reference_remove = re.compile(r"\[([0-9])+\]|\[([0-9])+,([0-9])+\]")
 
@@ -26,7 +26,10 @@ def webgpt_return_format(row):
 
 
 def get_tokenizer(tokenizer_name):
-    tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
+    if "t5" in tokenizer_name: #rankgen
+        tokenizer = T5Tokenizer.from_pretrained(tokenizer_name, truncation_side="left")
+    else:
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)
     if "galactica" in tokenizer_name:
         tokenizer.add_special_tokens({"pad_token": "<pad>", "eos_token": "</s>"})
 

--- a/model/reward/instructor/utils.py
+++ b/model/reward/instructor/utils.py
@@ -71,6 +71,10 @@ def freeze_top_n_layers(model, target_layers):
 
 
 def argument_parsing(parser):
+    args = parser.parse_args()
+    with open(args.config, "r", encoding="utf-8") as f:
+        training_conf = yaml.safe_load(f.read())
+
     default_params = {
         "num_train_epochs": 4,
         "learning_rate": 3e-5,
@@ -82,10 +86,9 @@ def argument_parsing(parser):
         "gradient_accumulation_steps": 8,
         "gradient_checkpointing": False,
         "datasets": ["webgpt"],
+        "fp16": True,
+        "tokenizer_name": training_conf["model_name"],
     }
-    args = parser.parse_args()
-    with open(args.config, "r", encoding="utf-8") as f:
-        training_conf = yaml.safe_load(f.read())
 
     params = {**default_params, **training_conf}
     params["gradient_accumulation_steps"] = int(params["gradient_accumulation_steps"])

--- a/model/reward/instructor/utils.py
+++ b/model/reward/instructor/utils.py
@@ -26,7 +26,7 @@ def webgpt_return_format(row):
 
 
 def get_tokenizer(tokenizer_name):
-    if "t5" in tokenizer_name: #rankgen
+    if "t5" in tokenizer_name:  # rankgen
         tokenizer = T5Tokenizer.from_pretrained(tokenizer_name, truncation_side="left")
     else:
         tokenizer = AutoTokenizer.from_pretrained(tokenizer_name)


### PR DESCRIPTION
#78 

As per discussion with @theblackcat102 I built the rankgen trainer on top of their framework ([wandb](https://wandb.ai/bobakhashemi/reward-model/runs/2sgitozt?workspace=user-bobakhashemi)). The model seems to be training now in fp32. Apparently t5 has some issue with fp16. Blackcat suggested scaling the weights might help as in [1](https://github.com/LAION-AI/Open-Assistant/blob/main/model/reward/instructor/trainer.py). This could be a good next step if we want to move with this model. Until then, I think this code is worth comitting since it shows how to add new models which are not `AutoModelForSequenceClassification`