### PR TITLE
Tag in the user table when they are new and include it in use session

### DIFF
--- a/website/prisma/schema.prisma
+++ b/website/prisma/schema.prisma
@@ -41,6 +41,7 @@ model User {
   email         String?   @unique
   emailVerified DateTime?
   image         String?
+  isNew         Boolean   @default(true)
   role          String    @default("general")
 
   accounts      Account[]

--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -86,6 +86,7 @@ export const authOptions: AuthOptions = {
      */
     async session({ session, token }) {
       session.user.role = token.role;
+      session.user.isNew = token.isNew;
       return session;
     },
     /**
@@ -93,11 +94,12 @@ export const authOptions: AuthOptions = {
      * This let's use forward the role to the session object.
      */
     async jwt({ token }) {
-      const { role } = await prisma.user.findUnique({
+      const { isNew, role } = await prisma.user.findUnique({
         where: { id: token.sub },
-        select: { role: true },
+        select: { role: true, isNew: true },
       });
       token.role = role;
+      token.isNew = isNew;
       return token;
     },
   },

--- a/website/src/pages/api/update_task.ts
+++ b/website/src/pages/api/update_task.ts
@@ -17,6 +17,9 @@ const handler = withoutRole("banned", async (req, res, token) => {
   // Parse out the local task ID and the interaction contents.
   const { id: frontendId, content, update_type } = req.body;
 
+  // Record that the user has done meaningful work and is no longer new.
+  await prisma.user.update({ where: { id: token.sub }, data: { isNew: false } });
+
   // Accept the task so that we can complete it, this will probably go away soon.
   const registeredTask = await prisma.registeredTask.findUniqueOrThrow({ where: { id: frontendId } });
   const task = registeredTask.task as Prisma.JsonObject;

--- a/website/src/pages/dashboard.tsx
+++ b/website/src/pages/dashboard.tsx
@@ -1,9 +1,15 @@
 import Head from "next/head";
+import { useSession } from "next-auth/react";
 import { LeaderboardTable, TaskOption } from "src/components/Dashboard";
 import { getDashboardLayout } from "src/components/Layout";
 import { TaskCategory } from "src/components/Tasks/TaskTypes";
 
 const Dashboard = () => {
+  const { data: session } = useSession();
+
+  // TODO(#670): Do something more meaningful when the user is new.
+  console.log(session?.user?.isNew);
+
   return (
     <>
       <Head>

--- a/website/types/next-auth.d.ts
+++ b/website/types/next-auth.d.ts
@@ -6,6 +6,8 @@ declare module "next-auth" {
     user: {
       /** The user's role. */
       role: string;
+      /** True when the user is new. */
+      isNew: boolean;
     } & DefaultSession["user"];
   }
 }
@@ -14,5 +16,7 @@ declare module "next-auth/jwt" {
   interface JWT {
     /** The user's role. */
     role?: string;
+    /** True when the user is new. */
+    isNew?: boolean;
   }
 }


### PR DESCRIPTION
Applies to #670 

When a new user signs up we tag them as `isNew` in the User table.  When they contribute data we update the field to be `false`.

The `isNew` field is forwarded during JWT and session creation so that we can present onboarding information.  The one flaw with this approach is that they will see the onboarding information until they create a new session.