### PR TITLE
#668 - Add simple label

### DIFF
--- a/website/cypress/e2e/tasks/random.cy.ts
+++ b/website/cypress/e2e/tasks/random.cy.ts
@@ -44,12 +44,44 @@ describe("handles random tasks", () => {
                 break;
               }
               case "label-task": {
-                // Clicking on the slider will set the value to about the middle where it clicks
-                cy.get('[aria-roledescription="slider"]').first().click();
+                cy.get('[data-cy="label-group-item"]')
+                  .first()
+                  .invoke("attr", "data-label-type")
+                  .then((label_type) => {
+                    const parent = cy
+                      .get('[data-cy="label-group-item"]')
+                      .first();
+                    cy.log("Label type", label_type);
 
-                cy.get('[data-cy="review"]').click();
+                    switch (label_type) {
+                      case "slider": {
+                        // Clicking on the slider will set the value to about the middle where it clicks
+                        parent
+                          .get('[aria-roledescription="slider"]')
+                          .first()
+                          .click();
 
-                cy.get('[data-cy="submit"]').click();
+                        cy.get('[data-cy="review"]').click();
+
+                        cy.get('[data-cy="submit"]').click();
+
+                        break;
+                      }
+                      case "radio": {
+                        // Clicking on the slider will set the value to about the middle where it clicks
+                        parent
+                          .get('[aria-roledescription="radio-button"]')
+                          .last()
+                          .click();
+
+                        cy.get('[data-cy="review"]').click();
+
+                        cy.get('[data-cy="submit"]').click();
+
+                        break;
+                      }
+                    }
+                  });
 
                 break;
               }

--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -10,6 +10,7 @@ interface LabelRadioGroupProps {
 
 export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
   const [labelValues, setLabelValues] = useState<number[]>(Array.from({ length: props.labelIDs.length }).map(() => 0));
+  const [interactionFlag, setInteractionFlag] = useState(false);
 
   return (
     <Flex direction="column" justify="center">
@@ -23,12 +24,14 @@ export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
             newState[idx] = newValue;
             props.onChange(labelValues);
             setLabelValues(newState);
+            if (!interactionFlag) setInteractionFlag(true);
           }}
           states={[
             { text: "No", value: 0 },
             { text: "Yes", value: 1 },
           ]}
           isDisabled={props.isDisabled}
+          interactionFlag={interactionFlag}
         />
       ))}
     </Flex>
@@ -47,6 +50,7 @@ interface LabelRadioItemProps {
   clickHandler: (newVal: number) => unknown;
   states: ButtonState[];
   isDisabled: boolean;
+  interactionFlag: boolean;
 }
 
 const LabelRadioItem = (props: LabelRadioItemProps) => {
@@ -64,7 +68,7 @@ const LabelRadioItem = (props: LabelRadioItemProps) => {
       <Flex direction="row" gap={6} justify="center">
         {props.states.map((item, idx) => (
           <Button
-            colorScheme={item.value === props.labelValue ? item.colorScheme || "blue" : "gray"}
+            colorScheme={item.value === props.labelValue && props.interactionFlag ? item.colorScheme || "blue" : "gray"}
             isDisabled={props.isDisabled}
             size="lg"
             key={idx}

--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -5,7 +5,7 @@ import { colors } from "src/styles/Theme/colors";
 interface LabelRadioGroupProps {
   labelIDs: Array<string>;
   onChange: (sliderValues: number[]) => unknown;
-  isDisabled?: boolean;
+  isEditable?: boolean;
 }
 
 export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
@@ -30,7 +30,7 @@ export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
             { text: "No", value: 0 },
             { text: "Yes", value: 1 },
           ]}
-          isDisabled={props.isDisabled}
+          isEditable={props.isEditable}
           interactionFlag={interactionFlag}
         />
       ))}
@@ -49,7 +49,7 @@ interface LabelRadioItemProps {
   labelValue: number;
   clickHandler: (newVal: number) => unknown;
   states: ButtonState[];
-  isDisabled: boolean;
+  isEditable: boolean;
   interactionFlag: boolean;
 }
 
@@ -69,7 +69,7 @@ const LabelRadioItem = (props: LabelRadioItemProps) => {
         {props.states.map((item, idx) => (
           <Button
             colorScheme={item.value === props.labelValue && props.interactionFlag ? item.colorScheme || "blue" : "gray"}
-            isDisabled={props.isDisabled}
+            isDisabled={!props.isEditable}
             size="lg"
             key={idx}
             onClick={() => props.clickHandler(item.value)}

--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -2,19 +2,19 @@ import { Box, Button, Flex, useColorMode } from "@chakra-ui/react";
 import { useId, useState } from "react";
 import { colors } from "src/styles/Theme/colors";
 
-interface LabelSimpleGroupProps {
+interface LabelRadioGroupProps {
   labelIDs: Array<string>;
   onChange: (sliderValues: number[]) => unknown;
   isDisabled?: boolean;
 }
 
-export const LabelSimpleGroup = (props: LabelSimpleGroupProps) => {
+export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
   const [labelValues, setLabelValues] = useState<number[]>(Array.from({ length: props.labelIDs.length }).map(() => 0));
 
   return (
     <Flex direction="column" justify="center">
       {props.labelIDs.map((labelId, idx) => (
-        <LabelSimpleItem
+        <LabelRadioItem
           key={idx}
           labelId={labelId}
           labelValue={labelValues[idx]}
@@ -25,8 +25,8 @@ export const LabelSimpleGroup = (props: LabelSimpleGroupProps) => {
             setLabelValues(newState);
           }}
           states={[
-            { text: "No", value: 0, colorScheme: "green" },
-            { text: "Yes", value: 1, colorScheme: "red" },
+            { text: "No", value: 0, colorScheme: "blue" },
+            { text: "Yes", value: 1, colorScheme: "blue" },
           ]}
           isDisabled={props.isDisabled}
         />
@@ -41,7 +41,7 @@ interface ButtonState {
   colorScheme: string;
 }
 
-interface LabelSimpleItemProps {
+interface LabelRadioItemProps {
   labelId: string;
   labelValue: number;
   clickHandler: (newVal: number) => unknown;
@@ -49,7 +49,7 @@ interface LabelSimpleItemProps {
   isDisabled: boolean;
 }
 
-const LabelSimpleItem = (props: LabelSimpleItemProps) => {
+const LabelRadioItem = (props: LabelRadioItemProps) => {
   const id = useId();
   const { colorMode } = useColorMode();
 

--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -25,8 +25,8 @@ export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
             setLabelValues(newState);
           }}
           states={[
-            { text: "No", value: 0, colorScheme: "blue" },
-            { text: "Yes", value: 1, colorScheme: "blue" },
+            { text: "No", value: 0 },
+            { text: "Yes", value: 1 },
           ]}
           isDisabled={props.isDisabled}
         />
@@ -38,7 +38,7 @@ export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
 interface ButtonState {
   text: string;
   value: number;
-  colorScheme: string;
+  colorScheme?: string;
 }
 
 interface LabelRadioItemProps {
@@ -64,7 +64,7 @@ const LabelRadioItem = (props: LabelRadioItemProps) => {
       <Flex direction="row" gap={6} justify="center">
         {props.states.map((item, idx) => (
           <Button
-            colorScheme={item.value === props.labelValue ? item.colorScheme : "gray"}
+            colorScheme={item.value === props.labelValue ? item.colorScheme || "blue" : "gray"}
             isDisabled={props.isDisabled}
             size="lg"
             key={idx}

--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -60,7 +60,7 @@ const LabelRadioItem = (props: LabelRadioItemProps) => {
   const labelTextClass = colorMode === "light" ? `text-${colors.light.text}` : `text-${colors.dark.text}`;
 
   return (
-    <Box>
+    <Box data-cy="label-group-item" data-label-type="radio">
       <label className="text-sm" htmlFor={id}>
         {/* TODO: display real text instead of just the id */}
         <span className={labelTextClass}>{props.labelId}</span>
@@ -68,6 +68,7 @@ const LabelRadioItem = (props: LabelRadioItemProps) => {
       <Flex direction="row" gap={6} justify="center">
         {props.states.map((item, idx) => (
           <Button
+            aria-roledescription="radio-button"
             colorScheme={item.value === props.labelValue && props.interactionFlag ? item.colorScheme || "blue" : "gray"}
             isDisabled={!props.isEditable}
             size="lg"

--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -22,7 +22,7 @@ export const LabelRadioGroup = (props: LabelRadioGroupProps) => {
           clickHandler={(newValue) => {
             const newState = labelValues.slice();
             newState[idx] = newValue;
-            props.onChange(labelValues);
+            props.onChange(newState);
             setLabelValues(newState);
             if (!interactionFlag) setInteractionFlag(true);
           }}

--- a/website/src/components/Survey/LabelSimpleGroup.tsx
+++ b/website/src/components/Survey/LabelSimpleGroup.tsx
@@ -25,8 +25,8 @@ export const LabelSimpleGroup = (props: LabelSimpleGroupProps) => {
             setLabelValues(newState);
           }}
           states={[
-            { text: "No", value: 0 },
-            { text: "Yes", value: 1 },
+            { text: "No", value: 0, colorScheme: "green" },
+            { text: "Yes", value: 1, colorScheme: "red" },
           ]}
           isDisabled={props.isDisabled}
         />
@@ -38,6 +38,7 @@ export const LabelSimpleGroup = (props: LabelSimpleGroupProps) => {
 interface ButtonState {
   text: string;
   value: number;
+  colorScheme: string;
 }
 
 interface LabelSimpleItemProps {
@@ -63,7 +64,7 @@ const LabelSimpleItem = (props: LabelSimpleItemProps) => {
       <Flex direction="row" gap={6} justify="center">
         {props.states.map((item, idx) => (
           <Button
-            colorScheme={item.value === props.labelValue ? "green" : "gray"}
+            colorScheme={item.value === props.labelValue ? item.colorScheme : "gray"}
             isDisabled={props.isDisabled}
             size="lg"
             key={idx}

--- a/website/src/components/Survey/LabelSimpleGroup.tsx
+++ b/website/src/components/Survey/LabelSimpleGroup.tsx
@@ -1,0 +1,78 @@
+import { Box, Button, Flex, useColorMode } from "@chakra-ui/react";
+import { useId, useState } from "react";
+import { colors } from "src/styles/Theme/colors";
+
+interface LabelSimpleGroupProps {
+  labelIDs: Array<string>;
+  onChange: (sliderValues: number[]) => unknown;
+  isDisabled?: boolean;
+}
+
+export const LabelSimpleGroup = (props: LabelSimpleGroupProps) => {
+  const [labelValues, setLabelValues] = useState<number[]>(Array.from({ length: props.labelIDs.length }).map(() => 0));
+
+  return (
+    <Flex direction="column" justify="center">
+      {props.labelIDs.map((labelId, idx) => (
+        <LabelSimpleItem
+          key={idx}
+          labelId={labelId}
+          labelValue={labelValues[idx]}
+          clickHandler={(newValue) => {
+            const newState = labelValues.slice();
+            newState[idx] = newValue;
+            props.onChange(labelValues);
+            setLabelValues(newState);
+          }}
+          states={[
+            { text: "No", value: 0 },
+            { text: "Yes", value: 1 },
+          ]}
+          isDisabled={props.isDisabled}
+        />
+      ))}
+    </Flex>
+  );
+};
+
+interface ButtonState {
+  text: string;
+  value: number;
+}
+
+interface LabelSimpleItemProps {
+  labelId: string;
+  labelValue: number;
+  clickHandler: (newVal: number) => unknown;
+  states: ButtonState[];
+  isDisabled: boolean;
+}
+
+const LabelSimpleItem = (props: LabelSimpleItemProps) => {
+  const id = useId();
+  const { colorMode } = useColorMode();
+
+  const labelTextClass = colorMode === "light" ? `text-${colors.light.text}` : `text-${colors.dark.text}`;
+
+  return (
+    <Box>
+      <label className="text-sm" htmlFor={id}>
+        {/* TODO: display real text instead of just the id */}
+        <span className={labelTextClass}>{props.labelId}</span>
+      </label>
+      <Flex direction="row" gap={6} justify="center">
+        {props.states.map((item, idx) => (
+          <Button
+            colorScheme={item.value === props.labelValue ? "green" : "gray"}
+            isDisabled={props.isDisabled}
+            size="lg"
+            key={idx}
+            onClick={() => props.clickHandler(item.value)}
+          >
+            {item.text}
+          </Button>
+        ))}
+      </Flex>
+    </Box>
+  );
+};

--- a/website/src/components/Survey/LabelSliderGroup.tsx
+++ b/website/src/components/Survey/LabelSliderGroup.tsx
@@ -6,10 +6,10 @@ import { colors } from "styles/Theme/colors";
 interface LabelSliderGroupProps {
   labelIDs: Array<string>;
   onChange: (sliderValues: number[]) => unknown;
-  isDisabled?: boolean;
+  isEditable?: boolean;
 }
 
-export const LabelSliderGroup = ({ labelIDs, onChange, isDisabled }: LabelSliderGroupProps) => {
+export const LabelSliderGroup = ({ labelIDs, onChange, isEditable }: LabelSliderGroupProps) => {
   const [sliderValues, setSliderValues] = useState<number[]>(Array.from({ length: labelIDs.length }).map(() => 0));
 
   return (
@@ -25,7 +25,7 @@ export const LabelSliderGroup = ({ labelIDs, onChange, isDisabled }: LabelSlider
             onChange(sliderValues);
             setSliderValues(newState);
           }}
-          isDisabled={isDisabled}
+          isEditable={isEditable}
         />
       ))}
     </Grid>
@@ -36,7 +36,7 @@ function CheckboxSliderItem(props: {
   labelId: string;
   sliderValue: number;
   sliderHandler: (newVal: number) => unknown;
-  isDisabled: boolean;
+  isEditable: boolean;
 }) {
   const id = useId();
   const { colorMode } = useColorMode();
@@ -49,7 +49,7 @@ function CheckboxSliderItem(props: {
         {/* TODO: display real text instead of just the id */}
         <span className={labelTextClass}>{props.labelId}</span>
       </label>
-      <Slider defaultValue={0} isDisabled={props.isDisabled} onChangeEnd={(val) => props.sliderHandler(val / 100)}>
+      <Slider defaultValue={0} isDisabled={!props.isEditable} onChangeEnd={(val) => props.sliderHandler(val / 100)}>
         <SliderTrack>
           <SliderFilledTrack />
           <SliderThumb />

--- a/website/src/components/Survey/LabelSliderGroup.tsx
+++ b/website/src/components/Survey/LabelSliderGroup.tsx
@@ -1,0 +1,60 @@
+import { Grid, Slider, SliderFilledTrack, SliderThumb, SliderTrack, useColorMode } from "@chakra-ui/react";
+import { useId, useState } from "react";
+import { colors } from "styles/Theme/colors";
+
+// TODO: consolidate with FlaggableElement
+interface LabelSliderGroupProps {
+  labelIDs: Array<string>;
+  onChange: (sliderValues: number[]) => unknown;
+  isDisabled?: boolean;
+}
+
+export const LabelSliderGroup = ({ labelIDs, onChange, isDisabled }: LabelSliderGroupProps) => {
+  const [sliderValues, setSliderValues] = useState<number[]>(Array.from({ length: labelIDs.length }).map(() => 0));
+
+  return (
+    <Grid templateColumns="auto 1fr" rowGap={1} columnGap={3}>
+      {labelIDs.map((labelId, idx) => (
+        <CheckboxSliderItem
+          key={idx}
+          labelId={labelId}
+          sliderValue={sliderValues[idx]}
+          sliderHandler={(sliderValue) => {
+            const newState = sliderValues.slice();
+            newState[idx] = sliderValue;
+            onChange(sliderValues);
+            setSliderValues(newState);
+          }}
+          isDisabled={isDisabled}
+        />
+      ))}
+    </Grid>
+  );
+};
+
+function CheckboxSliderItem(props: {
+  labelId: string;
+  sliderValue: number;
+  sliderHandler: (newVal: number) => unknown;
+  isDisabled: boolean;
+}) {
+  const id = useId();
+  const { colorMode } = useColorMode();
+
+  const labelTextClass = colorMode === "light" ? `text-${colors.light.text}` : `text-${colors.dark.text}`;
+
+  return (
+    <>
+      <label className="text-sm" htmlFor={id}>
+        {/* TODO: display real text instead of just the id */}
+        <span className={labelTextClass}>{props.labelId}</span>
+      </label>
+      <Slider defaultValue={0} isDisabled={props.isDisabled} onChangeEnd={(val) => props.sliderHandler(val / 100)}>
+        <SliderTrack>
+          <SliderFilledTrack />
+          <SliderThumb />
+        </SliderTrack>
+      </Slider>
+    </>
+  );
+}

--- a/website/src/components/Survey/LabelSliderGroup.tsx
+++ b/website/src/components/Survey/LabelSliderGroup.tsx
@@ -1,4 +1,4 @@
-import { Grid, Slider, SliderFilledTrack, SliderThumb, SliderTrack, useColorMode } from "@chakra-ui/react";
+import { Box, Grid, Slider, SliderFilledTrack, SliderThumb, SliderTrack, useColorMode } from "@chakra-ui/react";
 import { useId, useState } from "react";
 import { colors } from "styles/Theme/colors";
 
@@ -44,7 +44,7 @@ function CheckboxSliderItem(props: {
   const labelTextClass = colorMode === "light" ? `text-${colors.light.text}` : `text-${colors.dark.text}`;
 
   return (
-    <>
+    <Box data-cy="label-group-item" data-label-type="slider">
       <label className="text-sm" htmlFor={id}>
         {/* TODO: display real text instead of just the id */}
         <span className={labelTextClass}>{props.labelId}</span>
@@ -60,6 +60,6 @@ function CheckboxSliderItem(props: {
           <SliderThumb />
         </SliderTrack>
       </Slider>
-    </>
+    </Box>
   );
 }

--- a/website/src/components/Survey/LabelSliderGroup.tsx
+++ b/website/src/components/Survey/LabelSliderGroup.tsx
@@ -22,7 +22,7 @@ export const LabelSliderGroup = ({ labelIDs, onChange, isEditable }: LabelSlider
           sliderHandler={(sliderValue) => {
             const newState = sliderValues.slice();
             newState[idx] = sliderValue;
-            onChange(sliderValues);
+            onChange(newState);
             setSliderValues(newState);
           }}
           isEditable={isEditable}
@@ -49,7 +49,12 @@ function CheckboxSliderItem(props: {
         {/* TODO: display real text instead of just the id */}
         <span className={labelTextClass}>{props.labelId}</span>
       </label>
-      <Slider defaultValue={0} isDisabled={!props.isEditable} onChangeEnd={(val) => props.sliderHandler(val / 100)}>
+      <Slider
+        aria-roledescription="slider"
+        defaultValue={0}
+        isDisabled={!props.isEditable}
+        onChangeEnd={(val) => props.sliderHandler(val / 100)}
+      >
         <SliderTrack>
           <SliderFilledTrack />
           <SliderThumb />

--- a/website/src/components/Tasks/LabelTask.tsx
+++ b/website/src/components/Tasks/LabelTask.tsx
@@ -7,7 +7,7 @@ import { TwoColumnsWithCards } from "src/components/Survey/TwoColumnsWithCards";
 import { TaskSurveyProps } from "src/components/Tasks/Task";
 import { TaskType } from "src/types/Task";
 import { LabelSliderGroup } from "src/components/Survey/LabelSliderGroup";
-import { LabelSimpleGroup } from "src/components/Survey/LabelSimpleGroup";
+import { LabelRadioGroup } from "src/components/Survey/LabelRadioGroup";
 
 export const LabelTask = ({
   task,
@@ -67,7 +67,7 @@ export const LabelTask = ({
           )}
         </>
         {valid_labels.length === 1 ? (
-          <LabelSimpleGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
+          <LabelRadioGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
         ) : (
           <LabelSliderGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
         )}

--- a/website/src/components/Tasks/LabelTask.tsx
+++ b/website/src/components/Tasks/LabelTask.tsx
@@ -67,9 +67,9 @@ export const LabelTask = ({
           )}
         </>
         {valid_labels.length === 1 ? (
-          <LabelRadioGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
+          <LabelRadioGroup labelIDs={task.valid_labels} isEditable={isEditable} onChange={onSliderChange} />
         ) : (
-          <LabelSliderGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
+          <LabelSliderGroup labelIDs={task.valid_labels} isEditable={isEditable} onChange={onSliderChange} />
         )}
       </TwoColumnsWithCards>
     </div>

--- a/website/src/components/Tasks/LabelTask.tsx
+++ b/website/src/components/Tasks/LabelTask.tsx
@@ -7,6 +7,7 @@ import { TwoColumnsWithCards } from "src/components/Survey/TwoColumnsWithCards";
 import { TaskSurveyProps } from "src/components/Tasks/Task";
 import { TaskType } from "src/types/Task";
 import { LabelSliderGroup } from "src/components/Survey/LabelSliderGroup";
+import { LabelSimpleGroup } from "src/components/Survey/LabelSimpleGroup";
 
 export const LabelTask = ({
   task,
@@ -65,7 +66,11 @@ export const LabelTask = ({
             </Box>
           )}
         </>
-        <LabelSliderGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
+        {valid_labels.length === 1 ? (
+          <LabelSimpleGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
+        ) : (
+          <LabelSliderGroup labelIDs={task.valid_labels} isDisabled={isDisabled} onChange={onSliderChange} />
+        )}
       </TwoColumnsWithCards>
     </div>
   );

--- a/website/src/components/Tasks/LabelTask.tsx
+++ b/website/src/components/Tasks/LabelTask.tsx
@@ -1,12 +1,12 @@
-import { Box, Grid, Slider, SliderFilledTrack, SliderThumb, SliderTrack } from "@chakra-ui/react";
-import { Text, useColorMode, useColorModeValue } from "@chakra-ui/react";
-import { useEffect, useId, useState } from "react";
+import { Box } from "@chakra-ui/react";
+import { Text, useColorModeValue } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
 import { MessageView } from "src/components/Messages";
 import { MessageTable } from "src/components/Messages/MessageTable";
 import { TwoColumnsWithCards } from "src/components/Survey/TwoColumnsWithCards";
 import { TaskSurveyProps } from "src/components/Tasks/Task";
 import { TaskType } from "src/types/Task";
-import { colors } from "styles/Theme/colors";
+import { LabelSliderGroup } from "src/components/Survey/LabelSliderGroup";
 
 export const LabelTask = ({
   task,
@@ -70,60 +70,3 @@ export const LabelTask = ({
     </div>
   );
 };
-
-// TODO: consolidate with FlaggableElement
-interface LabelSliderGroupProps {
-  labelIDs: Array<string>;
-  onChange: (sliderValues: number[]) => unknown;
-  isDisabled?: boolean;
-}
-
-export const LabelSliderGroup = ({ labelIDs, onChange, isDisabled }: LabelSliderGroupProps) => {
-  const [sliderValues, setSliderValues] = useState<number[]>(Array.from({ length: labelIDs.length }).map(() => 0));
-
-  return (
-    <Grid templateColumns="auto 1fr" rowGap={1} columnGap={3}>
-      {labelIDs.map((labelId, idx) => (
-        <CheckboxSliderItem
-          key={idx}
-          labelId={labelId}
-          sliderValue={sliderValues[idx]}
-          sliderHandler={(sliderValue) => {
-            const newState = sliderValues.slice();
-            newState[idx] = sliderValue;
-            onChange(sliderValues);
-            setSliderValues(newState);
-          }}
-          isDisabled={isDisabled}
-        />
-      ))}
-    </Grid>
-  );
-};
-
-function CheckboxSliderItem(props: {
-  labelId: string;
-  sliderValue: number;
-  sliderHandler: (newVal: number) => unknown;
-  isDisabled: boolean;
-}) {
-  const id = useId();
-  const { colorMode } = useColorMode();
-
-  const labelTextClass = colorMode === "light" ? `text-${colors.light.text}` : `text-${colors.dark.text}`;
-
-  return (
-    <>
-      <label className="text-sm" htmlFor={id}>
-        {/* TODO: display real text instead of just the id */}
-        <span className={labelTextClass}>{props.labelId}</span>
-      </label>
-      <Slider defaultValue={0} isDisabled={props.isDisabled} onChangeEnd={(val) => props.sliderHandler(val / 100)}>
-        <SliderTrack>
-          <SliderFilledTrack />
-          <SliderThumb />
-        </SliderTrack>
-      </Slider>
-    </>
-  );
-}


### PR DESCRIPTION
Closes #668.

Added new `LabelRadioGroup` component which reuses some logic from `LabelSliderGroup`.
Thought it would be better if component supported multiple labels if we want to simplify UX.
`LabelRadioItem` contains `states` prop to configure _(specify the text, value or color)_ presented buttons.
**Here's a demo:**
![image](https://user-images.githubusercontent.com/30481105/212367369-aa3b0174-52d9-40db-8454-9da6108e266c.png)
![image](https://user-images.githubusercontent.com/30481105/212368598-9a70e220-c27d-441c-9062-161d4179ba7c.png)

Blocked by #686.
