### PR TITLE
A few small changes to the Discord Bot

### DIFF
--- a/discord-bot/bot/extensions/work.py
+++ b/discord-bot/bot/extensions/work.py
@@ -29,8 +29,8 @@ from oasst_shared.schemas.protocol import TaskRequestType
 
 plugin = lightbulb.Plugin("WorkPlugin")
 
-MAX_TASK_TIME = 60 * 60  # 1 hour
-MAX_TASK_ACCEPT_TIME = 60  # 1 minute
+MAX_TASK_TIME = 60 * 60  # seconds
+MAX_TASK_ACCEPT_TIME = 60 * 10  # seconds
 
 settings = Settings()
 
@@ -117,7 +117,7 @@ async def _handle_task(ctx: lightbulb.Context, task_type: TaskRequestType) -> No
         # Task action loop
         completed = False
         while not completed:
-            await ctx.author.send(embed=plain_embed("Please type your response here"))
+            await ctx.author.send(embed=plain_embed("Please type your response below:"))
             try:
                 event = await ctx.bot.wait_for(
                     hikari.DMMessageCreateEvent,

--- a/discord-bot/bot/messages.py
+++ b/discord-bot/bot/messages.py
@@ -80,6 +80,7 @@ def initial_prompt_message(task: protocol_schema.InitialPromptTask) -> str:
 
 {_h1("INITIAL PROMPT")}
 
+
 {_writing_prompt("Please provide an initial prompt to the assistant.")}
 {_hint(task.hint)}
 """
@@ -91,10 +92,10 @@ def rank_initial_prompts_message(task: protocol_schema.RankInitialPromptsTask) -
 
 {_h1("RANK INITIAL PROMPTS")}
 
-{_ranking_prompt("Reply with the numbers of best to worst prompts separated by commas (example: '4,1,3,2')")}
-
 
 {_ordered_list(task.prompts)}
+
+{_ranking_prompt("Reply with the numbers of best to worst prompts separated by commas (example: '4,1,3,2')")}
 """
 
 
@@ -104,12 +105,12 @@ def rank_prompter_reply_message(task: protocol_schema.RankPrompterRepliesTask) -
 
 {_h1("RANK PROMPTER REPLIES")}
 
-{_ranking_prompt("Reply with the numbers of best to worst replies separated by commas (example: '4,1,3,2')")}
-
 
 {_conversation(task.conversation)}
 {_user(None)}
 {_ordered_list(task.replies)}
+
+{_ranking_prompt("Reply with the numbers of best to worst replies separated by commas (example: '4,1,3,2')")}
 """
 
 
@@ -119,12 +120,12 @@ def rank_assistant_reply_message(task: protocol_schema.RankAssistantRepliesTask)
 
 {_h1("RANK ASSISTANT REPLIES")}
 
-{_ranking_prompt("Reply with the numbers of best to worst replies separated by commas (example: '4,1,3,2')")}
-
 
 {_conversation(task.conversation)}
 {_assistant(None)}
 {_ordered_list(task.replies)}
+
+{_ranking_prompt("Reply with the numbers of best to worst replies separated by commas (example: '4,1,3,2')")}
 """
 
 
@@ -134,11 +135,11 @@ def prompter_reply_message(task: protocol_schema.PrompterReplyTask) -> str:
 
 {_h1("PROMPTER REPLY")}
 
-{_response_prompt("Please provide a reply to the assistant.")}
-
 
 {_conversation(task.conversation)}
 {_hint(task.hint)}
+
+{_response_prompt("Please provide a reply to the assistant.")}
 """
 
 
@@ -147,10 +148,10 @@ def assistant_reply_message(task: protocol_schema.AssistantReplyTask) -> str:
     return f"""\
 {_h1("ASSISTANT REPLY")}
 
-{_response_prompt("Please provide a reply to the assistant.")}
-
 
 {_conversation(task.conversation)}
+
+{_response_prompt("Please provide a reply to the assistant.")}
 """
 
 


### PR DESCRIPTION
These are small requests from @andreaskoepf to improve the discord bot.

- [x] The timeout of the private bot-session is set too low, please make it configurable in seconds, default to 600.
- [x] Please add a colon at the end of "Enter response here:"
- [x] Please move task instructions like "Reply with the numbers of best to worst replies separated by commas (example: '4,1,3,2')" to the bottom.. e.g. below the ranking-options, so that the comma delimited example is visible just above the discord-input text-box at the bottom of the screen.