### PR TITLE
Add api auth to user stat repo

### DIFF
--- a/backend/oasst_backend/user_stats_repository.py
+++ b/backend/oasst_backend/user_stats_repository.py
@@ -300,5 +300,3 @@ if __name__ == "__main__":
         usr = UserStatsRepository(db)
         usr.update_all_time_frames()
         db.commit()
-        # usr.get_leader_board(UserStatsTimeFrame.total)
-        print(usr.get_user_stats_all_time_frames(UUID("0d6ff62a-0bea-4c56-ade8-b3e0520a10ce")))

--- a/backend/oasst_backend/user_stats_repository.py
+++ b/backend/oasst_backend/user_stats_repository.py
@@ -10,6 +10,7 @@ from oasst_backend.models.db_payload import (
     LabelPrompterReplyPayload,
     RankingReactionPayload,
 )
+from oasst_backend.config import settings
 from oasst_shared.schemas.protocol import LeaderboardStats, UserScore
 from oasst_shared.utils import log_timing, utcnow
 from sqlalchemy.dialects import postgresql
@@ -291,13 +292,13 @@ WHERE
 
 
 if __name__ == "__main__":
-    from oasst_backend.api.deps import get_dummy_api_client
+    from oasst_backend.api.deps import api_auth
     from oasst_backend.database import engine
 
-    with Session(engine) as session:
-        api_client = get_dummy_api_client(session)
-        usr = UserStatsRepository(session)
-        # usr.update_all_time_frames()
-        # session.commit()
-        # usr.get_leader_board(UserStatsTimeFrame.total)
-        usr.get_user_stats_all_time_frames(UUID("0d6ff62a-0bea-4c56-ade8-b3e0520a10ce"))
+    with Session(engine) as db:
+        api_client = api_auth(settings.OFFICIAL_WEB_API_KEY, db=db)
+        usr = UserStatsRepository(db)
+        usr.update_all_time_frames()
+        db.commit()
+        #usr.get_leader_board(UserStatsTimeFrame.total)
+        print(usr.get_user_stats_all_time_frames(UUID("0d6ff62a-0bea-4c56-ade8-b3e0520a10ce")))

--- a/backend/oasst_backend/user_stats_repository.py
+++ b/backend/oasst_backend/user_stats_repository.py
@@ -4,13 +4,13 @@ from uuid import UUID
 
 import sqlalchemy as sa
 from loguru import logger
+from oasst_backend.config import settings
 from oasst_backend.models import Message, MessageReaction, Task, User, UserStats, UserStatsTimeFrame
 from oasst_backend.models.db_payload import (
     LabelAssistantReplyPayload,
     LabelPrompterReplyPayload,
     RankingReactionPayload,
 )
-from oasst_backend.config import settings
 from oasst_shared.schemas.protocol import LeaderboardStats, UserScore
 from oasst_shared.utils import log_timing, utcnow
 from sqlalchemy.dialects import postgresql
@@ -300,5 +300,5 @@ if __name__ == "__main__":
         usr = UserStatsRepository(db)
         usr.update_all_time_frames()
         db.commit()
-        #usr.get_leader_board(UserStatsTimeFrame.total)
+        # usr.get_leader_board(UserStatsTimeFrame.total)
         print(usr.get_user_stats_all_time_frames(UUID("0d6ff62a-0bea-4c56-ade8-b3e0520a10ce")))


### PR DESCRIPTION
Small pull request, to remove old get_dummy_api and replace it with new api_auth function.
it was breaking before. I'm working on user_stats_repo so just adding this quick fix.