### PR TITLE
#492 - Add regex word counter

### DIFF
--- a/website/src/components/Survey/TrackedTextarea.tsx
+++ b/website/src/components/Survey/TrackedTextarea.tsx
@@ -12,7 +12,7 @@ interface TrackedTextboxProps {
 }
 
 export const TrackedTextarea = (props: TrackedTextboxProps) => {
-  const wordCount = props.text.split(" ").length - 1;
+  const wordCount = (props.text.match(/\w+/g) || []).length;
 
   let progressColor: string;
   switch (true) {


### PR DESCRIPTION
Closes #492 

Changed word counter to use regex `/\w+/g` in the `TrackedTextarea` component. Should also be more accurate.