### PR TITLE
#224: display OAuthAccountNotLinked error message + other errors messages

### DIFF
--- a/website/src/pages/auth/signin.tsx
+++ b/website/src/pages/auth/signin.tsx
@@ -4,7 +4,7 @@ import Head from "next/head";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { getCsrfToken, getProviders, signIn } from "next-auth/react";
-import React, { useRef, useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import { FaBug, FaDiscord, FaEnvelope, FaGithub } from "react-icons/fa";
 import { AuthLayout } from "src/components/AuthLayout";
 import { Footer } from "src/components/Footer";
@@ -23,7 +23,7 @@ export type SignInErrorTypes =
   | "SessionRequired"
   | "default";
 
-const errors: Record<SignInErrorTypes, string> = {
+const errorMessages: Record<SignInErrorTypes, string> = {
   Signin: "Try signing in with a different account.",
   OAuthSignin: "Try signing in with a different account.",
   OAuthCallback: "Try signing in with the same account you used originally.",
@@ -45,13 +45,12 @@ function Signin({ csrfToken, providers }) {
   const [error, setError] = useState("");
 
   useEffect(() => {
-    if (router?.query?.error) {
-      if (typeof router.query.error === "string") {
-        const errorType = errors[router.query.error];
-        setError(errorType);
+    const err = router?.query?.error;
+    if (err) {
+      if (typeof err === "string") {
+        setError(errorMessages[err]);
       } else {
-        const errorType = errors[router.query.error[0]];
-        setError(errorType);
+        setError(errorMessages[err[0]]);
       }
     }
   }, [router]);

--- a/website/src/pages/auth/signin.tsx
+++ b/website/src/pages/auth/signin.tsx
@@ -2,17 +2,60 @@ import { Button, Input, Stack } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/react";
 import Head from "next/head";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { getCsrfToken, getProviders, signIn } from "next-auth/react";
-import React, { useRef } from "react";
+import React, { useRef, useEffect, useState } from "react";
 import { FaBug, FaDiscord, FaEnvelope, FaGithub } from "react-icons/fa";
 import { AuthLayout } from "src/components/AuthLayout";
 import { Footer } from "src/components/Footer";
 import { Header } from "src/components/Header";
 
+export type SignInErrorTypes =
+  | "Signin"
+  | "OAuthSignin"
+  | "OAuthCallback"
+  | "OAuthCreateAccount"
+  | "EmailCreateAccount"
+  | "Callback"
+  | "OAuthAccountNotLinked"
+  | "EmailSignin"
+  | "CredentialsSignin"
+  | "SessionRequired"
+  | "default";
+
+const errors: Record<SignInErrorTypes, string> = {
+  Signin: "Try signing in with a different account.",
+  OAuthSignin: "Try signing in with a different account.",
+  OAuthCallback: "Try signing in with the same account you used originally.",
+  OAuthCreateAccount: "Try signing in with a different account.",
+  EmailCreateAccount: "Try signing in with a different account.",
+  Callback: "Try signing in with a different account.",
+  OAuthAccountNotLinked: "To confirm your identity, sign in with the same account you used originally.",
+  EmailSignin: "The e-mail could not be sent.",
+  CredentialsSignin: "Sign in failed. Check the details you provided are correct.",
+  SessionRequired: "Please sign in to access this page.",
+  default: "Unable to sign in.",
+};
+
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function Signin({ csrfToken, providers }) {
+  const router = useRouter();
   const { discord, email, github, credentials } = providers;
   const emailEl = useRef(null);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    if (router?.query?.error) {
+      if (typeof router.query.error === "string") {
+        const errorType = errors[router.query.error];
+        setError(errorType);
+      } else {
+        const errorType = errors[router.query.error[0]];
+        setError(errorType);
+      }
+    }
+  }, [router]);
+
   const signinWithEmail = (ev: React.FormEvent) => {
     ev.preventDefault();
     signIn(email.id, { callbackUrl: "/dashboard", email: emailEl.current.value });
@@ -110,6 +153,11 @@ function Signin({ csrfToken, providers }) {
           </Link>
           .
         </div>
+        {error && (
+          <div className="text-center mt-8">
+            <p className="text-orange-600">Error: {error}</p>
+          </div>
+        )}
       </AuthLayout>
     </div>
   );


### PR DESCRIPTION
I checked how NextAuth does it https://github.com/nextauthjs/next-auth/blob/main/packages/next-auth/src/core/pages/signin.tsx. They seem to pass the error in props somehow. I didn't want to add too much code or change the overall structure too much so I just added a useEffect to check whether the router contains an error. If it does, use a type guard to check if it's a string or an array, and handle them appropriately. I don't think there are cases when you'll get two errors at once, so it's mainly to stop TypeScript errors. I also added all the other error code from the above NextAuth page mentioned, so if other errors pop up they should be correctly displayed to the user. I also changed the error message for the OAuthAccountNotLinked as it didnt' seem to correctly reflect what we'd want the user to do, which is to login with the account they initially logged in with. I added the error message below the terms and conditions, I hope that's alright, obviously it can easily be moved elsewhere. I'm not sure whether you want the SignInErrorTypes and the errors object moved to a separate location? Other than this, any additional thoughts or does this satisfy the requirements?