### PR TITLE
Send language when fetching available tasks

### DIFF
--- a/website/src/lib/oasst_api_client.ts
+++ b/website/src/lib/oasst_api_client.ts
@@ -269,8 +269,8 @@ export class OasstApiClient {
   /**
    * Returns the counts of all tasks (some might be zero)
    */
-  async fetch_available_tasks(user: BackendUserCore): Promise<AvailableTasks> {
-    return this.post(`/api/v1/tasks/availability`, user);
+  async fetch_available_tasks(user: BackendUserCore, lang: string): Promise<AvailableTasks> {
+    return this.post(`/api/v1/tasks/availability`, { ...user, lang });
   }
 }
 

--- a/website/src/lib/users.ts
+++ b/website/src/lib/users.ts
@@ -15,7 +15,7 @@ const LOCALE_SET = new Set(i18n.locales);
  *    the i18n module.
  * 3. "en" as a final fallback.
  */
-const getUserLanguage = (req: NextApiRequest) => {
+const getUserLanguage = (req: NextApiRequest): string => {
   const cookieLanguage = req.cookies["NEXT_LOCALE"];
   if (cookieLanguage) {
     return cookieLanguage;

--- a/website/src/pages/admin/status/index.tsx
+++ b/website/src/pages/admin/status/index.tsx
@@ -4,12 +4,12 @@ import {
   CardBody,
   CircularProgress,
   SimpleGrid,
-  Text,
   Table,
   TableCaption,
   TableContainer,
   Tbody,
   Td,
+  Text,
   Th,
   Thead,
   Tr,
@@ -19,9 +19,10 @@ import Head from "next/head";
 import { useRouter } from "next/router";
 import { useSession } from "next-auth/react";
 import { useEffect } from "react";
-import useSWRImmutable from "swr/immutable";
 import { getAdminLayout } from "src/components/Layout";
 import { get } from "src/lib/api";
+import useSWRImmutable from "swr/immutable";
+export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
 /**
  * Provides the admin status page that shows result of calls to several backend API endpoints,

--- a/website/src/pages/api/available_tasks.ts
+++ b/website/src/pages/api/available_tasks.ts
@@ -1,10 +1,11 @@
 import { withoutRole } from "src/lib/auth";
 import { oasstApiClient } from "src/lib/oasst_api_client";
-import { getBackendUserCore } from "src/lib/users";
+import { getBackendUserCore, getUserLanguage } from "src/lib/users";
 
 const handler = withoutRole("banned", async (req, res, token) => {
   const user = await getBackendUserCore(token.sub);
-  const availableTasks = await oasstApiClient.fetch_available_tasks(user);
+  const userLanguage = getUserLanguage(req);
+  const availableTasks = await oasstApiClient.fetch_available_tasks(user, userLanguage);
   res.status(200).json(availableTasks);
 });
 


### PR DESCRIPTION
Otherwise the backend will only respond with english tasks.

Also, fixes #889 by adding a missing export of the staticProps