### PR TITLE
Replace npm install with npm ci

### DIFF
--- a/.github/workflows/test-api-contract.yaml
+++ b/.github/workflows/test-api-contract.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - run: cd backend && pip install -r requirements.txt
 
-      - run: cd website && npm install
+      - run: cd website && npm ci
 
       - run: ./scripts/backend-development/start-mock-server.sh
 

--- a/website/README.md
+++ b/website/README.md
@@ -53,7 +53,7 @@ If you're doing active development we suggest the following workflow:
 1.  Run `docker compose up frontend-dev --build --attach-dependencies`. You can
     optionally include `-d` to detach and later track the logs if desired.
 1.  In another tab navigate to `${OPEN_ASSISTANT_ROOT/website`.
-1.  Run `npm install`
+1.  Run `npm ci`
 1.  Run `npx prisma db push` (This is also needed when you restart the docker
     stack from scratch).
 1.  Run `npm run dev`. Now the website is up and running locally at


### PR DESCRIPTION
`npm ci` is intended for a deterministic, repeatable build and `npm install` for adding new dependencies and updating existing.
`npm ci` is already used in the project in `Dockerfile.website` and `build-frontend.yaml`.
Here are the full list of differences with `npm install`: [https://stackoverflow.com/questions/52499617/what-is-the-difference-between-npm-install-and-npm-ci](url)