### PR TITLE
website: Fix regression in accepting initial rankings

### DIFF
--- a/website/src/components/Tasks/Task/Task.tsx
+++ b/website/src/components/Tasks/Task/Task.tsx
@@ -74,7 +74,7 @@ export const Task = () => {
     ): TaskStatus => {
       switch (event.action) {
         case "NEW_TASK":
-          return { mode: "EDIT", replyValidity: "INVALID" };
+          return status.mode !== "EDIT" ? { mode: "EDIT", replyValidity: "INVALID" } : status;
         case "UPDATE_VALIDITY":
           return status.mode === "EDIT" ? { mode: "EDIT", replyValidity: event.replyValidity } : status;
         case "ACCEPT_DEFAULT":


### PR DESCRIPTION
Fix regression that broke the ability to review unchanged rankings. Normally the user should just get a warning that they haven't made a change, they can accept the warning and continue anyway. This must have been broken recently and the review button was instead disabled until the user moved one of the rankable items.

This was caused by the init effect in Task.tsx running _after_ the task submits it's default reply validity as part of it's init effect.

Clearly we need to refactor the way Task.tsx works. One of the main reasons for the complexity in Task.tsx is to avoid triggering re-rendering of the task inputs on every character the user types. Maybe moving to something like the form control from chakra would help or maybe we just need to move the user inputs and the submit button to the same level so that we don't need to pass state up and events down.