### PR TITLE
website: Ignore screenshots and videos produced by cypress e2e tests

### DIFF
--- a/website/.gitignore
+++ b/website/.gitignore
@@ -39,5 +39,7 @@ next-env.d.ts
 *.swp
 
 # cypress
+/cypress/screenshots
+/cypress/videos
 /cypress-visual-screenshots/diff
 /cypress-visual-screenshots/comparison


### PR DESCRIPTION
These files are generated by running `npm run cypress:run` and should not be checked in.