### PR TITLE
add example notebook

### DIFF
--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -6,8 +6,8 @@ explaining what they do.
 
 ## Contributing
 
-Contributing to both notebooks and making new notebooks is very welcome. If you
-do so, make sure to make a markdown (.md) file to go with your notebook, makes
+Contributing to notebooks and making new notebooks is very welcome. If you do
+so, make sure to make a markdown (.md) file to go with your notebook, it makes
 it easier for people to know what your notebook is about.
 
 Check out the [example notebook](example/) for a reference example you can use

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,6 +1,6 @@
 # Notebooks
 
-This is a folders with some useful notebooks, all the notebooks have a markdown
+This is a folder with some useful notebooks, all the notebooks have a markdown
 file with the same name explaining what they do (or a README.md if its a single
 notebook folder).
 

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,10 +1,14 @@
 # Notebooks
 
 This is a folders with some useful notebooks, all the notebooks have a markdown
-file with the same name explaining what they do.
+file with the same name explaining what they do (or a README.md if its a single
+notebook folder).
 
 ## Contributing
 
 Contributing to both notebooks and making new notebooks is very welcome. If you
 do so, make sure to make a markdown (.md) file to go with your notebook, makes
 it easier for people to know what your notebook is about.
+
+Check out the [example notebook](example/) for a reference example you can use
+as a starting point.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,8 +1,8 @@
 # Notebooks
 
 This is a folder with some useful notebooks, all the notebooks have a markdown
-file with the same name explaining what they do (or a README.md if its a single
-notebook folder).
+file with the same name (or a README.md if its a single notebook folder)
+explaining what they do.
 
 ## Contributing
 

--- a/notebooks/example/README.md
+++ b/notebooks/example/README.md
@@ -1,6 +1,43 @@
 # Example Notebook
 
-[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/andrewm4894/Open-Assistant/blob/example-notebook/notebooks/example/example.ipynb)
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/andrewm4894/Open-Assistant/blob/main/notebooks/example/example.ipynb)
 
 This folder contains an example reference notebook structure and approach for
-this project. Please try and follow this structure as closely as possible.
+this project. Please try and follow this structure as closely as possible. While
+things will not exactly be the same for each notebook some principles we would
+like to try ensure are:
+
+1. Each notebook or collection of related or dependant notebooks should live in
+   its own folder.
+1. Each notebook should have a markdown file with the same name as the notebook
+   (or README.md if it's a single notebook folder) that explains what the
+   notebook does and how to use it.
+1. Add an "Open in Colab" badge to the top of the notebook.
+1. Make it as easy as possible for someone to run the notebook in Google Colab
+   or some other environment based on standard practices like providing a
+   `requirements.txt` file or anything else needed to successfully run the
+   notebook.
+
+## Running in Google Colab
+
+At the top of the notebook there is a code cell that will (once uncommented):
+
+1. clone the repository into your colab instance.
+1. `cd` into the relevant notebook directory.
+1. run `pip install -r requirements.txt` to install the required packages.
+
+At this point you can run the notebook as normal and the folder structure will
+match that of the repository and the colab notebook will be running from the
+same directory that the notebook lives in so relative links etc should work as
+expected (for example `example.ipynb` will read some sample data from
+`data/data.csv`).
+
+If you are adding a notebook please try and add a similar cell to the top of the
+notebook so that it is easy for others to run the notebook in colab.
+
+## example.ipynb
+
+This notebook contains an example "Open In Colab" badge and a code cell to
+prepare the colab environment to run the notebook. It also contains a code cell
+that will read in some sample data from the `data` folder in the repository and
+display it as a pandas dataframe.

--- a/notebooks/example/README.md
+++ b/notebooks/example/README.md
@@ -1,0 +1,6 @@
+# Example Notebook
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/andrewm4894/Open-Assistant/blob/example-notebook/notebooks/example/example.ipynb)
+
+This folder contains an example reference notebook structure and approach for
+this project. Please try and follow this structure as closely as possible.

--- a/notebooks/example/README.md
+++ b/notebooks/example/README.md
@@ -20,7 +20,8 @@ like to try ensure are:
 
 ## Running in Google Colab
 
-At the top of the notebook there is a code cell that will (once uncommented):
+At the top of the [example notebook](example.ipynb) there is a code cell that
+will (once uncommented):
 
 1. clone the repository into your colab instance.
 1. `cd` into the relevant notebook directory.

--- a/notebooks/example/README.md
+++ b/notebooks/example/README.md
@@ -12,7 +12,8 @@ like to try ensure are:
 1. Each notebook should have a markdown file with the same name as the notebook
    (or README.md if it's a single notebook folder) that explains what the
    notebook does and how to use it.
-1. Add an "Open in Colab" badge to the top of the notebook.
+1. Add an "Open in Colab" badge to the top of the notebook (see the markdown
+   cell near the top of `example.ipynb` as an example you can adapt).
 1. Make it as easy as possible for someone to run the notebook in Google Colab
    or some other environment based on standard practices like providing a
    `requirements.txt` file or anything else needed to successfully run the
@@ -34,7 +35,10 @@ expected (for example `example.ipynb` will read some sample data from
 `data/data.csv`).
 
 If you are adding a notebook please try and add a similar cell to the top of the
-notebook so that it is easy for others to run the notebook in colab.
+notebook so that it is easy for others to run the notebook in colab. If your
+notebook does not have any dependencies beyond what already comes as standard in
+Google Colab then you do not need such a cell, just an "Open in Colab" badge
+will suffice.
 
 ## example.ipynb
 

--- a/notebooks/example/data/data.csv
+++ b/notebooks/example/data/data.csv
@@ -1,0 +1,3 @@
+row,text,label
+1,some example data,1
+2,some more data,0

--- a/notebooks/example/example.ipynb
+++ b/notebooks/example/example.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/andrewm4894/Open-Assistant/blob/example-notebook/notebooks/example/example.ipynb)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# uncomment and run below lines to set up if running in colab\n",
+    "# !git clone https://github.com/andrewm4894/Open-Assistant.git\n",
+    "# %cd Open-Assistant/notebooks/example\n",
+    "# !pip install -r requirements.txt"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example Notebook"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try to add a markdown section to the notebook that explains what the notebook is about and what it does. This will help people understand what the notebook is for and how to use it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import required packages\n",
+    "import pandas as pd\n",
+    "from transformers import pipeline"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Use Headings\n",
+    "\n",
+    "(it will help with link sharing to specific sections of the notebook)"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Make fancy markdown cells if you want."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>row</th>\n",
+       "      <th>text</th>\n",
+       "      <th>label</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>some example data</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2</td>\n",
+       "      <td>some more data</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   row               text  label\n",
+       "0    1  some example data      1\n",
+       "1    2     some more data      0"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Do cool stuff here\n",
+    "df = pd.read_csv(\"data/data.csv\")\n",
+    "df.head()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "orig_nbformat": 4,
+  "vscode": {
+   "interpreter": {
+    "hash": "3ad933181bd8a04b432d3370b9dc3b0662ad032c4dfaa4e4f1596c548f763858"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/notebooks/example/example.ipynb
+++ b/notebooks/example/example.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Example Notebook"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -17,14 +25,6 @@
     "# !git clone https://github.com/andrewm4894/Open-Assistant.git\n",
     "# %cd Open-Assistant/notebooks/example\n",
     "# !pip install -r requirements.txt"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Example Notebook"
    ]
   },
   {

--- a/notebooks/example/requirements.txt
+++ b/notebooks/example/requirements.txt
@@ -1,0 +1,1 @@
+transformers


### PR DESCRIPTION
this adds

- an example notebook as `notebooks/example/`
- a readme in `notebooks/example/README.md`
- a code cell at the top of `notebooks/example/example.ipynb`, to be uncommented and ran if running in colab, that will set up the colab notebook to just work and be able to use and files or dirs that live with the notebook, for example reading from a /data/ folder or installing from a requirements.txt.

Main idea here is to give an example that's as easy as just pressing the "Open In Colab", uncommenting top set up cell (if needed) and then ability to just run all cells. This is useful as you can just get a gpu instance (if needed) in colab so should make it easier for users to play with notebooks without too crazy configurations/env's locally that otherwise might block them.

I had a look at mybinder but it did not really work well (was not able to get it to open in a subfolder ([thread](https://discourse.jupyter.org/t/mybinder-jupyterlab-link-to-a-repo-subfolder-works-but-not-to-a-specific-notebook-in-that-folder/9443) suggests it should), was much slower than colab also since needed to create images etc). 

So i think Colab + set up cell at top should probably be fine and does seem to work pretty well in terms of minimal time to just being able to press "run all" in a notebook and have it run.

Thoughts? I don't mind helping to make sure any notebooks that come in are "runnable in colab" as best we can.

