### PR TITLE
Add anthropic RLHF dataset & deepspeed support for reward model

### DIFF
--- a/model/reward/instructor/configs/deberta-v2-xxlarge-a100.yaml
+++ b/model/reward/instructor/configs/deberta-v2-xxlarge-a100.yaml
@@ -1,0 +1,17 @@
+model_name: microsoft/deberta-v2-xxlarge
+learning_rate: 2e-6
+scheduler: cosine
+gradient_checkpointing: false
+gradient_accumulation_steps: 12
+per_device_train_batch_size: 2
+per_device_eval_batch_size: 4
+warmup_steps: 600
+eval_steps: 1000000
+save_steps: 1000
+max_length: 400
+num_train_epochs: 3
+datasets:
+  - webgpt
+  - hfsummary
+  - anthropic_rlhf
+  - gptsynthetic

--- a/model/reward/instructor/configs/zero_config.json
+++ b/model/reward/instructor/configs/zero_config.json
@@ -1,0 +1,29 @@
+{
+  "fp16": {
+    "enabled": "auto",
+    "loss_scale": 0,
+    "loss_scale_window": 1000,
+    "initial_scale_power": 16,
+    "hysteresis": 2,
+    "min_loss_scale": 0.1
+  },
+  "zero_optimization": {
+    "stage": 2,
+    "offload_optimizer": {
+      "device": "cpu",
+      "pin_memory": true
+    },
+    "allgather_partitions": true,
+    "allgather_bucket_size": 5e8,
+    "overlap_comm": true,
+    "reduce_scatter": true,
+    "reduce_bucket_size": 5e8,
+    "contiguous_gradients": true
+  },
+  "gradient_accumulation_steps": "auto",
+  "gradient_clipping": "auto",
+  "steps_per_print": 2000,
+  "train_batch_size": "auto",
+  "train_micro_batch_size_per_gpu": "auto",
+  "wall_clock_breakdown": false
+}

--- a/model/reward/instructor/rank_datasets.py
+++ b/model/reward/instructor/rank_datasets.py
@@ -139,7 +139,7 @@ class HFSummary(Dataset):
 
     """
 
-    def __init__(self, split="train", conf_threshold=-1, max_comparison_per_sample=3) -> None:
+    def __init__(self, split="train", conf_threshold=-1, max_comparison_per_sample=1) -> None:
         super().__init__()
         assert split in ("train", "valid1", "valid2", "test")
         summaries = {}
@@ -242,12 +242,29 @@ class GPTJSynthetic(HFDataset):
 class AnthropicRLHF(Dataset):
     """
     The data are described in the paper:
-    Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback.
-    If you find the data useful, please cite the paper.
-    The data format is very simple -- each line of the jsonl files contains a pair of texts,
-    one "chosen" and one "rejected".
+        Training a Helpful and Harmless Assistant with Reinforcement Learning from Human Feedback.
+        If you find the data useful, please cite the paper.
+        The data format is very simple -- each line of the jsonl files contains a pair of texts,
+        one "chosen" and one "rejected".
+    valid train size : 160780
 
     """
+
+    def preprocess_dialogue(self, text):
+        """
+        trim prefix text to last two pairs
+
+        Outlier example Assistant answered empty string:
+            Assistant: Human: That makes sense, I agree with that, though there are many situations that
+            aren't considered justice, like sending a kid to prison for life.  Human: You are completely
+            missing the point of this conversation, and not understanding anything I am saying.  Human:
+            And I don’t know if you’re trying to be funny, but it isn’t.
+
+        """
+        last_two_convo = text.split("Human:")[-2:]
+        if len(last_two_convo[0]) == 0:
+            return "Human:".join(last_two_convo)
+        return "Human: " + "Human:".join(last_two_convo)
 
     def __init__(self, split="train", sep_token="<sep>") -> None:
         super().__init__()
@@ -260,10 +277,18 @@ class AnthropicRLHF(Dataset):
         major_split = split if "train" == split else "test"
         dataset = load_dataset("Anthropic/hh-rlhf")[major_split]
         for data in dataset:
-            prompt, pos_postfix = data["chosen"].split("Assistant:", maxsplit=1)
-            pos_postfix = pos_postfix.replace("\n\nHuman: ", sep_token).replace("\n\nAssistant: ", sep_token)
-            _, neg_postfix = data["rejected"].split("Assistant:", maxsplit=1)
-            neg_postfix = neg_postfix.replace("\n\nHuman: ", sep_token).replace("\n\nAssistant: ", sep_token)
+            processed = self.preprocess_dialogue(data["chosen"])
+            # roughly 20 of these are invalid conversation
+            if "Assistant" not in processed:
+                continue
+            prompt, pos_postfix = processed.split("Assistant:", maxsplit=1)
+            prompt = prompt.replace("Human: ", "").strip()
+            pos_postfix = pos_postfix.replace("Human: ", sep_token).replace("\n\nAssistant: ", sep_token).strip()
+            processed = self.preprocess_dialogue(data["rejected"])
+            if "Assistant" not in processed:
+                continue
+            _, neg_postfix = processed.split("Assistant:", maxsplit=1)
+            neg_postfix = neg_postfix.replace("Human: ", sep_token).replace("\n\nAssistant: ", sep_token).strip()
             self.pairs.append((prompt, (pos_postfix.strip(), neg_postfix.strip())))
 
     def __len__(self):

--- a/model/reward/instructor/tests/test_dataset.py
+++ b/model/reward/instructor/tests/test_dataset.py
@@ -1,5 +1,5 @@
 from experimental_dataset import DataCollatorForSummaryScore, HFSummaryQuality
-from rank_datasets import DataCollatorForPairRank, GPTJSynthetic, HFSummary, WebGPT
+from rank_datasets import AnthropicRLHF, DataCollatorForPairRank, GPTJSynthetic, HFSummary, WebGPT
 from torch.utils.data import DataLoader
 from transformers import AutoTokenizer
 
@@ -20,6 +20,16 @@ def test_webgpt():
     tokenizer = AutoTokenizer.from_pretrained("bigscience/mt0-large")
     collate_fn = DataCollatorForPairRank(tokenizer, max_length=200)
     dataset = WebGPT()
+    dataloader = DataLoader(dataset, collate_fn=collate_fn, batch_size=32)
+    for batch in dataloader:
+        print(batch["input_ids"].shape)
+
+
+def test_anthropic_rlhf():
+
+    tokenizer = AutoTokenizer.from_pretrained("bigscience/mt0-large")
+    collate_fn = DataCollatorForPairRank(tokenizer, max_length=200)
+    dataset = AnthropicRLHF("test", sep_token=tokenizer.sep_token)
     dataloader = DataLoader(dataset, collate_fn=collate_fn, batch_size=32)
     for batch in dataloader:
         print(batch["input_ids"].shape)

--- a/model/reward/instructor/trainer.py
+++ b/model/reward/instructor/trainer.py
@@ -155,7 +155,7 @@ if __name__ == "__main__":
     )
 
     tokenizer = get_tokenizer(training_conf["tokenizer_name"])
-    train, evals = get_datasets(training_conf["datasets"])
+    train, evals = get_datasets(training_conf["datasets"], tokenizer)
     if "rankgen" in model_name:
         collate_fn = RankGenCollator(tokenizer, max_length=training_conf["max_length"])
     else:

--- a/model/reward/instructor/utils.py
+++ b/model/reward/instructor/utils.py
@@ -81,21 +81,35 @@ def argument_parsing(parser):
         "learning_rate": 3e-5,
         "eval_steps": 500,
         "loss": "rank",
+        "warmup_steps": 500,
         "max_length": 440,
+        "weight_decay": 0.01,
+        "max_grad_norm": 2.0,
+        "save_steps": 500,
         "per_device_eval_batch_size": 5,
         "per_device_train_batch_size": 8,
         "gradient_accumulation_steps": 8,
         "gradient_checkpointing": False,
+        "deepspeed": args.deepspeed,
+        "local_rank": args.local_rank,
         "datasets": ["webgpt"],
+        "wandb_entity": args.wandb_entity,
         "fp16": True,
         "tokenizer_name": training_conf["model_name"],
     }
 
     params = {**default_params, **training_conf}
-    params["gradient_accumulation_steps"] = int(params["gradient_accumulation_steps"])
-    params["num_train_epochs"] = int(params["num_train_epochs"])
-    params["per_device_train_batch_size"] = int(params["per_device_train_batch_size"])
-    params["learning_rate"] = float(params["learning_rate"])
+    for name in [
+        "gradient_accumulation_steps",
+        "num_train_epochs",
+        "save_steps",
+        "per_device_train_batch_size",
+        "per_device_eval_batch_size",
+    ]:
+        params[name] = int(params[name])
+    for name in ["learning_rate", "weight_decay", "max_grad_norm"]:
+        params[name] = float(params[name])
+
     return params
 
 

--- a/model/reward/instructor/utils.py
+++ b/model/reward/instructor/utils.py
@@ -103,6 +103,7 @@ def argument_parsing(parser):
         "gradient_accumulation_steps",
         "num_train_epochs",
         "save_steps",
+        "eval_steps",
         "per_device_train_batch_size",
         "per_device_eval_batch_size",
     ]:
@@ -142,11 +143,3 @@ def get_datasets(dataset_list: List[AnyStr], tokenizer):
             evals["anthropic_rlhf"] = eval
     train = ConcatDataset(train_datasets)
     return train, evals
-
-
-if __name__ == "__main__":
-    from transformers import AutoModelForSequenceClassification
-
-    model = AutoModelForSequenceClassification.from_pretrained("bigscience/bloomz-560m")
-    freeze_top_n_layers(model, 10)
-    print(model.state_dict().keys())

--- a/model/reward/instructor/utils.py
+++ b/model/reward/instructor/utils.py
@@ -99,8 +99,8 @@ def argument_parsing(parser):
     return params
 
 
-def get_datasets(dataset_list: List[AnyStr]):
-    from rank_datasets import GPTJSynthetic, HFSummary, WebGPT
+def get_datasets(dataset_list: List[AnyStr], tokenizer):
+    from rank_datasets import AnthropicRLHF, GPTJSynthetic, HFSummary, WebGPT
     from torch.utils.data import ConcatDataset
 
     train_datasets, evals = [], {}
@@ -121,6 +121,11 @@ def get_datasets(dataset_list: List[AnyStr]):
             train, eval = train_val_dataset(dataset, 0.1)
             train_datasets.append(train)
             evals["gptsynthetic"] = eval
+        elif "anthropic_rlhf" == dataset_name:
+            train = AnthropicRLHF("train", tokenizer.sep_token)
+            eval = AnthropicRLHF("test", tokenizer.sep_token)
+            train_datasets.append(train)
+            evals["anthropic_rlhf"] = eval
     train = ConcatDataset(train_datasets)
     return train, evals
 


### PR DESCRIPTION
- Added [Anthropic/hh-rlhf](https://huggingface.co/datasets/Anthropic/hh-rlhf) to list of available RLHF datasets. 

- The new trainer also support deepspeed config via deepspeed flag ( same as supervised training ). 

```
deepspeed trainer.py configs/deberta-v2-xxlarge-a100.yml --deepspeed
```

I have ran deberta-v2-xxlarge model for 12 hours ([OA wandb](https://wandb.ai/open-assistant/reward-model?workspace=)) with no major issue except the validation seems to stuck with no apparent error, I feels like its a cuda deadlock or something since the GPU utilization was fix at 100% with no fluctuation. So a work around is simply save the needed checkpoint and run evaluation offline.
