### PR TITLE
website: Fix responsiveness of '...' in sortable item

### DIFF
--- a/website/src/components/Sortable/Sortable.tsx
+++ b/website/src/components/Sortable/Sortable.tsx
@@ -3,7 +3,7 @@ import {
   closestCenter,
   DndContext,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
   TouchSensor,
   useSensor,
   useSensors,
@@ -49,8 +49,8 @@ export const Sortable = (props: SortableProps) => {
   }, [props.items]);
 
   const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(TouchSensor),
+    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { distance: 4 } }),
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 


### PR DESCRIPTION
This fixes the core issue with #685 and makes the '...' button work reliably in the sortable items and subsequent dialog easily closable.

It doesn't fix the issue where the modal dialog can be used to drag the sortable item or the fact that the '...' doesn't look like it can be clicked on.

Note: the change from PointerSensor to MouseSensor was required to make this work and dnd-kit says that PointerSensor shouldn't be used with touch sensor, but MouseSensor can be.