### PR TITLE
#479 - Fixed FOUC on website

### DIFF
--- a/website/src/components/Header/UserMenu.tsx
+++ b/website/src/components/Header/UserMenu.tsx
@@ -2,6 +2,7 @@ import { Box, Link, Text, useColorModeValue } from "@chakra-ui/react";
 import { Popover } from "@headlessui/react";
 import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
+import NextLink from "next/link";
 import { signOut, useSession } from "next-auth/react";
 import React from "react";
 import { FiLayout, FiLogOut, FiSettings } from "react-icons/fi";
@@ -77,6 +78,7 @@ export function UserMenu() {
                       <Box className="flex flex-col gap-1">
                         {accountOptions.map((item) => (
                           <Link
+                            as={NextLink}
                             key={item.name}
                             href={item.href}
                             aria-label={item.desc}

--- a/website/src/components/SideMenu.tsx
+++ b/website/src/components/SideMenu.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Link, Text, Tooltip, useColorMode } from "@chakra-ui/react";
+import { Box, Button, Text, Tooltip, useColorMode } from "@chakra-ui/react";
+import Link from "next/link";
 import { useRouter } from "next/router";
 import { FiSun } from "react-icons/fi";
 import { IconType } from "react-icons/lib";

--- a/website/src/pages/messages/index.tsx
+++ b/website/src/pages/messages/index.tsx
@@ -1,6 +1,6 @@
 import { Box, CircularProgress, SimpleGrid, Text, useColorModeValue } from "@chakra-ui/react";
 import Head from "next/head";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { getDashboardLayout } from "src/components/Layout";
 import { MessageTable } from "src/components/Messages/MessageTable";
 import fetcher from "src/lib/fetcher";
@@ -13,17 +13,26 @@ const MessagesDashboard = () => {
   const [messages, setMessages] = useState([]);
   const [userMessages, setUserMessages] = useState([]);
 
-  const { isLoading: isLoadingAll } = useSWRImmutable("/api/messages", fetcher, {
+  const { isLoading: isLoadingAll, mutate: mutateAll } = useSWRImmutable("/api/messages", fetcher, {
     onSuccess: (data) => {
       setMessages(data);
     },
   });
 
-  const { isLoading: isLoadingUser } = useSWRImmutable(`/api/messages/user`, fetcher, {
+  const { isLoading: isLoadingUser, mutate: mutateUser } = useSWRImmutable(`/api/messages/user`, fetcher, {
     onSuccess: (data) => {
       setUserMessages(data);
     },
   });
+
+  useEffect(() => {
+    if (messages.length == 0) {
+      mutateAll();
+    }
+    if (userMessages.length == 0) {
+      mutateUser();
+    }
+  }, [messages, userMessages]);
 
   return (
     <>


### PR DESCRIPTION
Would close #479.
Found simpler solution. Turns out some of the components used ChakraUI's `Link` which has limited support for NextJS's client-side routing.

Note:
ChakraUI's `Link` can be used if we provide `as` prop with NextJS's `link` component.

Also changed `/messages` page. It was having same issues as tasks in #343. Applied same fix as in PR #393. Works as intended.

**Demo:**
![Demo](https://user-images.githubusercontent.com/30481105/211152942-220df28b-beed-478e-bdc3-d1ca9cbaedef.gif)