### PR TITLE
Automate e2e test of the website (basic)

### DIFF
--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -1,0 +1,37 @@
+name: E2E Tests (Website)
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - backend/**
+      - website/**
+  pull_request:
+    paths:
+      - backend/**
+      - website/**
+
+jobs:
+  test-e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Start website, backend, etc
+        run: docker compose up ci --build -d
+      - name: Run Cypress tests
+        uses: cypress-io/github-action@v5.0.2
+        with:
+          browser: chrome
+          working-directory: website
+      - uses: actions/upload-artifact@v3
+        if: failure() # NOTE: screenshots will be generated only if E2E test failed
+        with:
+          name: cypress-screenshots
+          path: website/cypress/screenshots
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: cypress-videos
+          path: website/cypress/videos

--- a/.github/workflows/test-e2e.yaml
+++ b/.github/workflows/test-e2e.yaml
@@ -5,10 +5,12 @@ on:
     branches:
       - main
     paths:
+      - oasst-shared/**
       - backend/**
       - website/**
   pull_request:
     paths:
+      - oasst-shared/**
       - backend/**
       - website/**
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
     image: sverrirab/sleep
     depends_on: [db, webdb, adminer, maildev, backend, redis]
 
+  # Used by CI automations.
+  ci:
+    image: sverrirab/sleep
+    depends_on: [db, webdb, maildev, backend, redis, web]
+
   # This DB is for the FastAPI Backend.
   db:
     image: postgres


### PR DESCRIPTION
This is an alternative to #376 that strips down the CI step to reduce any potential for unforeseen changes to other CI steps and avoids spamming the ghcr with docker builds.

I decided to test this version to prove if all the extra work the other version does was warranted and it appears if might not have been. The performance of building the container on demand actually seems to be better than building it using the reusable workflow and the only downside is that tests in different browsers would be run sequentially rather than in parallel. In the original PR it turned out however that Cypress seemed to have more to trouble working with firefox than chrome and so I figure it might be better to just test one browser for now for E2E tests as that should be more than sufficient as a smoke test (detecting browser specific failures is not really the goal atm).

Example of tests passing: https://github.com/othrayte/Open-Assistant/pull/6
Example of tests failing: https://github.com/othrayte/Open-Assistant/pull/7