### PR TITLE
turn off auto-commit on `docs/docs/api/openapi.json` as clashing with branch protection

### DIFF
--- a/.github/workflows/test-api-contract.yaml
+++ b/.github/workflows/test-api-contract.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - add-api-docs-workflow
     paths:
       - "oasst-shared/**"
       - "backend/**"
@@ -46,8 +45,8 @@ jobs:
 
       - run: ./scripts/backend-development/stop-mock-server.sh
 
-      - uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          file_pattern: "docs/docs/api/openapi.json"
-          commit_message:
-            update docs/docs/api/openapi.json by run ${{ github.run_id }}
+      #- uses: stefanzweifel/git-auto-commit-action@v4
+      #  with:
+      #    file_pattern: "docs/docs/api/openapi.json"
+      #    commit_message:
+      #      update docs/docs/api/openapi.json by run ${{ github.run_id }}


### PR DESCRIPTION
this PR should [fix this](https://github.com/LAION-AI/Open-Assistant/pull/719#issuecomment-1382966107) by disabling last step to auto-commit docs/docs/api/openapi.json. 

the auto-commit seems to be clashing with GH branch protection rules - will need to read up to see how to resolve. 

looks like to resolve we would need to do this: seems like we need to do this: https://github.com/stefanzweifel/git-auto-commit-action#push-to-protected-branches

i think would need to be a repo admin who can make a access token the action can use.