### PR TITLE
dashboard shadow fix

### DIFF
--- a/website/src/components/SideMenuLayout.tsx
+++ b/website/src/components/SideMenuLayout.tsx
@@ -16,7 +16,7 @@ export const SideMenuLayout = (props: SideMenuLayoutProps) => {
         <Box p={["3", "3", "3", "6"]} pr={["3", "3", "3", "0"]}>
           <SideMenu buttonOptions={props.menuButtonOptions} />
         </Box>
-        <Box className="overflow-y-auto p-3 lg:p-6 lg:pl-0 w-full">{props.children}</Box>
+        <Box className="overflow-y-auto p-3 lg:p-6 lg:pl-1 w-full">{props.children}</Box>
       </Box>
     </Box>
   );


### PR DESCRIPTION
There was a problem where the shadow of components would get cut off by the container on large screens

before
![image](https://user-images.githubusercontent.com/45190934/212791830-53b4a526-6296-4b6f-9960-29d1ad809a9c.png)

after
![image](https://user-images.githubusercontent.com/45190934/212791850-802a89ae-7cec-4c9f-817c-e7a1694c184f.png)
