### PR TITLE
Fix dark mode display for some pages

### DIFF
--- a/website/src/pages/account/edit.tsx
+++ b/website/src/pages/account/edit.tsx
@@ -36,22 +36,24 @@ export default function Account() {
           content="Conversational AI for everyone. An open source project to create a chat enabled GPT LLM run by LAION and contributors around the world."
         />
       </Head>
-      <main className="h-3/4 z-0 bg-white flex flex-col items-center justify-center">
-        <p>{session.user.name || "No username"}</p>
-        <form onSubmit={updateUser}>
-          <InputGroup>
-            <Input
-              onChange={(e) => setUsername(e.target.value)}
-              placeholder="Edit Username"
-              type="text"
-              value={username}
-            ></Input>
-            <Button disabled={!username} type="submit" value="Change">
-              Submit
-            </Button>
-          </InputGroup>
-        </form>
-      </main>
+      <div className="oa-basic-theme">
+        <main className="h-3/4 z-0 flex flex-col items-center justify-center">
+          <p>{session.user.name || "No username"}</p>
+          <form onSubmit={updateUser}>
+            <InputGroup>
+              <Input
+                onChange={(e) => setUsername(e.target.value)}
+                placeholder="Edit Username"
+                type="text"
+                value={username}
+              ></Input>
+              <Button disabled={!username} type="submit" value="Change">
+                Submit
+              </Button>
+            </InputGroup>
+          </form>
+        </main>
+      </div>
     </>
   );
 }

--- a/website/src/pages/account/index.tsx
+++ b/website/src/pages/account/index.tsx
@@ -19,13 +19,15 @@ export default function Account() {
           content="Conversational AI for everyone. An open source project to create a chat enabled GPT LLM run by LAION and contributors around the world."
         />
       </Head>
-      <main className="h-3/4 z-0 bg-white flex flex-col items-center justify-center">
-        <p>{session.user.name || "No username"}</p>
-        <Button>
-          <Link href="/account/edit">Edit Username</Link>
-        </Button>
-        <p>{session.user.email}</p>
-      </main>
+      <div className="oa-basic-theme">
+        <main className="h-3/4 z-0 flex flex-col items-center justify-center">
+          <p>{session.user.name || "No username"}</p>
+          <Button>
+            <Link href="/account/edit">Edit Username</Link>
+          </Button>
+          <p>{session.user.email}</p>
+        </main>
+      </div>
     </>
   );
 }

--- a/website/src/pages/privacy-policy.tsx
+++ b/website/src/pages/privacy-policy.tsx
@@ -14,7 +14,7 @@ const PrivacyPolicy = () => {
           content="Conversational AI for everyone. An open source project to create a chat enabled GPT LLM run by LAION and contributors around the world."
         />
       </Head>
-      <main>
+      <main className="oa-basic-theme">
         <Container>
           <Heading as="h1" size="3xl">
             Privacy Policy

--- a/website/src/pages/terms-of-service.tsx
+++ b/website/src/pages/terms-of-service.tsx
@@ -14,7 +14,7 @@ const TermsOfService = () => {
           content="Conversational AI for everyone. An open source project to create a chat enabled GPT LLM run by LAION and contributors around the world."
         />
       </Head>
-      <main>
+      <main className="oa-basic-theme">
         <Container>
           <Heading as="h1" size="3xl">
             Terms Of Service


### PR DESCRIPTION
Some pages (account, privacy-policy, terms-of-service) are not correctly displayed in dark mode. This is fixed in this PR. 

E.g. for the account page:
Before:
<img width="585" alt="before" src="https://user-images.githubusercontent.com/78084157/210588488-2d4e1f5c-ca2e-45ff-959d-6e587482a8db.png">
After:
<img width="588" alt="after" src="https://user-images.githubusercontent.com/78084157/210588498-011218ac-c586-4b17-a901-d449865356e3.png">
