### PR TITLE
Fix Ambiguous Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,12 +50,12 @@ contributions smoothly we recommend the following:
     [Here](https://github.com/LAION-AI/Open-Assistant/pull/658) is an example PR
     for this project to illustrate this flow.
 1.  If you're lucky, we can merge your change into `main` without any problems.
-    If there's changes to files you're working on, resolve them by:
-1.  First try rebase as suggested
-    [in these instructions](https://timwise.co.uk/2019/10/14/merge-vs-rebase/#should-you-rebase).
-1.  If rebase feels too painful, merge as suggested
-    [in these instructions](https://timwise.co.uk/2019/10/14/merge-vs-rebase/#should-you-merge).
-1.  Once you've resolved any conflicts, finish the review and
+    If there's changes to files you're working on, resolve them by :
+    1.  First try rebase as suggested
+        [in these instructions](https://timwise.co.uk/2019/10/14/merge-vs-rebase/#should-you-rebase).
+    1.  If rebase feels too painful, merge as suggested
+        [in these instructions](https://timwise.co.uk/2019/10/14/merge-vs-rebase/#should-you-merge).
+1.  Once you've resolved conflicts (if any), finish the review and
     [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-commits)
     your PR (when squashing try to clean up or update the individual commit
     messages to be one sensible single one).


### PR DESCRIPTION
What is the problem?
Contributing guidelines in `contributing.md` are slightly confusing as the 6th point in [this](https://github.com/LAION-AI/Open-Assistant/blob/main/CONTRIBUTING.md#submitting-work) section talks about few possibilities but then 7th point is followed leaving readers confused. 

What does this PR do?

1. Removes ambiguity by nesting the points related to 6th point.