### PR TITLE
Fixed broken link in the dashboard

### DIFF
--- a/website/src/components/Dashboard/TaskOption.tsx
+++ b/website/src/components/Dashboard/TaskOption.tsx
@@ -6,7 +6,7 @@ const crTasks = [
     label: "Reply as User",
     desc: "Chat with Open Assistant and help improve it’s responses as you interact with it.",
     type: "create",
-    pathname: "/create/assistant_reply",
+    pathname: "/create/user_reply",
   },
   {
     label: "Reply as Assistant",


### PR DESCRIPTION
Small fix for the broken link in the dashboard. Reply as User card redirected to assistant_reply url.
**Before**
![Before](https://user-images.githubusercontent.com/30481105/210656745-d5ca444c-6f5c-4985-aa27-ed35912ec7a6.png)
**After**
![After](https://user-images.githubusercontent.com/30481105/210656962-031c2f12-2275-4afc-a693-5c103469650d.png)
