### PR TITLE
Update the web to match the backends new API

### DIFF
--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -25,4 +25,5 @@ jobs:
           cache: "npm"
           cache-dependency-path: website/package-lock.json
       - run: npm ci
+      - run: npx prisma generate
       - run: npm run build

--- a/.github/workflows/build-frontend.yaml
+++ b/.github/workflows/build-frontend.yaml
@@ -25,5 +25,4 @@ jobs:
           cache: "npm"
           cache-dependency-path: website/package-lock.json
       - run: npm ci
-      - run: npx prisma generate
       - run: npm run build

--- a/website/cypress/contract/oasst_api_contract_tests.cy.ts
+++ b/website/cypress/contract/oasst_api_contract_tests.cy.ts
@@ -33,6 +33,7 @@ describe("Contract test for Oasst API", function () {
       await oasstApiClient.interactTask(
         "text_reply_to_message",
         task.id,
+        "321",
         "1",
         { text: "Test" },
         {

--- a/website/src/components/Tasks/LabelTask.tsx
+++ b/website/src/components/Tasks/LabelTask.tsx
@@ -13,9 +13,8 @@ export const LabelTask = ({
   taskType,
   onReplyChanged,
 }: TaskSurveyProps<{ text: string; labels: { [k: string]: number }; message_id: string }>) => {
-  const [sliderValues, setSliderValues] = useState<number[]>([]);
-
   const valid_labels = task.valid_labels;
+  const [sliderValues, setSliderValues] = useState<number[]>(new Array(valid_labels.length).fill(0));
 
   useEffect(() => {
     onReplyChanged({ content: { labels: {}, text: task.reply, message_id: task.message_id }, state: "DEFAULT" });

--- a/website/src/lib/oasst_api_client.ts
+++ b/website/src/lib/oasst_api_client.ts
@@ -1,10 +1,5 @@
 import { JWT } from "next-auth/jwt";
 
-declare global {
-  // eslint-disable-next-line no-var
-  var oasstApiClient: OasstApiClient | undefined;
-}
-
 export class OasstError {
   message: string;
   errorCode: number;
@@ -106,6 +101,7 @@ export class OasstApiClient {
   // This is a raw Json type, so we can't use it to strongly type the task.
   async interactTask(
     updateType: string,
+    taskId: string,
     messageId: string,
     userMessageId: string,
     content: object,
@@ -118,6 +114,7 @@ export class OasstApiClient {
         display_name: userToken.name || userToken.email,
         auth_method: "local",
       },
+      task_id: taskId,
       message_id: messageId,
       user_message_id: userMessageId,
       ...content,
@@ -131,8 +128,6 @@ export class OasstApiClient {
   }
 }
 
-export const oasstApiClient =
-  globalThis.oasstApiClient || new OasstApiClient(process.env.FASTAPI_URL, process.env.FASTAPI_KEY);
-if (process.env.NODE_ENV !== "production") {
-  globalThis.oasstApiClient = oasstApiClient;
-}
+const oasstApiClient = new OasstApiClient(process.env.FASTAPI_URL, process.env.FASTAPI_KEY);
+
+export { oasstApiClient };

--- a/website/src/pages/api/update_task.ts
+++ b/website/src/pages/api/update_task.ts
@@ -20,8 +20,8 @@ const handler = withoutRole("banned", async (req, res, token) => {
   // Accept the task so that we can complete it, this will probably go away soon.
   const registeredTask = await prisma.registeredTask.findUniqueOrThrow({ where: { id: frontendId } });
   const task = registeredTask.task as Prisma.JsonObject;
-  const id = task.id as string;
-  await oasstApiClient.ackTask(id, registeredTask.id);
+  const taskId = task.id as string;
+  await oasstApiClient.ackTask(taskId, registeredTask.id);
 
   // Log the interaction locally to create our user_post_id needed by the Task
   // Backend.
@@ -38,8 +38,9 @@ const handler = withoutRole("banned", async (req, res, token) => {
 
   let newTask;
   try {
-    newTask = await oasstApiClient.interactTask(update_type, frontendId, interaction.id, content, token);
+    newTask = await oasstApiClient.interactTask(update_type, taskId, frontendId, interaction.id, content, token);
   } catch (err) {
+    console.error(JSON.stringify(err));
     return res.status(500).json(err);
   }
 

--- a/website/src/pages/tasks/random.tsx
+++ b/website/src/pages/tasks/random.tsx
@@ -9,16 +9,16 @@ const RandomTask = () => {
   const { tasks, isLoading, trigger, reset } = useGenericTaskAPI("random");
 
   useEffect(() => {
-    if (tasks.length == 0) {
+    if (tasks.length === 0) {
       reset();
     }
-  }, [tasks]);
+  }, [tasks, reset]);
 
   if (isLoading) {
     return <LoadingScreen text="Loading..." />;
   }
 
-  if (tasks.length == 0) {
+  if (tasks.length === 0) {
     return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
   }
 

--- a/website/src/pages/tasks/random.tsx
+++ b/website/src/pages/tasks/random.tsx
@@ -1,18 +1,11 @@
 import { Container } from "@chakra-ui/react";
 import Head from "next/head";
-import { useEffect } from "react";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useGenericTaskAPI } from "src/hooks/tasks/useGenericTaskAPI";
 
 const RandomTask = () => {
   const { tasks, isLoading, trigger, reset } = useGenericTaskAPI("random");
-
-  useEffect(() => {
-    if (tasks.length === 0) {
-      reset();
-    }
-  }, [tasks, reset]);
 
   if (isLoading) {
     return <LoadingScreen text="Loading..." />;


### PR DESCRIPTION
Closes #616 

The backend now expects a `task_id` field when calling `/api/v1/interaction` which matches the backend's task ID.  The backend currently only requires this for labeling tasks but soon will require it for all tasks.  This forwards that for all interaction types.

Also, this fixes the labeling tasks by ensuring that `sliderValues` is always set properly.