### PR TITLE
#432 - Added basic Admin Dashboard layout

### DIFF
--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -1,7 +1,7 @@
 // https://nextjs.org/docs/basic-features/layouts
 
 import type { NextPage } from "next";
-import { FiLayout, FiMessageSquare } from "react-icons/fi";
+import { FiLayout, FiMessageSquare, FiUsers } from "react-icons/fi";
 import { Header } from "src/components/Header";
 
 import { Footer } from "./Footer";
@@ -43,6 +43,24 @@ export const getDashboardLayout = (page: React.ReactElement) => (
           pathname: "/messages",
           desc: "Messages Dashboard",
           icon: FiMessageSquare,
+        },
+      ]}
+    >
+      {page}
+    </SideMenuLayout>
+  </div>
+);
+
+export const getAdminLayout = (page: React.ReactElement) => (
+  <div className="grid grid-rows-[min-content_1fr_min-content] h-full justify-items-stretch">
+    <Header transparent={true} />
+    <SideMenuLayout
+      menuButtonOptions={[
+        {
+          label: "Users",
+          pathname: "/admin",
+          desc: "Users Dashboard",
+          icon: FiUsers,
         },
       ]}
     >

--- a/website/src/pages/admin/index.tsx
+++ b/website/src/pages/admin/index.tsx
@@ -2,7 +2,7 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
-import { getTransparentHeaderLayout } from "src/components/Layout";
+import { getAdminLayout } from "src/components/Layout";
 import UsersCell from "src/components/UsersCell";
 
 /**
@@ -44,6 +44,6 @@ const AdminIndex = () => {
   );
 };
 
-AdminIndex.getLayout = getTransparentHeaderLayout;
+AdminIndex.getLayout = getAdminLayout;
 
 export default AdminIndex;


### PR DESCRIPTION
#432 
Should be done with the issue. For now decided against moving `GeneralSidebarLayout` and `AdminSidebarLayout` into separate components. But that could easily be fixed.

Fixed `/admin` page to use new `getAdminLayout` function.

Preview:
![Preview](https://user-images.githubusercontent.com/30481105/211150159-2007f2df-8519-40c8-8a94-e81f4da26f7d.png)