### PR TITLE
website: Change spam question to "Is the message spam?"

### DIFF
--- a/website/src/components/Survey/LabelRadioGroup.tsx
+++ b/website/src/components/Survey/LabelRadioGroup.tsx
@@ -24,7 +24,7 @@ interface LabelRadioGroupProps {
 
 const label_messages: { [label: string]: { description: string; explanation: string[] } } = {
   spam: {
-    description: "The message is spam?",
+    description: "Is the message spam?",
     explanation: [
       'We consider the following unwanted content as spam: trolling, intentional undermining of our purpose, illegal material, material that violates our code of conduct, and other things that are inappropriate for our dataset. We collect these under the common heading of "spam".',
       "This is not an assessment of whether this message is the best possible answer. Especially for prompts or user-replies, we very much want to retain all kinds of responses in the dataset, so that the assistant can learn to reply appropriately.",


### PR DESCRIPTION
As multiple people have pointed out "This message is spam?" sounds odd #813. This is a very simple change instead make it say "Is this message spam?" whilst we are considering how to generally improve these tasks. #707.