### PR TITLE
Ensure all the API routes reject banned users

### DIFF
--- a/website/src/lib/auth.ts
+++ b/website/src/lib/auth.ts
@@ -1,5 +1,20 @@
 import type { NextApiRequest, NextApiResponse } from "next";
-import { getToken } from "next-auth/jwt";
+import { getToken, JWT } from "next-auth/jwt";
+
+/**
+ * Wraps any API Route handler and verifies that the user does not have the
+ * specified role.  Returns a 403 if they do, otherwise runs the handler.
+ */
+const withoutRole = (role: string, handler: (arg0: NextApiRequest, arg1: NextApiResponse, arg2: JWT) => void) => {
+  return async (req: NextApiRequest, res: NextApiResponse) => {
+    const token = await getToken({ req });
+    if (!token || token.role === role) {
+      res.status(403).end();
+      return;
+    }
+    return handler(req, res, token);
+  };
+};
 
 /**
  * Wraps any API Route handler and verifies that the user has the appropriate
@@ -16,4 +31,4 @@ const withRole = (role: string, handler: (arg0: NextApiRequest, arg1: NextApiRes
   };
 };
 
-export default withRole;
+export { withoutRole, withRole };

--- a/website/src/pages/api/admin/update_user.ts
+++ b/website/src/pages/api/admin/update_user.ts
@@ -1,4 +1,4 @@
-import withRole from "src/lib/auth";
+import { withRole } from "src/lib/auth";
 import prisma from "src/lib/prismadb";
 
 /**

--- a/website/src/pages/api/admin/users.ts
+++ b/website/src/pages/api/admin/users.ts
@@ -1,4 +1,4 @@
-import withRole from "src/lib/auth";
+import { withRole } from "src/lib/auth";
 import prisma from "src/lib/prismadb";
 
 // The number of users to fetch in any request.

--- a/website/src/pages/api/messages/[id]/children.ts
+++ b/website/src/pages/api/messages/[id]/children.ts
@@ -1,14 +1,6 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res) => {
   const { id } = req.query;
 
   const messagesRes = await fetch(`${process.env.FASTAPI_URL}/api/v1/messages/${id}/children`, {
@@ -22,6 +14,6 @@ const handler = async (req, res) => {
 
   // Send recieved messages to the client.
   res.status(200).json(messages);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/messages/[id]/conversation.ts
+++ b/website/src/pages/api/messages/[id]/conversation.ts
@@ -1,14 +1,6 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res) => {
   const { id } = req.query;
 
   const messagesRes = await fetch(`${process.env.FASTAPI_URL}/api/v1/messages/${id}/conversation`, {
@@ -22,6 +14,6 @@ const handler = async (req, res) => {
 
   // Send recieved messages to the client.
   res.status(200).json(messages);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/messages/[id]/index.ts
+++ b/website/src/pages/api/messages/[id]/index.ts
@@ -1,14 +1,6 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res) => {
   const { id } = req.query;
 
   const messageRes = await fetch(`${process.env.FASTAPI_URL}/api/v1/messages/${id}`, {
@@ -22,6 +14,6 @@ const handler = async (req, res) => {
 
   // Send recieved messages to the client.
   res.status(200).json(message);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/messages/[id]/parent.ts
+++ b/website/src/pages/api/messages/[id]/parent.ts
@@ -1,14 +1,6 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res) => {
   const { id } = req.query;
 
   if (!id) {
@@ -43,6 +35,6 @@ const handler = async (req, res) => {
 
   // Send recieved messages to the client.
   res.status(200).json(parent);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/messages/index.ts
+++ b/website/src/pages/api/messages/index.ts
@@ -1,14 +1,6 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res) => {
   const messagesRes = await fetch(`${process.env.FASTAPI_URL}/api/v1/messages`, {
     method: "GET",
     headers: {
@@ -19,6 +11,6 @@ const handler = async (req, res) => {
 
   // Send recieved messages to the client.
   res.status(200).json(messages);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/messages/user.ts
+++ b/website/src/pages/api/messages/user.ts
@@ -1,14 +1,6 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res, token) => {
   //TODO: add params if needed
   const params = new URLSearchParams({
     username: token.sub,
@@ -24,6 +16,6 @@ const handler = async (req, res) => {
 
   // Send recieved messages to the client.
   res.status(200).json(messages);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/new_task/[task_type].ts
+++ b/website/src/pages/api/new_task/[task_type].ts
@@ -1,4 +1,4 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 import { oasstApiClient } from "src/lib/oasst_api_client";
 import prisma from "src/lib/prismadb";
 
@@ -10,19 +10,10 @@ import prisma from "src/lib/prismadb";
  * 3) Send and Ack to the Task Backend with our local id for the task.
  * 4) Return everything to the client.
  */
-const handler = async (req, res) => {
-  const { task_type } = req.query;
-
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res, token) => {
   // Fetch the new task.
-  const task = await oasstApiClient.fetchTask(task_type, token);
+  const { task_type } = req.query;
+  const task = await oasstApiClient.fetchTask(task_type as string, token);
   const valid_labels = await oasstApiClient.fetch_valid_text();
 
   // Store the task and link it to the user..
@@ -42,6 +33,6 @@ const handler = async (req, res) => {
 
   // Send the results to the client.
   res.status(200).json(registeredTask);
-};
+});
 
 export default handler;

--- a/website/src/pages/api/reject_task.ts
+++ b/website/src/pages/api/reject_task.ts
@@ -1,17 +1,9 @@
 import { Prisma } from "@prisma/client";
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 import { oasstApiClient } from "src/lib/oasst_api_client";
 import prisma from "src/lib/prismadb";
 
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res) => {
   // Parse out the local task ID and the interaction contents.
   const { id: frontendId, reason } = await JSON.parse(req.body);
 
@@ -25,6 +17,6 @@ const handler = async (req, res) => {
 
   // Send the results to the client.
   res.status(200).json({});
-};
+});
 
 export default handler;

--- a/website/src/pages/api/set_label.ts
+++ b/website/src/pages/api/set_label.ts
@@ -1,18 +1,10 @@
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 
 /**
  * Sets the Label in the Backend.
  *
  */
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res, token) => {
   // Parse out the local message_id, task ID and the interaction contents.
   const { message_id, label_map, text } = await JSON.parse(req.body);
 
@@ -35,6 +27,6 @@ const handler = async (req, res) => {
     }),
   });
   res.status(interactionRes.status).end();
-};
+});
 
 export default handler;

--- a/website/src/pages/api/update_task.ts
+++ b/website/src/pages/api/update_task.ts
@@ -1,5 +1,5 @@
 import { Prisma } from "@prisma/client";
-import { getToken } from "next-auth/jwt";
+import { withoutRole } from "src/lib/auth";
 import { oasstApiClient } from "src/lib/oasst_api_client";
 import prisma from "src/lib/prismadb";
 
@@ -13,15 +13,7 @@ import prisma from "src/lib/prismadb";
  * 4) Records the new task in our local database.
  * 5) Returns the newly created task to the client.
  */
-const handler = async (req, res) => {
-  const token = await getToken({ req });
-
-  // Return nothing if the user isn't registered.
-  if (!token) {
-    res.status(401).end();
-    return;
-  }
-
+const handler = withoutRole("banned", async (req, res, token) => {
   // Parse out the local task ID and the interaction contents.
   const { id: frontendId, content, update_type } = await JSON.parse(req.body);
 
@@ -65,6 +57,6 @@ const handler = async (req, res) => {
 
   // Send the next task in the sequence to the client.
   res.status(200).json(newRegisteredTask);
-};
+});
 
 export default handler;


### PR DESCRIPTION
Closes #589 

This creates a new API wrapper `withoutRole` that sends a 403 whenever a user has no token or has a specified role.  We wrap all the API routes except the already wrapped admin routes with this new wrapper and ensure that banned users can't fetch tasks or do anything meaningful.

`username` is left unchanged for now.