### PR TITLE
Add note on Python version to backend README.md

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -7,6 +7,9 @@ In root directory, run
 database. The default settings are already configured to connect to the database
 at `localhost:5432`.
 
+Python 3.10 is required. It is recommended to use `pyenv` which will recognise
+the `.python-version` in the project root directory.
+
 Make sure you have all requirements installed. You can do this by running
 `pip install -r requirements.txt` inside the `backend` folder and
 `pip install -e .` inside the `oasst-shared` folder. Then, run the backend using


### PR DESCRIPTION
We have had a couple of GitHub issues created by people reporting issues with running the backend which seem to be a result of running with Python versions older than 3.10. This PR modifies the backend README.md to explicitly state the Python 3.10 requirement to hopefully avoid anyone else running into this issue.