### PR TITLE
Create role field in website User table and be able to seed it#236

### DIFF
--- a/website/prisma/schema.prisma
+++ b/website/prisma/schema.prisma
@@ -41,7 +41,7 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
-
+  role          String?  // New Column
   accounts      Account[]
   sessions      Session[]
 

--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -1,3 +1,4 @@
+import "./config.js"
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { boolean } from "boolean";
 import type { AuthOptions } from "next-auth";
@@ -79,7 +80,7 @@ const authOptions: AuthOptions = {
         const discordID = account.id;
         const discordUsername = account.username;
         const discordIdAndUsername = `${discordUsername}#${discordID}`;
-        if (adminUsers && (adminUsers.includes(discordIdAndUsername))) {
+        if (adminUsers && adminUsers.includes(discordIdAndUsername)) {
           // Mark the user as an admin.
           await prisma.user.update({
             where: {
@@ -91,7 +92,7 @@ const authOptions: AuthOptions = {
           });
         }
       }
-      if (adminUsers && (adminUsers.includes(user.email))) {
+      if (adminUsers && adminUsers.includes(user.email)) {
         // Mark the user as an admin.
         await prisma.user.update({
           where: {
@@ -101,8 +102,7 @@ const authOptions: AuthOptions = {
             role: "ADMIN",
           },
         });
-      }
-      else {
+      } else {
         await prisma.user.update({
           where: {
             id: user.id,


### PR DESCRIPTION
I was trying to test this, but I do not know how to set up the backend to test whether or not the roles updated.  Also, the discord/email authentication does not seem to be setup, so I do not know where the admin discord/emails would be held.  Currently, the admin data would have to be saved in a config file, but that seems unrealistic (I would expect it to be held in some database with the admins email/discord). Also, the signin button doesnt seem to go anywhere, so I don't know how to test whether or not the callback is working or updating.  Made a draft PR for thoughts and whether or not I should wait for these changes to be made by others.  @fozziethebeat   