### PR TITLE
Fix missing `name` for debug users

### DIFF
--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -50,7 +50,7 @@ if (boolean(process.env.DEBUG_LOGIN) || process.env.NODE_ENV === "development") 
           where: {
             id: user.id,
           },
-          update: {},
+          update: user,
           create: user,
         });
         return user;


### PR DESCRIPTION
This leads to api requests also failing since they need a the `display_name`