### PR TITLE
website: Make the more text button clearer

### DIFF
--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -6,6 +6,7 @@ import {
   ModalContent,
   ModalHeader,
   ModalOverlay,
+  useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
 import React, { ReactNode } from "react";
@@ -21,15 +22,27 @@ export const CollapsableText = ({
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
 
+  const moreButtonColor = useColorModeValue("gray.600", "gray.400");
+
   if (typeof text !== "string" || text.length <= maxLength) {
     return <>{text}</>;
   } else {
     return (
       <>
-        {text.substring(0, maxLength - 3)}
-        <Button style={{ display: "contents" }} isDisabled={isDisabled} onClick={onOpen}>
-          ...
-        </Button>
+        <span>
+          {text.substring(0, maxLength - 3)}&nbsp;
+          <Button
+            style={{ display: "inline" }}
+            size={"xs"}
+            variant={"solid"}
+            bg={moreButtonColor}
+            color={"white"}
+            isDisabled={isDisabled}
+            onClick={onOpen}
+          >
+            ...
+          </Button>
+        </span>
         <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior={"inside"}>
           <ModalOverlay style={{ width: "100%", height: "100%" }}>
             <ModalContent maxH="400">


### PR DESCRIPTION
Before (yes it's a button, see #685):
![Screenshot from 2023-01-14 15-40-37](https://user-images.githubusercontent.com/241372/212451192-24292961-f18b-4ce3-89e2-72d477f5ba66.png)

After:
![Screenshot from 2023-01-14 15-40-01](https://user-images.githubusercontent.com/241372/212451090-377e53af-b5ff-45ed-a6c3-9b4a740825ee.png)

This is a suggestion, it was not explicitly mentioned that this was an issue in #685, but I figured it could be a compounding factor.

If you liked this PR you might also like these PRs:
* [website: Fix responsiveness of '...' in sortable item](https://github.com/LAION-AI/Open-Assistant/pull/696)