### PR TITLE
Add warning when submitting unchanged ranking

### DIFF
--- a/website/src/components/Survey/TaskControls.tsx
+++ b/website/src/components/Survey/TaskControls.tsx
@@ -4,7 +4,7 @@ import { SkipButton } from "src/components/Buttons/Skip";
 import { SubmitButton } from "src/components/Buttons/Submit";
 import { TaskInfo } from "src/components/TaskInfo/TaskInfo";
 
-interface TaskControlsProps {
+export interface TaskControlsProps {
   // we need a task type
   // eslint-disable-next-line  @typescript-eslint/no-explicit-any
   tasks: any[];

--- a/website/src/components/Survey/TaskControlsOverridable.tsx
+++ b/website/src/components/Survey/TaskControlsOverridable.tsx
@@ -1,0 +1,60 @@
+import {
+  Button,
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from "@chakra-ui/react";
+import { TaskControls, TaskControlsProps } from "./TaskControls";
+
+interface TaskControlsOverridableProps extends TaskControlsProps {
+  isValid: boolean;
+  prepareForSubmit: () => void;
+}
+
+export const TaskControlsOverridable = (props: TaskControlsOverridableProps) => {
+  const { isValid, onSubmitResponse, ...rest } = props;
+  const { isOpen: isModalOpen, onOpen: onOpenModal, onClose: onModalClose } = useDisclosure();
+
+  const unchangedResponsePrompt = () => {
+    onOpenModal();
+
+    // Ideally this happens when the user clicks submit, but we can't
+    // reliably wait for it to be executed before submitting the response
+    // without significant refactoring.
+    // As a result, modal will only display once even if the user doesn't proceed
+    props.prepareForSubmit();
+  };
+
+  const onSubmitResponseOverride = () => {
+    onSubmitResponse(props.tasks[0]);
+    onModalClose();
+  };
+
+  return (
+    <>
+      <Modal isOpen={isModalOpen} onClose={onModalClose} isCentered>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalCloseButton />
+          <ModalHeader>Order Unchanged</ModalHeader>
+          <ModalBody>You have not changed the order of the prompts. Are you sure you would like to submit?</ModalBody>
+          <ModalFooter>
+            <Flex justify="center" ml="auto" gap={2}>
+              <Button variant={"ghost"} onClick={onModalClose}>
+                Cancel
+              </Button>
+              <Button onClick={onSubmitResponseOverride}>Submit anyway</Button>
+            </Flex>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+      <TaskControls onSubmitResponse={isValid ? props.onSubmitResponse : unchangedResponsePrompt} {...rest} />
+    </>
+  );
+};

--- a/website/src/pages/evaluate/rank_assistant_replies.tsx
+++ b/website/src/pages/evaluate/rank_assistant_replies.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Sortable } from "src/components/Sortable/Sortable";
 import { SurveyCard } from "src/components/Survey/SurveyCard";
-import { TaskControls } from "src/components/Survey/TaskControls";
+import { TaskControlsOverridable } from "src/components/Survey/TaskControlsOverridable";
 import fetcher from "src/lib/fetcher";
 import poster from "src/lib/poster";
 import useSWRImmutable from "swr/immutable";
@@ -27,6 +27,7 @@ const RankAssistantReplies = () => {
   const { trigger } = useSWRMutation("/api/update_task", poster, {
     onSuccess: async (data) => {
       const newTask = await data.json();
+      console.log("response", newTask);
       setTasks((oldTasks) => [...oldTasks, newTask]);
     },
   });
@@ -80,7 +81,13 @@ const RankAssistantReplies = () => {
           <Sortable items={replies} onChange={setRanking} className="my-8" />
         </SurveyCard>
 
-        <TaskControls tasks={tasks} onSubmitResponse={submitResponse} onSkip={fetchNextTask} />
+        <TaskControlsOverridable
+          tasks={tasks}
+          isValid={ranking.length == tasks[0].task.replies.length}
+          prepareForSubmit={() => setRanking(tasks[0].task.replies.map((_, idx) => idx))}
+          onSubmitResponse={submitResponse}
+          onSkip={fetchNextTask}
+        />
       </div>
     </>
   );

--- a/website/src/pages/evaluate/rank_initial_prompts.tsx
+++ b/website/src/pages/evaluate/rank_initial_prompts.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Sortable } from "src/components/Sortable/Sortable";
 import { SurveyCard } from "src/components/Survey/SurveyCard";
-import { TaskControls } from "src/components/Survey/TaskControls";
+import { TaskControlsOverridable } from "src/components/Survey/TaskControlsOverridable";
 import fetcher from "src/lib/fetcher";
 import poster from "src/lib/poster";
 import useSWRImmutable from "swr/immutable";
@@ -79,7 +79,13 @@ const RankInitialPrompts = () => {
           <Sortable items={tasks[0].task.prompts} onChange={setRanking} className="my-8" />
         </SurveyCard>
 
-        <TaskControls tasks={tasks} onSubmitResponse={submitResponse} onSkip={fetchNextTask} />
+        <TaskControlsOverridable
+          tasks={tasks}
+          isValid={ranking.length == tasks[0].task.prompts.length}
+          prepareForSubmit={() => setRanking(tasks[0].task.prompts.map((_, idx) => idx))}
+          onSubmitResponse={submitResponse}
+          onSkip={fetchNextTask}
+        />
       </div>
     </>
   );

--- a/website/src/pages/evaluate/rank_user_replies.tsx
+++ b/website/src/pages/evaluate/rank_user_replies.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Sortable } from "src/components/Sortable/Sortable";
 import { SurveyCard } from "src/components/Survey/SurveyCard";
-import { TaskControls } from "src/components/Survey/TaskControls";
+import { TaskControlsOverridable } from "src/components/Survey/TaskControlsOverridable";
 import fetcher from "src/lib/fetcher";
 import poster from "src/lib/poster";
 import useSWRImmutable from "swr/immutable";
@@ -79,7 +79,13 @@ const RankUserReplies = () => {
           <Sortable items={replies} onChange={setRanking} className="my-8" />
         </SurveyCard>
 
-        <TaskControls tasks={tasks} onSubmitResponse={submitResponse} onSkip={fetchNextTask} />
+        <TaskControlsOverridable
+          tasks={tasks}
+          isValid={ranking.length == tasks[0].task.replies.length}
+          prepareForSubmit={() => setRanking(tasks[0].task.replies.map((_, idx) => idx))}
+          onSubmitResponse={submitResponse}
+          onSkip={fetchNextTask}
+        />
       </div>
     </>
   );


### PR DESCRIPTION
Fix for #272.

When the list is unchanged and the user tries to submit, they are presented with this modal:
<img width="1214" alt="Screenshot 2023-01-04 at 01 19 43" src="https://user-images.githubusercontent.com/5469870/210457601-92a1f46f-bd7f-4881-a695-fa7d33e4967b.png">

Something that may be an issue is that once the modal is presented, if the user presses Cancel, and they click submit again, it won't be presented again. More information on L27 of website/src/components/Survey/TaskControlsOverridable.tsx. Not sure how important this is but will required additional refactoring to fix.
