### PR TITLE
website: Simplify isLoading handling

### DIFF
--- a/website/src/hooks/tasks/useGenericTaskAPI.tsx
+++ b/website/src/hooks/tasks/useGenericTaskAPI.tsx
@@ -7,19 +7,16 @@ import useSWRMutation from "swr/mutation";
 
 export const useGenericTaskAPI = <TaskType extends BaseTask>(taskType: TaskTypeEnum): TaskApiHook<TaskType> => {
   const [response, setReponse] = useState<TaskResponse<TaskType>>({ taskAvailability: "AWAITING_INITIAL" });
-  const [isLoading, setIsLoading] = useState(true);
-
-  const { mutate: requestNewTask } = useSWRImmutable<TaskAvailableResponse<TaskType>>(
+  // Note: We use isValidating to indiate we are loading beause it signals eash load, not just the first one.
+  const { isValidating: isLoading, mutate: requestNewTask } = useSWRImmutable<TaskAvailableResponse<TaskType>>(
     "/api/new_task/" + taskType,
     get,
     {
       onSuccess: (response) => {
-        setIsLoading(false);
         setReponse({ taskAvailability: "AVAILABLE", ...response });
       },
       onError: () => {
         // We could check for code 503 here for truely unavailable, but we need to do something with other errors anyway.
-        setIsLoading(false);
         setReponse({ taskAvailability: "NONE_AVAILABLE" });
       },
       revalidateOnMount: true,
@@ -29,12 +26,10 @@ export const useGenericTaskAPI = <TaskType extends BaseTask>(taskType: TaskTypeE
 
   const { trigger: completeTask } = useSWRMutation<TaskAvailableResponse<TaskType>>("/api/update_task", post, {
     onSuccess: () => {
-      setIsLoading(true);
       requestNewTask();
     },
     onError: () => {
       // We could check for code 503 here for truely unavailable, but we need to do something with other errors anyway.
-      setIsLoading(false);
       setReponse({ taskAvailability: "NONE_AVAILABLE" });
     },
   });


### PR DESCRIPTION
As a follow up to this comment (https://github.com/LAION-AI/Open-Assistant/pull/970#discussion_r1089880512) in #970 I read up more on useSWR and realised the behavior we wanted is provided by isValidating. I still thought it deserved a comment as renaming isValidating isLoading is still a bit odd.