### PR TITLE
fix: redundant row updates with no Task id in text_labels table

### DIFF
--- a/backend/oasst_backend/api/v1/text_labels.py
+++ b/backend/oasst_backend/api/v1/text_labels.py
@@ -15,7 +15,6 @@ router = APIRouter()
 @router.post("/", status_code=HTTP_204_NO_CONTENT)
 def label_text(
     *,
-    # db: Session = Depends(deps.get_db),
     api_key: APIKey = Depends(deps.get_api_key),
     text_labels: protocol_schema.TextLabels,
 ) -> None:
@@ -24,14 +23,14 @@ def label_text(
     """
 
     @managed_tx_function(CommitMode.COMMIT)
-    def store_text_labels(session: deps.Session, api_key):
+    def store_text_labels(session: deps.Session):
         api_client = deps.api_auth(api_key, session)
         pr = PromptRepository(session, api_client, client_user=text_labels.user)
         pr.store_text_labels(text_labels)
 
     try:
         logger.info(f"Labeling text {text_labels=}.")
-        store_text_labels(api_key=api_key)
+        store_text_labels()
 
     except OasstError:
         raise

--- a/backend/oasst_backend/api/v1/text_labels.py
+++ b/backend/oasst_backend/api/v1/text_labels.py
@@ -5,6 +5,7 @@ from oasst_backend.api import deps
 from oasst_backend.prompt_repository import PromptRepository
 from oasst_backend.schemas.text_labels import LabelOption, ValidLabelsResponse
 from oasst_backend.utils.database_utils import CommitMode, managed_tx_function
+from oasst_shared.exceptions import OasstError
 from oasst_shared.schemas import protocol as protocol_schema
 from starlette.status import HTTP_204_NO_CONTENT, HTTP_400_BAD_REQUEST
 
@@ -32,6 +33,8 @@ def label_text(
         logger.info(f"Labeling text {text_labels=}.")
         store_text_labels(api_key=api_key)
 
+    except OasstError:
+        raise
     except Exception:
         logger.exception("Failed to store label.")
         raise HTTPException(

--- a/backend/oasst_backend/prompt_repository.py
+++ b/backend/oasst_backend/prompt_repository.py
@@ -449,7 +449,7 @@ class PromptRepository:
                 message.review_count += 1
                 self.db.add(message)
             # for the same User id with no task id associated with the message, then update existing record for repeated updates
-            existing_text_label = self.fetch_task_of_text_labels(message_id, self.user_id)
+            existing_text_label = self.fetch_non_task_text_labels(message_id, self.user_id)
             if existing_text_label is not None:
                 existing_text_label.labels = text_labels.labels
                 model = existing_text_label
@@ -566,7 +566,7 @@ class PromptRepository:
             raise OasstError("Message not found", OasstErrorCode.MESSAGE_NOT_FOUND, HTTP_404_NOT_FOUND)
         return message
 
-    def fetch_task_of_text_labels(self, message_id: UUID, user_id: UUID) -> Optional[TextLabels]:
+    def fetch_non_task_text_labels(self, message_id: UUID, user_id: UUID) -> Optional[TextLabels]:
 
         query = (
             self.db.query(TextLabels)


### PR DESCRIPTION
For every report from the frontend , a new entry was created in text_label table.

**Solution**
- Update existing record based on message_id iff there is no Task ID associated to it
- create new row if none exists
- Outer Commit function in API handler

**Dependency**
- Blocked by https://github.com/LAION-AI/Open-Assistant/issues/794

**Test Evidence**
- SInce https://github.com/LAION-AI/Open-Assistant/issues/794#event-8242335186 is still open. Used Postman to recreate the scenario. 

**First Update**
![Screenshot 2023-01-18 at 11 01 17 AM](https://user-images.githubusercontent.com/6395936/213092695-99cf3988-9fca-4387-950b-f21ac9fad6c8.png)

**Second Update**
![Screenshot 2023-01-18 at 11 00 47 AM](https://user-images.githubusercontent.com/6395936/213093102-2c9a7e1e-b7b6-426b-842e-8f1524240093.png)
