### PR TITLE
website: request message specific labels for on demand labelling

### DIFF
--- a/website/src/components/Messages/LabelPopup.tsx
+++ b/website/src/components/Messages/LabelPopup.tsx
@@ -28,7 +28,7 @@ interface ValidLabelsResponse {
 
 export const LabelMessagePopup = ({ messageId, show, onClose }: LabelMessagePopupProps) => {
   const { t } = useTranslation();
-  const { data: response } = useSWRImmutable<ValidLabelsResponse>("/api/valid_labels", get);
+  const { data: response } = useSWRImmutable<ValidLabelsResponse>(`/api/valid_labels?message_id=${messageId}`, get);
   const valid_labels = response?.valid_labels ?? [];
   const [values, setValues] = useState<number[]>(new Array(valid_labels.length).fill(null));
 

--- a/website/src/lib/oasst_api_client.ts
+++ b/website/src/lib/oasst_api_client.ts
@@ -160,8 +160,8 @@ export class OasstApiClient {
   /**
    * Returns the valid labels for messages.
    */
-  async fetch_valid_text(): Promise<any> {
-    return this.get(`/api/v1/text_labels/valid_labels`);
+  async fetch_valid_text(messageId?: string): Promise<any> {
+    return this.get("/api/v1/text_labels/valid_labels", { message_id: messageId });
   }
 
   /**

--- a/website/src/pages/api/valid_labels.ts
+++ b/website/src/pages/api/valid_labels.ts
@@ -5,8 +5,9 @@ import { createApiClient } from "src/lib/oasst_client_factory";
  * Returns the set of valid labels that can be applied to messages.
  */
 const handler = withoutRole("banned", async (req, res, token) => {
+  const { message_id } = req.query;
   const client = await createApiClient(token);
-  const valid_labels = await client.fetch_valid_text();
+  const valid_labels = await client.fetch_valid_text(message_id as string);
   res.status(200).json(valid_labels);
 });
 


### PR DESCRIPTION
This just passes the message id when getting the labels for the message so that we only get the labels that make sense for the message. (e.g. the "fails task" yes/no question is omitted for prompter messages.