### PR TITLE
Fix leaderboard sorting

### DIFF
--- a/backend/oasst_backend/user_stats_repository.py
+++ b/backend/oasst_backend/user_stats_repository.py
@@ -40,7 +40,7 @@ class UserStatsRepository:
             self.session.query(User.id.label("user_id"), User.username, User.auth_method, User.display_name, UserStats)
             .join(UserStats, User.id == UserStats.user_id)
             .filter(UserStats.time_frame == time_frame.value)
-            .order_by(UserStats.leader_score.desc())
+            .order_by(UserStats.rank)
             .limit(limit)
         )
 


### PR DESCRIPTION
User ranks with the same score don't correspond to their position in the leaderboard.
![leaderboard](https://user-images.githubusercontent.com/28014244/213280635-6b3f0dfa-3103-4ace-9bd4-b4ffc689ca53.png)

Also this solution matches index `ix_user_stats__timeframe__rank__user_id`