### PR TITLE
add docs site url to docs/readme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,8 @@
 
 https://liaon-ai.github.io/Open-Assistant/
 
-This [site](https://liaon-ai.github.io/Open-Assistant/) is built using [Docusaurus 2](https://docusaurus.io/), a modern
-static website generator.
+This [site](https://liaon-ai.github.io/Open-Assistant/) is built using
+[Docusaurus 2](https://docusaurus.io/), a modern static website generator.
 
 ### Contributing
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,8 @@
-# Website
+# Docs Site
 
-This website is built using [Docusaurus 2](https://docusaurus.io/), a modern
+https://liaon-ai.github.io/Open-Assistant/
+
+This [site](https://liaon-ai.github.io/Open-Assistant/) is built using [Docusaurus 2](https://docusaurus.io/), a modern
 static website generator.
 
 ### Contributing

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -20,7 +20,7 @@ const config = {
   // If you aren't using GitHub pages, you don't need these.
   organizationName: "LAION-AI", // Usually your GitHub org/user name.
   projectName: "Open-Assistant", // Usually your repo name.
-  deploymentBranch: "docs-site-poc",
+  deploymentBranch: "main",
 
   // Even if you don't use internalization, you can use this field to set useful
   // metadata like html lang. For example, if your site is Chinese, you may want


### PR DESCRIPTION
Once merged, this should hopefully trigger the GH workflow to build and push to https://github.com/LAION-AI/Open-Assistant/tree/gh-pages which will then be picked up by GH pages and hosted here: https://liaon-ai.github.io/Open-Assistant/