### PR TITLE
devcontainer: post create run npm install in /website

### DIFF
--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,2 +1,7 @@
 # ensure pre-commit is installed
 pre-commit install
+
+# npm install in /website
+cd website
+npm install
+cd ..


### PR DESCRIPTION
Small pr to run npm install in `/website` so users in devcontainer dont need to.