### PR TITLE
Add /tasks/all route to website

### DIFF
--- a/website/src/pages/tasks/all.tsx
+++ b/website/src/pages/tasks/all.tsx
@@ -1,0 +1,19 @@
+import Head from "next/head";
+import { TaskOption } from "src/components/Dashboard";
+import { getDashboardLayout } from "src/components/Layout";
+
+const AllTasks = () => {
+  return (
+    <>
+      <Head>
+        <title>All Tasks - Open Assistant</title>
+        <meta name="description" content="All tasks for Open Assistant." />
+      </Head>
+      <TaskOption />
+    </>
+  );
+};
+
+AllTasks.getLayout = (page) => getDashboardLayout(page);
+
+export default AllTasks;


### PR DESCRIPTION
Added a route for all tasks in `/tasks/all` in preperation for adding `/tasks/random`.

Did not add a link to the page anywhere.

Note: We will need to later decide how to handle the page. Should we add it to a feature flag? Give access to "advanced users" or something?

In any case, this will be useful for dev once we move over to the random tasks.