### PR TITLE
Switch back to useEffect in FlaggableElement 

### DIFF
--- a/website/src/components/FlaggableElement.tsx
+++ b/website/src/components/FlaggableElement.tsx
@@ -22,7 +22,7 @@ import {
 } from "@chakra-ui/react";
 import { QuestionMarkCircleIcon } from "@heroicons/react/20/solid";
 import clsx from "clsx";
-import { useReducer } from "react";
+import { useEffect, useReducer } from "react";
 import { FiAlertCircle } from "react-icons/fi";
 import { get, post } from "src/lib/api";
 import { Message } from "src/types/Conversation";
@@ -100,12 +100,14 @@ export const FlaggableElement = (props: FlaggableElementProps) => {
   );
   const [isEditing, setIsEditing] = useBoolean();
 
-  useSWR("/api/valid_labels", get, {
-    onSuccess: (data) => {
-      const { valid_labels } = data;
-      updateReport({ type: "load_labels", labels: valid_labels });
-    },
-  });
+  const { data, isLoading } = useSWR("/api/valid_labels", get);
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    const { valid_labels } = data;
+    updateReport({ type: "load_labels", labels: valid_labels });
+  }, [data, isLoading]);
 
   const { trigger } = useSWRMutation("/api/set_label", post, {
     onSuccess: () => {


### PR DESCRIPTION
Fixes #753 

We have to save the data from `useSWR` and then update via `useEffect`.  Otherwise the valid label set gets thrown away when different versions of `FlaggableElement` is rendered and the label list is empty.