### PR TITLE
website: Fix crash on reopen labelling after submitting

### DIFF
--- a/website/src/components/Messages/LabelPopup.tsx
+++ b/website/src/components/Messages/LabelPopup.tsx
@@ -51,7 +51,7 @@ export const LabelMessagePopup = ({ messageId, show, onClose }: LabelMessagePopu
       label_map: Object.fromEntries(label_map),
     });
 
-    setValues(null);
+    setValues(new Array(values.length).fill(null));
     onClose();
   };
 


### PR DESCRIPTION
There is a crash in the on demand message labeling workflow.

Steps to reproduce:
1. Use the ... on a message to label it, submit the labels
2. Attempt to reopen the labeling popup, crash.

Note this is not an opinion on whether the user should label twice, but at a minimum it shouldn't crash and take them away from the task that they were doing when they initiated on demand labeling.