### PR TITLE
clean up docs github workflow

### DIFF
--- a/.github/workflows/deploy-docs-site.yaml
+++ b/.github/workflows/deploy-docs-site.yaml
@@ -44,8 +44,7 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if:
-          ${{ github.ref == 'refs/heads/main' }}
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build

--- a/.github/workflows/deploy-docs-site.yaml
+++ b/.github/workflows/deploy-docs-site.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - docs-site-poc
     paths:
       - ".github/workflows/deploy-docs-site.yaml"
       - "docs/**"
@@ -46,8 +45,7 @@ jobs:
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         if:
-          ${{ github.ref == 'refs/heads/main' || github.ref ==
-          'refs/heads/docs-site-poc' }}
+          ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./docs/build


### PR DESCRIPTION
now that docs site pr is merged we should only trigger github docs site deploy workflow on `main` branch. `docs-site-poc` branch was just here as part of the PR testing, not needed anymore.