### PR TITLE
website: Refactor task page routes and repetition

### DIFF
--- a/website/cypress/e2e/tasks/no_tasks_available.cy.ts
+++ b/website/cypress/e2e/tasks/no_tasks_available.cy.ts
@@ -1,0 +1,23 @@
+describe("no tasks available", () => {
+  it("displays an empty state when no tasks are available", () => {
+    cy.signInWithEmail("cypress@example.com");
+    cy.intercept(
+      {
+        method: "GET",
+        url: "/api/new_task/prompter_reply",
+      },
+      {
+        statusCode: 500,
+        body: {
+          message: "No tasks of type 'label_prompter_reply' are currently available.",
+          errorCode: 1006,
+          httpStatusCode: 503,
+        },
+      }
+    ).as("newTaskPrompterReply");
+    cy.visit("/create/user_reply");
+    cy.wait("@newTaskPrompterReply").then(() => {
+      cy.get('[data-cy="cy-no-tasks"]').should("exist");
+    });
+  });
+});

--- a/website/public/locales/en/common.json
+++ b/website/public/locales/en/common.json
@@ -9,11 +9,12 @@
   "docs": "Docs",
   "github": "GitHub",
   "legal": "Legal",
+  "loading": "Loading...",
+  "more_information": "More Information",
   "privacy_policy": "Privacy Policy",
   "report_a_bug": "Report a Bug",
   "sign_in": "Sign In",
   "sign_out": "Sign Out",
   "terms_of_service": "Terms of Service",
-  "title": "Open Assistant",
-  "more_information": "More Information"
+  "title": "Open Assistant"
 }

--- a/website/src/components/EmptyState.tsx
+++ b/website/src/components/EmptyState.tsx
@@ -15,7 +15,7 @@ export const EmptyState = (props: EmptyStateProps) => {
     <Box data-cy={props["data-cy"]} bg={backgroundColor} p="10" borderRadius="xl" shadow="base">
       <Box display="flex" flexDirection="column" alignItems="center" gap="8" fontSize="lg">
         <props.icon size="30" color="DarkOrange" />
-        <Text>{props.text}</Text>
+        <Text data-cy="cy-no-tasks">{props.text}</Text>
         <NextLink href="/dashboard">
           <Text color="blue.500">Go back to the dashboard</Text>
         </NextLink>

--- a/website/src/components/TaskPage/TaskPage.tsx
+++ b/website/src/components/TaskPage/TaskPage.tsx
@@ -16,7 +16,7 @@ export const TaskPage = ({ type }: TaskPageProps) => {
   const { t } = useTranslation(["tasks", "common"]);
   const apiHook = apiHooksByType[type];
   const { tasks, isLoading, reset, trigger, error } = apiHook(type);
-  const taskType = TaskInfos.find((taskType) => taskType.type === type);
+  const taskInfo = TaskInfos.find((taskType) => taskType.type === type);
 
   if (isLoading) {
     return <LoadingScreen text={t("common:loading")} />;
@@ -31,8 +31,8 @@ export const TaskPage = ({ type }: TaskPageProps) => {
   return (
     <>
       <Head>
-        <title>{t(getTypeSafei18nKey(`${taskType.id}.label`))}</title>
-        <meta name="description" content={t(getTypeSafei18nKey(`${taskType.id}.desc`))} />
+        <title>{t(getTypeSafei18nKey(`${taskInfo.id}.label`))}</title>
+        <meta name="description" content={t(getTypeSafei18nKey(`${taskInfo.id}.desc`))} />
       </Head>
       <Task key={task.task.id} frontendId={task.id} task={task.task} trigger={trigger} mutate={reset} />
     </>

--- a/website/src/components/TaskPage/TaskPage.tsx
+++ b/website/src/components/TaskPage/TaskPage.tsx
@@ -1,0 +1,40 @@
+import Head from "next/head";
+import { useTranslation } from "next-i18next";
+import { TaskEmptyState } from "src/components/EmptyState";
+import { LoadingScreen } from "src/components/Loading/LoadingScreen";
+import { Task } from "src/components/Tasks/Task";
+import { TaskInfos } from "src/components/Tasks/TaskTypes";
+import { apiHooksByType, ERROR_CODES } from "src/lib/constants";
+import { getTypeSafei18nKey } from "src/lib/i18n";
+import { TaskType } from "src/types/Task";
+
+type TaskPageProps = {
+  type: TaskType;
+};
+
+export const TaskPage = ({ type }: TaskPageProps) => {
+  const { t } = useTranslation(["tasks", "common"]);
+  const apiHook = apiHooksByType[type];
+  const { tasks, isLoading, reset, trigger, error } = apiHook(type);
+  const taskType = TaskInfos.find((taskType) => taskType.type === type);
+
+  if (isLoading) {
+    return <LoadingScreen text={t("common:loading")} />;
+  }
+
+  if (tasks.length === 0 || error?.errorCode === ERROR_CODES.TASK_REQUESTED_TYPE_NOT_AVAILABLE) {
+    return <TaskEmptyState />;
+  }
+
+  const task = tasks[0];
+
+  return (
+    <>
+      <Head>
+        <title>{t(getTypeSafei18nKey(`${taskType.id}.label`))}</title>
+        <meta name="description" content={t(getTypeSafei18nKey(`${taskType.id}.desc`))} />
+      </Head>
+      <Task key={task.task.id} frontendId={task.id} task={task.task} trigger={trigger} mutate={reset} />
+    </>
+  );
+};

--- a/website/src/components/TaskPage/TaskPage.tsx
+++ b/website/src/components/TaskPage/TaskPage.tsx
@@ -4,7 +4,7 @@ import { TaskEmptyState } from "src/components/EmptyState";
 import { LoadingScreen } from "src/components/Loading/LoadingScreen";
 import { Task } from "src/components/Tasks/Task";
 import { TaskInfos } from "src/components/Tasks/TaskTypes";
-import { apiHooksByType, ERROR_CODES } from "src/lib/constants";
+import { ERROR_CODES, taskApiHooks } from "src/lib/constants";
 import { getTypeSafei18nKey } from "src/lib/i18n";
 import { TaskType } from "src/types/Task";
 
@@ -14,8 +14,8 @@ type TaskPageProps = {
 
 export const TaskPage = ({ type }: TaskPageProps) => {
   const { t } = useTranslation(["tasks", "common"]);
-  const apiHook = apiHooksByType[type];
-  const { tasks, isLoading, reset, trigger, error } = apiHook(type);
+  const taskApiHook = taskApiHooks[type];
+  const { tasks, isLoading, reset, trigger, error } = taskApiHook(type);
   const taskInfo = TaskInfos.find((taskType) => taskType.type === type);
 
   if (isLoading) {

--- a/website/src/lib/api.ts
+++ b/website/src/lib/api.ts
@@ -17,7 +17,8 @@ export const post = (url: string, { arg: data }) => api.post(url, data).then((re
 api.interceptors.response.use(
   (response) => response,
   (error) => {
-    throw new OasstError(error.message ?? error, error.error_code, error?.response?.status || -1);
+    const err = error?.response?.data;
+    throw new OasstError(err?.message ?? error, err?.errorCode, error?.response?.httpStatusCode || -1);
   }
 );
 

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -1,0 +1,42 @@
+import {
+  useCreateAssistantReply,
+  useCreateInitialPrompt,
+  useCreatePrompterReply,
+} from "src/hooks/tasks/useCreateReply";
+import { useGenericTaskAPI } from "src/hooks/tasks/useGenericTaskAPI";
+import {
+  useLabelAssistantReplyTask,
+  useLabelInitialPromptTask,
+  useLabelPrompterReplyTask,
+} from "src/hooks/tasks/useLabelingTask";
+import {
+  useRankAssistantRepliesTask,
+  useRankInitialPromptsTask,
+  useRankPrompterRepliesTask,
+} from "src/hooks/tasks/useRankReplies";
+import { TaskType } from "src/types/Task";
+
+export const ERROR_CODES = {
+  TASK_REQUESTED_TYPE_NOT_AVAILABLE: 1006,
+  TASK_INVALID_REQUEST_TYPE: 1000,
+  TASK_ACK_FAILED: 1001,
+  TASK_NACK_FAILED: 1002,
+  TASK_INVALID_RESPONSE_TYPE: 1003,
+  TASK_INTERACTION_REQUEST_FAILED: 1004,
+  TASK_GENERATION_FAILED: 1005,
+  TASK_AVAILABILITY_QUERY_FAILED: 1007,
+  TASK_MESSAGE_TOO_LONG: 1008,
+};
+
+export const apiHooksByType = {
+  [TaskType.random]: useGenericTaskAPI,
+  [TaskType.assistant_reply]: useCreateAssistantReply,
+  [TaskType.initial_prompt]: useCreateInitialPrompt,
+  [TaskType.label_assistant_reply]: useLabelAssistantReplyTask,
+  [TaskType.label_initial_prompt]: useLabelInitialPromptTask,
+  [TaskType.label_prompter_reply]: useLabelPrompterReplyTask,
+  [TaskType.prompter_reply]: useCreatePrompterReply,
+  [TaskType.rank_assistant_replies]: useRankAssistantRepliesTask,
+  [TaskType.rank_initial_prompts]: useRankInitialPromptsTask,
+  [TaskType.rank_prompter_replies]: useRankPrompterRepliesTask,
+};

--- a/website/src/lib/constants.ts
+++ b/website/src/lib/constants.ts
@@ -14,6 +14,7 @@ import {
   useRankInitialPromptsTask,
   useRankPrompterRepliesTask,
 } from "src/hooks/tasks/useRankReplies";
+import { TaskApiHooks } from "src/types/Hooks";
 import { TaskType } from "src/types/Task";
 
 export const ERROR_CODES = {
@@ -28,7 +29,7 @@ export const ERROR_CODES = {
   TASK_MESSAGE_TOO_LONG: 1008,
 };
 
-export const apiHooksByType = {
+export const taskApiHooks: TaskApiHooks = {
   [TaskType.random]: useGenericTaskAPI,
   [TaskType.assistant_reply]: useCreateAssistantReply,
   [TaskType.initial_prompt]: useCreateInitialPrompt,

--- a/website/src/pages/create/assistant_reply.tsx
+++ b/website/src/pages/create/assistant_reply.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useCreateAssistantReply } from "src/hooks/tasks/useCreateReply";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const AssistantReply = () => {
-  const { tasks, isLoading, reset, trigger } = useCreateAssistantReply();
-
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Reply as Assistant</title>
-        <meta name="description" content="Reply as Assistant." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const AssistantReply = () => <TaskPage type={TaskType.assistant_reply} />;
 
 AssistantReply.getLayout = getDashboardLayout;
 

--- a/website/src/pages/create/initial_prompt.tsx
+++ b/website/src/pages/create/initial_prompt.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useCreateInitialPrompt } from "src/hooks/tasks/useCreateReply";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const InitialPrompt = () => {
-  const { tasks, isLoading, reset, trigger } = useCreateInitialPrompt();
-
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Initial Prompt</title>
-        <meta name="description" content="Add an initial Prompt." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const InitialPrompt = () => <TaskPage type={TaskType.initial_prompt} />;
 
 InitialPrompt.getLayout = getDashboardLayout;
 

--- a/website/src/pages/create/user_reply.tsx
+++ b/website/src/pages/create/user_reply.tsx
@@ -1,33 +1,10 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useCreatePrompterReply } from "src/hooks/tasks/useCreateReply";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const UserReply = () => {
-  const { tasks, isLoading, reset, trigger } = useCreatePrompterReply();
+const PrompterReply = () => <TaskPage type={TaskType.prompter_reply} />;
 
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
+PrompterReply.getLayout = getDashboardLayout;
 
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Reply as User</title>
-        <meta name="description" content="Reply as User." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
-
-UserReply.getLayout = getDashboardLayout;
-
-export default UserReply;
+export default PrompterReply;

--- a/website/src/pages/evaluate/rank_assistant_replies.tsx
+++ b/website/src/pages/evaluate/rank_assistant_replies.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useRankAssistantRepliesTask } from "src/hooks/tasks/useRankReplies";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const RankAssistantReplies = () => {
-  const { tasks, isLoading, reset, trigger } = useRankAssistantRepliesTask();
-
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Rank Assistant Replies</title>
-        <meta name="description" content="Rank Assistant Replies." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const RankAssistantReplies = () => <TaskPage type={TaskType.rank_assistant_replies} />;
 
 RankAssistantReplies.getLayout = getDashboardLayout;
 

--- a/website/src/pages/evaluate/rank_initial_prompts.tsx
+++ b/website/src/pages/evaluate/rank_initial_prompts.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useRankInitialPromptsTask } from "src/hooks/tasks/useRankReplies";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const RankInitialPrompts = () => {
-  const { tasks, isLoading, reset, trigger } = useRankInitialPromptsTask();
-
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Rank Initial Prompts</title>
-        <meta name="description" content="Rank initial prompts." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const RankInitialPrompts = () => <TaskPage type={TaskType.rank_initial_prompts} />;
 
 RankInitialPrompts.getLayout = getDashboardLayout;
 

--- a/website/src/pages/evaluate/rank_user_replies.tsx
+++ b/website/src/pages/evaluate/rank_user_replies.tsx
@@ -1,33 +1,10 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useRankPrompterRepliesTask } from "src/hooks/tasks/useRankReplies";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const RankUserReplies = () => {
-  const { tasks, isLoading, reset, trigger } = useRankPrompterRepliesTask();
+const RankPrompterReplies = () => <TaskPage type={TaskType.rank_prompter_replies} />;
 
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
+RankPrompterReplies.getLayout = getDashboardLayout;
 
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Rank User Replies</title>
-        <meta name="description" content="Rank User Replies." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
-
-RankUserReplies.getLayout = getDashboardLayout;
-
-export default RankUserReplies;
+export default RankPrompterReplies;

--- a/website/src/pages/label/label_assistant_reply.tsx
+++ b/website/src/pages/label/label_assistant_reply.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useLabelAssistantReplyTask } from "src/hooks/tasks/useLabelingTask";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const LabelAssistantReply = () => {
-  const { tasks, isLoading, trigger, reset } = useLabelAssistantReplyTask();
-
-  if (isLoading) {
-    return <LoadingScreen />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Label Assistant Reply</title>
-        <meta name="description" content="Label Assistant Reply" />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const LabelAssistantReply = () => <TaskPage type={TaskType.label_assistant_reply} />;
 
 LabelAssistantReply.getLayout = getDashboardLayout;
 

--- a/website/src/pages/label/label_initial_prompt.tsx
+++ b/website/src/pages/label/label_initial_prompt.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useLabelInitialPromptTask } from "src/hooks/tasks/useLabelingTask";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const LabelInitialPrompt = () => {
-  const { tasks, isLoading, trigger, reset } = useLabelInitialPromptTask();
-
-  if (isLoading) {
-    return <LoadingScreen />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Label Initial Prompt</title>
-        <meta name="description" content="Label Initial Prompt" />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const LabelInitialPrompt = () => <TaskPage type={TaskType.label_initial_prompt} />;
 
 LabelInitialPrompt.getLayout = getDashboardLayout;
 

--- a/website/src/pages/label/label_prompter_reply.tsx
+++ b/website/src/pages/label/label_prompter_reply.tsx
@@ -1,32 +1,9 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useLabelPrompterReplyTask } from "src/hooks/tasks/useLabelingTask";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
+import { TaskType } from "src/types/Task";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 
-const LabelPrompterReply = () => {
-  const { tasks, isLoading, trigger, reset } = useLabelPrompterReplyTask();
-
-  if (isLoading) {
-    return <LoadingScreen />;
-  }
-
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Label Prompter Reply</title>
-        <meta name="description" content="Label Prompter Reply" />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
+const LabelPrompterReply = () => <TaskPage type={TaskType.label_prompter_reply} />;
 
 LabelPrompterReply.getLayout = getDashboardLayout;
 

--- a/website/src/pages/tasks/random.tsx
+++ b/website/src/pages/tasks/random.tsx
@@ -1,34 +1,10 @@
-import Head from "next/head";
-import { TaskEmptyState } from "src/components/EmptyState";
 import { getDashboardLayout } from "src/components/Layout";
-import { LoadingScreen } from "src/components/Loading/LoadingScreen";
-import { Task } from "src/components/Tasks/Task";
-import { useGenericTaskAPI } from "src/hooks/tasks/useGenericTaskAPI";
+import { TaskPage } from "src/components/TaskPage/TaskPage";
 export { getDefaultStaticProps as getStaticProps } from "src/lib/default_static_props";
 import { TaskType } from "src/types/Task";
 
-const RandomTask = () => {
-  const { tasks, isLoading, trigger, reset } = useGenericTaskAPI(TaskType.random);
+const Random = () => <TaskPage type={TaskType.random} />;
 
-  if (isLoading) {
-    return <LoadingScreen text="Loading..." />;
-  }
+Random.getLayout = getDashboardLayout;
 
-  if (tasks.length === 0) {
-    return <TaskEmptyState />;
-  }
-
-  return (
-    <>
-      <Head>
-        <title>Random Task</title>
-        <meta name="description" content="Random Task." />
-      </Head>
-      <Task key={tasks[0].task.id} frontendId={tasks[0].id} task={tasks[0].task} trigger={trigger} mutate={reset} />
-    </>
-  );
-};
-
-RandomTask.getLayout = (page) => getDashboardLayout(page);
-
-export default RandomTask;
+export default Random;

--- a/website/src/types/Hooks.ts
+++ b/website/src/types/Hooks.ts
@@ -1,0 +1,26 @@
+import { MutatorCallback, MutatorOptions } from "swr";
+
+import { BaseTask, TaskResponse, TaskType } from "./Task";
+
+type ConcreteTaskResponse = TaskResponse<BaseTask>;
+type TaskError = { errorCode: number; message: string };
+
+type Trigger = (
+  extraArgument?: unknown,
+  options?: MutatorOptions<ConcreteTaskResponse>
+) => Promise<ConcreteTaskResponse>;
+
+type Reset = (
+  data?: ConcreteTaskResponse | Promise<ConcreteTaskResponse> | MutatorCallback<ConcreteTaskResponse>,
+  opts?: boolean | MutatorOptions<ConcreteTaskResponse>
+) => Promise<ConcreteTaskResponse>;
+
+type TaskAPIHook = {
+  tasks: TaskResponse<BaseTask>[];
+  isLoading: boolean;
+  error: TaskError;
+  trigger: Trigger;
+  reset: Reset;
+};
+
+export type TaskApiHooks = Record<TaskType, (args: TaskType) => TaskAPIHook>;

--- a/website/src/types/Task.ts
+++ b/website/src/types/Task.ts
@@ -1,4 +1,4 @@
-export const enum TaskType {
+export enum TaskType {
   initial_prompt = "initial_prompt",
   assistant_reply = "assistant_reply",
   prompter_reply = "prompter_reply",


### PR DESCRIPTION
Hey,

Through careful refactoring, we were able to make the code more DRY (Don't Repeat Yourself) by creating a single, reusable component that dynamically renders the correct task based on the type passed to it. This not only streamlines the codebase but also ensures consistency across all routes. Additionally, we have fixed an error that previously caused the app to show a disabled button instead of a "no-tasks" interface #924. These improvements will lead to a smoother user experience and make the code easier to maintain.

If you have any questions or concerns please let me know.