### PR TITLE
bugfix in alembic downgrade (frontend_type not frontend_id)

### DIFF
--- a/backend/alembic/versions/2023_01_07_1250-ba61fe17fb6e_added_frontend_type_to_api_client.py
+++ b/backend/alembic/versions/2023_01_07_1250-ba61fe17fb6e_added_frontend_type_to_api_client.py
@@ -20,4 +20,4 @@ def upgrade() -> None:
 
 
 def downgrade() -> None:
-    op.drop_column("api_client", "frontend_id")
+    op.drop_column("api_client", "frontend_type")


### PR DESCRIPTION
I had an typo in the alembic upgrade script...