### PR TITLE
Categorise notebooks as documentation to improve project language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto eol=lf
+*.ipynb linguist-documentation


### PR DESCRIPTION
This change causes GitHub to ignore `.ipynb` files when computing the project language statistics. This will make the statistics more reasonably classify the project as Python rather than Jupyter Notebook, as notebooks are largely generated content rather than code so have an outsized impact on the statistics.