### PR TITLE
Make menu icon visible in dark mode

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -10,9 +10,11 @@ import { ColorModeIconToggle } from "../UI/ColorModeIconToggle";
 import { UserMenu } from "./UserMenu";
 
 function MenuIcon(props) {
+  const { colorMode } = useColorMode();
+  const stroke = colorMode === "light" ? "black" : "white";
   return (
     <svg viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
-      <path d="M5 6h14M5 18h14M5 12h14" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" />
+      <path d="M5 6h14M5 18h14M5 12h14" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" stroke={stroke} />
     </svg>
   );
 }


### PR DESCRIPTION
Set the stroke of the menu icon based on the current color mode.

Before:
<img width="203" alt="before" src="https://user-images.githubusercontent.com/78084157/210357524-d8fe8f88-9dda-4bfa-a613-f93b1088f4c0.png">

After:
<img width="207" alt="after" src="https://user-images.githubusercontent.com/78084157/210357556-d17ea056-9f1e-4326-a9bd-9e746b4921fd.png">
