### PR TITLE
Guarantee all users get a name

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -45,6 +45,7 @@
         "sharp": "^0.31.3",
         "swr": "^2.0.0",
         "tailwindcss": "^3.2.4",
+        "unique-username-generator": "^1.1.3",
         "use-debounce": "^9.0.2"
       },
       "devDependencies": {
@@ -35987,6 +35988,11 @@
         "imurmurhash": "^0.1.4"
       }
     },
+    "node_modules/unique-username-generator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unique-username-generator/-/unique-username-generator-1.1.3.tgz",
+      "integrity": "sha512-TB6YdqPMKMpTSgxAzjZkKWtmpZPHvARoWreCKBpc1UrLFz/0C6Q96/qdjpLr9OXPCHk16sD1LHjTr3JDj7q2JA=="
+    },
     "node_modules/unist-builder": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/unist-builder/-/unist-builder-2.0.3.tgz",
@@ -64595,6 +64601,11 @@
       "requires": {
         "imurmurhash": "^0.1.4"
       }
+    },
+    "unique-username-generator": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/unique-username-generator/-/unique-username-generator-1.1.3.tgz",
+      "integrity": "sha512-TB6YdqPMKMpTSgxAzjZkKWtmpZPHvARoWreCKBpc1UrLFz/0C6Q96/qdjpLr9OXPCHk16sD1LHjTr3JDj7q2JA=="
     },
     "unist-builder": {
       "version": "2.0.3",

--- a/website/package.json
+++ b/website/package.json
@@ -62,6 +62,7 @@
     "sharp": "^0.31.3",
     "swr": "^2.0.0",
     "tailwindcss": "^3.2.4",
+    "unique-username-generator": "^1.1.3",
     "use-debounce": "^9.0.2"
   },
   "devDependencies": {

--- a/website/src/lib/oasst_api_client.ts
+++ b/website/src/lib/oasst_api_client.ts
@@ -113,7 +113,7 @@ export class OasstApiClient {
       type: taskType,
       user: {
         id: userToken.sub,
-        display_name: userToken.name || userToken.email,
+        display_name: userToken.name,
         auth_method: "local",
       },
     });
@@ -146,7 +146,7 @@ export class OasstApiClient {
       type: updateType,
       user: {
         id: userToken.sub,
-        display_name: userToken.name || userToken.email,
+        display_name: userToken.name,
         auth_method: "local",
       },
       task_id: taskId,

--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -97,12 +97,13 @@ export const authOptions: AuthOptions = {
      * When creating a token, fetch the user's role and inject it in the token.
      * This let's use forward the role to the session object.
      */
-    async jwt({ user, token }) {
+    async jwt({ token }) {
       const { isNew, name, role } = await prisma.user.findUnique({
         where: { id: token.sub },
         select: { name: true, role: true, isNew: true },
       });
-      (token.name = name), (token.role = role);
+      token.name = name;
+      token.role = role;
       token.isNew = isNew;
       return token;
     },


### PR DESCRIPTION
Fixes #795 

When a new user is created via email, we give them a random generated username.

When communicating with the backend we always use the user name instead of the email to retrain privacy.