### PR TITLE
Add empty state & tweak loading screen

### DIFF
--- a/website/src/components/EmptyState.tsx
+++ b/website/src/components/EmptyState.tsx
@@ -1,0 +1,32 @@
+import { Center, Text, useColorMode, useColorModeValue } from "@chakra-ui/react";
+import { FiFileText } from "react-icons/fi";
+import { IconType } from "react-icons/lib";
+
+type EmptyStateProps = {
+  text: string;
+  icon: IconType;
+};
+
+export const EmptyState = (props: EmptyStateProps) => {
+  const { colorMode } = useColorMode();
+  const mainBgClasses = colorMode === "light" ? "bg-slate-300 text-gray-900" : "bg-slate-900 text-white";
+
+  const widgetClasses = useColorModeValue("border-gray-700 text-gray-700", "border-gray-300 text-gray-300");
+
+  return (
+    <div className={`p-12 ${mainBgClasses}`}>
+      <Center>
+        <div className={`block border-2 border-dotted rounded-lg p-24 text-center ${widgetClasses}`}>
+          <props.icon className="mx-auto h-16 w-16" />
+          <Text fontFamily="inter" fontSize="2xl">
+            {props.text}
+          </Text>
+        </div>
+      </Center>
+    </div>
+  );
+};
+
+export const TaskEmptyState = () => {
+  return <EmptyState text="No tasks found!" icon={FiFileText} />;
+};

--- a/website/src/components/Loading/LoadingScreen.jsx
+++ b/website/src/components/Loading/LoadingScreen.jsx
@@ -1,13 +1,15 @@
-import { Box, Progress, Text } from "@chakra-ui/react";
+import { Box, Center, Progress, Text, useColorModeValue } from "@chakra-ui/react";
 
 export const LoadingScreen = ({ text = "Loading..." } = {}) => {
+  const mainBgClasses = useColorModeValue("bg-slate-300 text-gray-900", "bg-slate-900 text-white");
+
   return (
-    <Box width="full">
+    <Box width="full" className={mainBgClasses}>
       <Progress size="sm" isIndeterminate />
       {text && (
-        <Box width="full">
+        <Center width="full" className="p-12">
           <Text fontFamily="Inter">{text}</Text>
-        </Box>
+        </Center>
       )}
     </Box>
   );

--- a/website/src/pages/create/assistant_reply.tsx
+++ b/website/src/pages/create/assistant_reply.tsx
@@ -1,5 +1,5 @@
-import { Container } from "@chakra-ui/react";
 import Head from "next/head";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useCreateAssistantReply } from "src/hooks/tasks/useCreateReply";
@@ -12,7 +12,7 @@ const AssistantReply = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/create/initial_prompt.tsx
+++ b/website/src/pages/create/initial_prompt.tsx
@@ -1,5 +1,5 @@
-import { Container } from "@chakra-ui/react";
 import Head from "next/head";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useCreateInitialPrompt } from "src/hooks/tasks/useCreateReply";
@@ -12,7 +12,7 @@ const InitialPrompt = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/create/user_reply.tsx
+++ b/website/src/pages/create/user_reply.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Container } from "src/components/Container";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useCreatePrompterReply } from "src/hooks/tasks/useCreateReply";
@@ -12,7 +12,7 @@ const UserReply = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/evaluate/rank_assistant_replies.tsx
+++ b/website/src/pages/evaluate/rank_assistant_replies.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Container } from "src/components/Container";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useRankAssistantRepliesTask } from "src/hooks/tasks/useRankReplies";
@@ -12,7 +12,7 @@ const RankAssistantReplies = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/evaluate/rank_initial_prompts.tsx
+++ b/website/src/pages/evaluate/rank_initial_prompts.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Container } from "src/components/Container";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useRankInitialPromptsTask } from "src/hooks/tasks/useRankReplies";
@@ -12,7 +12,7 @@ const RankInitialPrompts = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/evaluate/rank_user_replies.tsx
+++ b/website/src/pages/evaluate/rank_user_replies.tsx
@@ -1,5 +1,5 @@
 import Head from "next/head";
-import { Container } from "src/components/Container";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useRankPrompterRepliesTask } from "src/hooks/tasks/useRankReplies";
@@ -12,7 +12,7 @@ const RankUserReplies = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/label/label_assistant_reply.tsx
+++ b/website/src/pages/label/label_assistant_reply.tsx
@@ -1,5 +1,5 @@
-import { Container } from "@chakra-ui/react";
 import Head from "next/head";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useLabelAssistantReplyTask } from "src/hooks/tasks/useLabelingTask";
@@ -12,7 +12,7 @@ const LabelAssistantReply = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/label/label_initial_prompt.tsx
+++ b/website/src/pages/label/label_initial_prompt.tsx
@@ -1,5 +1,5 @@
-import { Container } from "@chakra-ui/react";
 import Head from "next/head";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useLabelInitialPromptTask } from "src/hooks/tasks/useLabelingTask";
@@ -12,7 +12,7 @@ const LabelInitialPrompt = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/label/label_prompter_reply.tsx
+++ b/website/src/pages/label/label_prompter_reply.tsx
@@ -1,5 +1,5 @@
-import { Container } from "@chakra-ui/react";
 import Head from "next/head";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useLabelPrompterReplyTask } from "src/hooks/tasks/useLabelingTask";
@@ -12,7 +12,7 @@ const LabelPrompterReply = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (

--- a/website/src/pages/tasks/random.tsx
+++ b/website/src/pages/tasks/random.tsx
@@ -1,5 +1,5 @@
-import { Container } from "@chakra-ui/react";
 import Head from "next/head";
+import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { useGenericTaskAPI } from "src/hooks/tasks/useGenericTaskAPI";
@@ -12,7 +12,7 @@ const RandomTask = () => {
   }
 
   if (tasks.length === 0) {
-    return <Container className="p-6 text-center text-gray-800">No tasks found...</Container>;
+    return <TaskEmptyState />;
   }
 
   return (


### PR DESCRIPTION
### Empty State
Added `EmptyState` component which accepts `text` & `icon` props.
Updated task pages use new `TaskEmptyState`.
`TaskEmptyState` Demo:
**Light**
![light](https://user-images.githubusercontent.com/30481105/211914474-276330a4-0c43-4b1a-aa48-cc8e97691658.png)
**Dark**
![dark](https://user-images.githubusercontent.com/30481105/211914504-2b397867-2e55-4a9f-ae8e-ec72a691700d.png)
### Loading Screen
Tweaked `LoadingScreen` component to use color-mode specific styling.
`LoadingScreen` Demo:
**Light**
![light](https://user-images.githubusercontent.com/30481105/211914823-41cf8abf-00df-4929-ba85-af2af9d83d09.png)
**Dark**
![dark](https://user-images.githubusercontent.com/30481105/211914660-8f4bfcda-d4ca-4ba3-b83c-5fce6e2a7527.png)
