### PR TITLE
#320 - fixed color toggle being missing on light mode

### DIFF
--- a/website/src/components/UI/ColorModeIconToggle.tsx
+++ b/website/src/components/UI/ColorModeIconToggle.tsx
@@ -14,7 +14,7 @@ export function ColorModeIconToggle(props) {
       onClick={toggleColorMode}
     >
       {colorMode === "light" ? (
-        <CiDark className="h-5 w-5 stroke-zinc-900 dark:hidden" />
+        <CiDark className="h-5 w-5 stroke-zinc-900" />
       ) : (
         <CiLight className="h-5 w-5 stroke-white" />
       )}


### PR DESCRIPTION
Fixes #320 

Removed CSS based icon hiding because we already deside what icon to show based on colorMode flag.
Before:
![Before](https://user-images.githubusercontent.com/30481105/210333389-a7a655c2-965c-4e9b-9187-e7c3c3f94c6c.png)
After:
![After](https://user-images.githubusercontent.com/30481105/210339123-4aa768e6-a98e-4e47-a656-09598aadc1d2.png)
