### PR TITLE
add lang filter option to message endpoints

### DIFF
--- a/backend/oasst_backend/api/v1/frontend_users.py
+++ b/backend/oasst_backend/api/v1/frontend_users.py
@@ -70,9 +70,9 @@ def query_frontend_user_messages(
     only_roots: bool = False,
     desc: bool = True,
     include_deleted: bool = False,
+    lang: Optional[str] = None,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
-    lang: Optional[str] = None,
 ):
     """
     Query frontend user messages.

--- a/backend/oasst_backend/api/v1/frontend_users.py
+++ b/backend/oasst_backend/api/v1/frontend_users.py
@@ -72,6 +72,7 @@ def query_frontend_user_messages(
     include_deleted: bool = False,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
+    lang: Optional[str] = None,
 ):
     """
     Query frontend user messages.
@@ -87,6 +88,7 @@ def query_frontend_user_messages(
         lte_created_date=end_date,
         only_roots=only_roots,
         deleted=None if include_deleted else False,
+        lang=lang,
     )
     return utils.prepare_message_list(messages)
 
@@ -101,6 +103,7 @@ def query_frontend_user_messages_cursor(
     include_deleted: Optional[bool] = False,
     max_count: Optional[int] = Query(10, gt=0, le=1000),
     desc: Optional[bool] = False,
+    lang: Optional[str] = None,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
 ):
@@ -113,6 +116,7 @@ def query_frontend_user_messages_cursor(
         include_deleted=include_deleted,
         max_count=max_count,
         desc=desc,
+        lang=lang,
         api_client=api_client,
         db=db,
     )

--- a/backend/oasst_backend/api/v1/messages.py
+++ b/backend/oasst_backend/api/v1/messages.py
@@ -26,6 +26,7 @@ def query_messages(
     only_roots: Optional[bool] = False,
     desc: Optional[bool] = True,
     allow_deleted: Optional[bool] = False,
+    lang: Optional[str] = None,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
 ):
@@ -43,6 +44,7 @@ def query_messages(
         lte_created_date=end_date,
         only_roots=only_roots,
         deleted=None if allow_deleted else False,
+        lang=lang,
     )
 
     return utils.prepare_message_list(messages)
@@ -60,6 +62,7 @@ def get_messages_cursor(
     include_deleted: Optional[bool] = False,
     max_count: Optional[int] = Query(10, gt=0, le=1000),
     desc: Optional[bool] = False,
+    lang: Optional[str] = None,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
 ):
@@ -103,6 +106,7 @@ def get_messages_cursor(
         deleted=None if include_deleted else False,
         desc=query_desc,
         limit=qry_max_count,
+        lang=lang,
     )
 
     num_rows = len(items)

--- a/backend/oasst_backend/api/v1/users.py
+++ b/backend/oasst_backend/api/v1/users.py
@@ -223,6 +223,7 @@ def query_user_messages(
     only_roots: bool = False,
     desc: bool = True,
     include_deleted: bool = False,
+    lang: Optional[str] = None,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
 ):
@@ -239,6 +240,7 @@ def query_user_messages(
         lte_created_date=end_date,
         only_roots=only_roots,
         deleted=None if include_deleted else False,
+        lang=lang,
     )
 
     return utils.prepare_message_list(messages)
@@ -253,6 +255,7 @@ def query_user_messages_cursor(
     include_deleted: Optional[bool] = False,
     max_count: Optional[int] = Query(10, gt=0, le=1000),
     desc: Optional[bool] = False,
+    lang: Optional[str] = None,
     api_client: ApiClient = Depends(deps.get_api_client),
     db: Session = Depends(deps.get_db),
 ):
@@ -264,6 +267,7 @@ def query_user_messages_cursor(
         include_deleted=include_deleted,
         max_count=max_count,
         desc=desc,
+        lang=lang,
         api_client=api_client,
         db=db,
     )

--- a/backend/oasst_backend/prompt_repository.py
+++ b/backend/oasst_backend/prompt_repository.py
@@ -694,6 +694,7 @@ class PromptRepository:
         deleted: Optional[bool] = None,
         desc: bool = False,
         limit: Optional[int] = 100,
+        lang: Optional[str] = None,
     ) -> list[Message]:
         if not self.api_client.trusted:
             if not api_client_id:
@@ -757,6 +758,9 @@ class PromptRepository:
 
         if limit is not None:
             qry = qry.limit(limit)
+
+        if lang is not None:
+            qry = qry.filter(Message.lang == lang)
 
         return qry.all()
 


### PR DESCRIPTION
# add lang filter option to message endpoints
Fixes issues #896

As descriped in the issues, I added a lang filter option to:
- `api/v1/messages`
- `api/v1/messages/cursor`
- `api/v1/users/{user-id}/messages`
- `api/v1/users/{user-id}/messages/cursor`

I saw that `query_messages_ordered_by_created_date()` is also used in `/api/v1/frontend_users/{auth_method}/{username}/messages` and ``/api/v1/frontend_users/{auth_method}/{username}/messages/cursor`. However, I did not add the lang filter to this endpoint since the issues did not specify this endpoint. So, I was unsure if this was desired or not. Let me know if you also want it there, it is an easy fix.