### PR TITLE
Convert update ranks in user_stat_repository to sqlalchemy

### DIFF
--- a/backend/oasst_backend/user_stats_repository.py
+++ b/backend/oasst_backend/user_stats_repository.py
@@ -14,7 +14,7 @@ from oasst_backend.models.db_payload import (
 from oasst_shared.schemas.protocol import LeaderboardStats, UserScore
 from oasst_shared.utils import log_timing, utcnow
 from sqlalchemy.dialects import postgresql
-from sqlmodel import Session, delete, func, text
+from sqlmodel import Session, delete, func, select, update
 
 
 def _create_user_score(r):
@@ -220,6 +220,7 @@ class UserStatsRepository:
 
         self.update_ranks(time_frame=time_frame)
 
+
     @log_timing(log_kwargs=True)
     def update_ranks(self, time_frame: UserStatsTimeFrame = None):
         """
@@ -227,34 +228,28 @@ class UserStatsRepository:
         quickly the rank of a single user and to query nearby users.
         """
 
-        # todo: convert sql to sqlalchemy query..
-        # ranks = self.session.query(
-        #     func.row_number()
-        #     .over(partition_by=UserStats.time_frame, order_by=[UserStats.leader_score.desc(), UserStats.user_id])
-        #     .label("rank"),
-        #     UserStats.user_id,
-        #     UserStats.time_frame,
-        # )
-
-        sql_update_rank = """
--- update rank
-UPDATE user_stats us
-SET "rank" = r."rank"
-FROM
-    (SELECT
-        ROW_NUMBER () OVER(
-            PARTITION BY time_frame
-            ORDER BY leader_score DESC, user_id
-        ) AS "rank", user_id, time_frame
-    FROM user_stats
-    WHERE (:time_frame IS NULL OR time_frame = :time_frame)) AS r
-WHERE
-    us.user_id = r.user_id
-    AND us.time_frame = r.time_frame;"""
-        r = self.session.execute(
-            text(sql_update_rank), {"time_frame": time_frame.value if time_frame is not None else None}
+        #sql alchemy implementation
+        subquery = (
+            select([
+                func.row_number()
+                .over(partition_by=UserStats.time_frame, order_by=[UserStats.leader_score.desc(), UserStats.user_id])
+                .label('rank'),
+                UserStats.user_id,
+                UserStats.time_frame
+            ])
+            .where(UserStats.time_frame == time_frame.value if time_frame is not None else None)
+            .alias()
         )
-        logger.debug(f"pre_compute_ranks updated({time_frame=}) {r.rowcount} rows.")
+
+        update_stmt = (
+            update(UserStats)
+            .where(UserStats.user_id == subquery.c.user_id)
+            .where(UserStats.time_frame == subquery.c.time_frame)
+            .values(rank= subquery.c.rank)
+        )
+        qry = self.session.execute(update_stmt)
+        logger.debug(f"pre_compute_ranks updated({time_frame=}) {qry.rowcount} rows.")
+
 
     def update_stats_time_frame(self, time_frame: UserStatsTimeFrame, reference_time: Optional[datetime] = None):
         self._update_stats_internal(time_frame, reference_time)


### PR DESCRIPTION
Pull request to convert the SQL text to SQL alchemy. This new code updates all time frames of users based on the leader score.

After running this you will notice the rank column in the user table is now updated where before it was null. 

There is a warning that appears in the terminal when running this. but from what I can tell this can be ignored. 
``` bash
Users/danielhug/Open-Assistant/backend/venv/lib/python3.10/site-packages/sqlmodel/orm/session.py:101: SAWarning: Evaluating non-mapped column expression 'anon_1.user_id' onto ORM instances; this is a deprecated use case.  Please make use of the actual mapped columns in ORM-evaluated UPDATE / DELETE expressions.
  return super().execute(  # type: ignore
/Users/danielhug/Open-Assistant/backend/venv/lib/python3.10/site-packages/sqlmodel/orm/session.py:101: SAWarning: Evaluating non-mapped column expression 'anon_1.time_frame' onto ORM instances; this is a deprecated use case.  Please make use of the actual mapped columns in ORM-evaluated UPDATE / DELETE expressions.
  return super().execute(  # type: ignore
/Users/danielhug/Open-Assistant/backend/venv/lib/python3.10/site-packages/sqlmodel/orm/session.py:101: SAWarning: Evaluating non-mapped column expression 'anon_1.rank' onto ORM instances; this is a deprecated use case.  Please make use of the actual mapped columns in ORM-evaluated UPDATE / DELETE expressions.
  return super().execute(  # type: ignore
 ```