### PR TITLE
[fix] rename old summary human feedback dataset to new one

### DIFF
--- a/model/reward/instructor/experimental_dataset.py
+++ b/model/reward/instructor/experimental_dataset.py
@@ -60,7 +60,7 @@ class HFSummaryQuality(Dataset):
     def __init__(self, split, tokenizer, max_length=300) -> None:
         super().__init__()
         assert split in ("validation", "test")
-        dataset = load_dataset("Tristan/summarize_from_feedback", "axis")[split]
+        dataset = load_dataset("openai/summarize_from_feedback", "axis")[split]
         self.max_length = max_length
         mean_scores = defaultdict(list)
         self.contexts = []

--- a/model/reward/instructor/rank_datasets.py
+++ b/model/reward/instructor/rank_datasets.py
@@ -118,7 +118,7 @@ class HFSummary(Dataset):
         self.index2summary = {}
         self.max_comparison_per_sample = max_comparison_per_sample
         major_split = split if "train" == split else "validation"
-        dataset = load_dataset("Tristan/summarize_from_feedback", "comparisons")[major_split]
+        dataset = load_dataset("openai/summarize_from_feedback", "comparisons")[major_split]
         for data in dataset:
             if (
                 "extra" in data


### PR DESCRIPTION
Can verify that all test cases have finished without any errors and new source share the same format as the old one.