### PR TITLE
Show more stats in leaderboard table

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -46,7 +46,6 @@
         "react-feature-flags": "^1.0.0",
         "react-hook-form": "^7.42.1",
         "react-i18next": "^12.1.4",
-        "react-table": "^7.8.0",
         "sharp": "^0.31.3",
         "swr": "^2.0.0",
         "tailwindcss": "^3.2.4",
@@ -32756,18 +32755,6 @@
         }
       }
     },
-    "node_modules/react-table": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      },
-      "peerDependencies": {
-        "react": "^16.8.3 || ^17.0.0-0 || ^18.0.0"
-      }
-    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -62196,12 +62183,6 @@
         "invariant": "^2.2.4",
         "tslib": "^2.0.0"
       }
-    },
-    "react-table": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
-      "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "requires": {}
     },
     "read-cache": {
       "version": "1.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -63,7 +63,6 @@
     "react-feature-flags": "^1.0.0",
     "react-hook-form": "^7.42.1",
     "react-i18next": "^12.1.4",
-    "react-table": "^7.8.0",
     "sharp": "^0.31.3",
     "swr": "^2.0.0",
     "tailwindcss": "^3.2.4",

--- a/website/public/locales/en/leaderboard.json
+++ b/website/public/locales/en/leaderboard.json
@@ -8,5 +8,7 @@
   "score": "Score",
   "user": "User",
   "weekly": "Weekly",
-  "prompt_tasks": "Prompt Tasks"
+  "prompt": "Prompts",
+  "reply": "Replies",
+  "label": "Labels"
 }

--- a/website/public/locales/en/leaderboard.json
+++ b/website/public/locales/en/leaderboard.json
@@ -7,5 +7,6 @@
   "rank": "Rank",
   "score": "Score",
   "user": "User",
-  "weekly": "Weekly"
+  "weekly": "Weekly",
+  "prompt_tasks": "Prompt Tasks"
 }

--- a/website/src/components/Dashboard/LeaderboardWidget.tsx
+++ b/website/src/components/Dashboard/LeaderboardWidget.tsx
@@ -1,11 +1,9 @@
-import { Box, Link, Text, useColorModeValue } from "@chakra-ui/react";
+import { Card, CardBody, Link, Text } from "@chakra-ui/react";
 import NextLink from "next/link";
-import { LeaderboardGridCell } from "src/components/LeaderboardGridCell";
+import { LeaderboardTable } from "src/components/LeaderboardTable";
 import { LeaderboardTimeFrame } from "src/types/Leaderboard";
 
-export function LeaderboardTable() {
-  const backgroundColor = useColorModeValue("white", "gray.700");
-  const accentColor = useColorModeValue("gray.200", "gray.900");
+export function LeaderboardWidget() {
   return (
     <main className="h-fit col-span-3">
       <div className="flex flex-col gap-4">
@@ -17,15 +15,11 @@ export function LeaderboardTable() {
             </Text>
           </Link>
         </div>
-        <Box
-          backgroundColor={backgroundColor}
-          boxShadow="base"
-          dropShadow={accentColor}
-          borderRadius="xl"
-          className="p-6 shadow-sm"
-        >
-          <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.day} />
-        </Box>
+        <Card>
+          <CardBody>
+            <LeaderboardTable timeFrame={LeaderboardTimeFrame.day} limit={5} />
+          </CardBody>
+        </Card>
       </div>
     </main>
   );

--- a/website/src/components/Dashboard/index.ts
+++ b/website/src/components/Dashboard/index.ts
@@ -1,3 +1,3 @@
-export { LeaderboardTable } from "./LeaderboardTable";
+export { LeaderboardWidget } from "./LeaderboardWidget";
 export { TaskOption } from "./TaskOption";
 export { WelcomeCard } from "./WelcomeCard";

--- a/website/src/components/DataTable.tsx
+++ b/website/src/components/DataTable.tsx
@@ -80,7 +80,7 @@ export const DataTable = <T,>({
   };
   return (
     <>
-      {disablePagination && (
+      {!disablePagination && (
         <Flex mb="2">
           <Button onClick={onPreviousClick} disabled={disablePrevious}>
             Previous

--- a/website/src/components/DataTable.tsx
+++ b/website/src/components/DataTable.tsx
@@ -1,8 +1,6 @@
 import {
   Box,
   Button,
-  Card,
-  CardBody,
   Flex,
   FormControl,
   FormLabel,
@@ -49,6 +47,7 @@ export type DataTableProps<T> = {
   onFilterChange?: (items: FilterItem[]) => void;
   disableNext?: boolean;
   disablePrevious?: boolean;
+  disablePagination?: boolean;
 };
 
 export const DataTable = <T,>({
@@ -61,6 +60,7 @@ export const DataTable = <T,>({
   onFilterChange,
   disableNext,
   disablePrevious,
+  disablePagination,
 }: DataTableProps<T>) => {
   const { getHeaderGroups, getRowModel } = useReactTable<T>({
     data,
@@ -79,8 +79,8 @@ export const DataTable = <T,>({
     onFilterChange(newValues);
   };
   return (
-    <Card>
-      <CardBody>
+    <>
+      {disablePagination && (
         <Flex mb="2">
           <Button onClick={onPreviousClick} disabled={disablePrevious}>
             Previous
@@ -90,42 +90,42 @@ export const DataTable = <T,>({
             Next
           </Button>
         </Flex>
-        <TableContainer>
-          <Table variant="simple">
-            <TableCaption>{caption}</TableCaption>
-            <Thead>
-              {getHeaderGroups().map((headerGroup) => (
-                <Tr key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => (
-                    <Th key={header.id}>
-                      <Box display="flex" alignItems="center">
-                        {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
-                        {(header.column.columnDef as DataTableColumnDef<T>).filterable && (
-                          <FilterModal
-                            value={filterValues.find((value) => value.id === header.id)?.value ?? ""}
-                            onChange={(value) => handleFilterChange({ id: header.id, value })}
-                            label={flexRender(header.column.columnDef.header, header.getContext())}
-                          ></FilterModal>
-                        )}
-                      </Box>
-                    </Th>
-                  ))}
-                </Tr>
-              ))}
-            </Thead>
-            <Tbody>
-              {getRowModel().rows.map((row) => (
-                <Tr key={row.id}>
-                  {row.getVisibleCells().map((cell) => (
-                    <Td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</Td>
-                  ))}
-                </Tr>
-              ))}
-            </Tbody>
-          </Table>
-        </TableContainer>
-      </CardBody>
-    </Card>
+      )}
+      <TableContainer>
+        <Table variant="simple">
+          <TableCaption>{caption}</TableCaption>
+          <Thead>
+            {getHeaderGroups().map((headerGroup) => (
+              <Tr key={headerGroup.id}>
+                {headerGroup.headers.map((header) => (
+                  <Th key={header.id}>
+                    <Box display="flex" alignItems="center">
+                      {header.isPlaceholder ? null : flexRender(header.column.columnDef.header, header.getContext())}
+                      {(header.column.columnDef as DataTableColumnDef<T>).filterable && (
+                        <FilterModal
+                          value={filterValues.find((value) => value.id === header.id)?.value ?? ""}
+                          onChange={(value) => handleFilterChange({ id: header.id, value })}
+                          label={flexRender(header.column.columnDef.header, header.getContext())}
+                        ></FilterModal>
+                      )}
+                    </Box>
+                  </Th>
+                ))}
+              </Tr>
+            ))}
+          </Thead>
+          <Tbody>
+            {getRowModel().rows.map((row) => (
+              <Tr key={row.id}>
+                {row.getVisibleCells().map((cell) => (
+                  <Td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</Td>
+                ))}
+              </Tr>
+            ))}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </>
   );
 };
 

--- a/website/src/components/LeaderboardGridCell/index.tsx
+++ b/website/src/components/LeaderboardGridCell/index.tsx
@@ -1,1 +1,0 @@
-export * from "./LeaderboardGridCell";

--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -13,13 +13,13 @@ const columnHelper = createColumnHelper<LeaderboardEntity>();
 /**
  * Presents a grid of leaderboard entries with more detailed information.
  */
-const LeaderboardGridCell = ({ timeFrame }: { timeFrame: LeaderboardTimeFrame }) => {
+export const LeaderboardTable = ({ timeFrame, limit }: { timeFrame: LeaderboardTimeFrame; limit: number }) => {
   const { t } = useTranslation("leaderboard");
   const {
     data: reply,
     isLoading,
     error,
-  } = useSWRImmutable<LeaderboardReply>(`/api/leaderboard?time_frame=${timeFrame}`, get, {
+  } = useSWRImmutable<LeaderboardReply>(`/api/leaderboard?time_frame=${timeFrame}&limit=${limit}`, get, {
     revalidateOnMount: true,
   });
 
@@ -35,7 +35,13 @@ const LeaderboardGridCell = ({ timeFrame }: { timeFrame: LeaderboardTimeFrame })
         header: t("score"),
       }),
       columnHelper.accessor("prompts", {
-        header: t("pro"),
+        header: t("prompt"),
+      }),
+      columnHelper.accessor((row) => row.replies_assistant + row.replies_prompter, {
+        header: t("reply"),
+      }),
+      columnHelper.accessor((row) => row.labels_full + row.labels_simple, {
+        header: t("label"),
       }),
     ],
     [t]
@@ -45,7 +51,6 @@ const LeaderboardGridCell = ({ timeFrame }: { timeFrame: LeaderboardTimeFrame })
     const val = new Date(reply?.last_updated);
     return t("last_updated_at", { val, formatParams: { val: { dateStyle: "full", timeStyle: "short" } } });
   }, [t, reply?.last_updated]);
-  console.log(reply, isLoading);
 
   if (isLoading) {
     return <CircularProgress isIndeterminate></CircularProgress>;
@@ -55,7 +60,5 @@ const LeaderboardGridCell = ({ timeFrame }: { timeFrame: LeaderboardTimeFrame })
     return <span>Unable to load leaderboard</span>;
   }
 
-  return <DataTable data={reply?.leaderboard || []} columns={columns} caption={lastUpdated}></DataTable>;
+  return <DataTable data={reply.leaderboard} columns={columns} caption={lastUpdated}></DataTable>;
 };
-
-export { LeaderboardGridCell };

--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -60,5 +60,5 @@ export const LeaderboardTable = ({ timeFrame, limit }: { timeFrame: LeaderboardT
     return <span>Unable to load leaderboard</span>;
   }
 
-  return <DataTable data={reply.leaderboard} columns={columns} caption={lastUpdated}></DataTable>;
+  return <DataTable data={reply.leaderboard} columns={columns} caption={lastUpdated} disablePagination></DataTable>;
 };

--- a/website/src/components/LeaderboardTable/index.tsx
+++ b/website/src/components/LeaderboardTable/index.tsx
@@ -1,0 +1,1 @@
+export * from "./LeaderboardTable";

--- a/website/src/components/UserTable.tsx
+++ b/website/src/components/UserTable.tsx
@@ -1,4 +1,4 @@
-import { IconButton } from "@chakra-ui/react";
+import { Card, CardBody, IconButton } from "@chakra-ui/react";
 import { createColumnHelper } from "@tanstack/react-table";
 import { Pencil } from "lucide-react";
 import Link from "next/link";
@@ -90,19 +90,21 @@ export const UserTable = memo(function UserTable() {
   };
 
   return (
-    <>
-      <DataTable
-        data={data?.items || []}
-        columns={columns}
-        caption="Users"
-        onNextClick={toNextPage}
-        onPreviousClick={toPreviousPage}
-        disableNext={!data?.next}
-        disablePrevious={!data?.prev}
-        filterValues={filterValues}
-        onFilterChange={handleFilterValuesChange}
-      ></DataTable>
-      {error && "Unable to load users."}
-    </>
+    <Card>
+      <CardBody>
+        <DataTable
+          data={data?.items || []}
+          columns={columns}
+          caption="Users"
+          onNextClick={toNextPage}
+          onPreviousClick={toPreviousPage}
+          disableNext={!data?.next}
+          disablePrevious={!data?.prev}
+          filterValues={filterValues}
+          onFilterChange={handleFilterValuesChange}
+        ></DataTable>
+        {error && "Unable to load users."}
+      </CardBody>
+    </Card>
   );
 });

--- a/website/src/lib/oasst_api_client.ts
+++ b/website/src/lib/oasst_api_client.ts
@@ -262,8 +262,14 @@ export class OasstApiClient {
   /**
    * Returns the current leaderboard ranking.
    */
-  async fetch_leaderboard(time_frame: LeaderboardTimeFrame): Promise<LeaderboardReply> {
-    return this.get(`/api/v1/leaderboards/${time_frame}`);
+  async fetch_leaderboard(
+    time_frame: LeaderboardTimeFrame,
+    { limit = 20 }: { limit?: number }
+  ): Promise<LeaderboardReply> {
+    const params = new URLSearchParams({
+      limit: limit.toString(),
+    });
+    return this.get(`/api/v1/leaderboards/${time_frame}?${params.toString()}`);
   }
 
   /**

--- a/website/src/pages/api/leaderboard.ts
+++ b/website/src/pages/api/leaderboard.ts
@@ -7,7 +7,7 @@ import { LeaderboardTimeFrame } from "src/types/Leaderboard";
  */
 const handler = withoutRole("banned", async (req, res) => {
   const time_frame = (req.query.time_frame as LeaderboardTimeFrame) ?? LeaderboardTimeFrame.day;
-  const info = await oasstApiClient.fetch_leaderboard(time_frame);
+  const info = await oasstApiClient.fetch_leaderboard(time_frame, { limit: req.query.limit as unknown as number });
   res.status(200).json(info);
 });
 

--- a/website/src/pages/dashboard.tsx
+++ b/website/src/pages/dashboard.tsx
@@ -2,7 +2,7 @@ import { Flex } from "@chakra-ui/react";
 import Head from "next/head";
 import { useTranslation } from "next-i18next";
 import { useEffect, useMemo, useState } from "react";
-import { LeaderboardTable, TaskOption, WelcomeCard } from "src/components/Dashboard";
+import { LeaderboardWidget, TaskOption, WelcomeCard } from "src/components/Dashboard";
 import { getDashboardLayout } from "src/components/Layout";
 import { TaskCategory } from "src/components/Tasks/TaskTypes";
 import { get } from "src/lib/api";
@@ -42,7 +42,7 @@ const Dashboard = () => {
       <Flex direction="column" gap="10">
         <WelcomeCard />
         <TaskOption content={availableTaskTypes} />
-        <LeaderboardTable />
+        <LeaderboardWidget />
       </Flex>
     </>
   );

--- a/website/src/pages/leaderboard.tsx
+++ b/website/src/pages/leaderboard.tsx
@@ -1,4 +1,4 @@
-import { Box, Heading, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
+import { Box, Card, CardBody, Heading, Tab, TabList, TabPanel, TabPanels, Tabs } from "@chakra-ui/react";
 import Head from "next/head";
 import { useTranslation } from "next-i18next";
 import { getDashboardLayout } from "src/components/Layout";
@@ -18,29 +18,33 @@ const Leaderboard = () => {
         <Heading fontSize="2xl" fontWeight="bold" pb="4">
           {t("leaderboard")}
         </Heading>
-        <Tabs isFitted isLazy>
-          <TabList>
-            <Tab>{t("daily")}</Tab>
-            <Tab>{t("weekly")}</Tab>
-            <Tab>{t("monthly")}</Tab>
-            <Tab>{t("overall")}</Tab>
-          </TabList>
+        <Card>
+          <CardBody>
+            <Tabs isFitted isLazy>
+              <TabList mb="4">
+                <Tab>{t("daily")}</Tab>
+                <Tab>{t("weekly")}</Tab>
+                <Tab>{t("monthly")}</Tab>
+                <Tab>{t("overall")}</Tab>
+              </TabList>
 
-          <TabPanels>
-            <TabPanel p="0">
-              <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.day} />
-            </TabPanel>
-            <TabPanel p="0">
-              <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.week} />
-            </TabPanel>
-            <TabPanel p="0">
-              <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.month} />
-            </TabPanel>
-            <TabPanel p="0">
-              <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.total} />
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
+              <TabPanels>
+                <TabPanel p="0">
+                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.day} />
+                </TabPanel>
+                <TabPanel p="0">
+                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.week} />
+                </TabPanel>
+                <TabPanel p="0">
+                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.month} />
+                </TabPanel>
+                <TabPanel p="0">
+                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.total} />
+                </TabPanel>
+              </TabPanels>
+            </Tabs>
+          </CardBody>
+        </Card>
       </Box>
     </>
   );

--- a/website/src/pages/leaderboard.tsx
+++ b/website/src/pages/leaderboard.tsx
@@ -2,8 +2,8 @@ import { Box, Card, CardBody, Heading, Tab, TabList, TabPanel, TabPanels, Tabs }
 import Head from "next/head";
 import { useTranslation } from "next-i18next";
 import { getDashboardLayout } from "src/components/Layout";
-import { LeaderboardGridCell } from "src/components/LeaderboardGridCell";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
+import { LeaderboardTable } from "src/components/LeaderboardTable";
 import { LeaderboardTimeFrame } from "src/types/Leaderboard";
 
 const Leaderboard = () => {
@@ -30,16 +30,16 @@ const Leaderboard = () => {
 
               <TabPanels>
                 <TabPanel p="0">
-                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.day} />
+                  <LeaderboardTable timeFrame={LeaderboardTimeFrame.day} limit={20} />
                 </TabPanel>
                 <TabPanel p="0">
-                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.week} />
+                  <LeaderboardTable timeFrame={LeaderboardTimeFrame.week} limit={20} />
                 </TabPanel>
                 <TabPanel p="0">
-                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.month} />
+                  <LeaderboardTable timeFrame={LeaderboardTimeFrame.month} limit={20} />
                 </TabPanel>
                 <TabPanel p="0">
-                  <LeaderboardGridCell timeFrame={LeaderboardTimeFrame.total} />
+                  <LeaderboardTable timeFrame={LeaderboardTimeFrame.total} limit={20} />
                 </TabPanel>
               </TabPanels>
             </Tabs>


### PR DESCRIPTION
close #765  fix #838

- Migrate react-table to v8.
- Show more data in the leaderboard.
- Limit the data in the leaderboard widget on the dashboard page to 5.
- Remove `Card` and `CardBody` from the `DataTable` component.