### PR TITLE
website: changed the UI label for failed answer to avoid implicit negative

### DIFF
--- a/website/public/locales/de/labelling.json
+++ b/website/public/locales/de/labelling.json
@@ -6,7 +6,7 @@
   "label_message_flag_instruction": "Wählen Sie aus, was auf die Nachricht zutrifft:",
   "label_message_likert_instruction": "Nachricht bewerten:",
   "spam.question": "Ist die Nachricht Spam?",
-  "fails_task.question": "Verfehlt die Antwort die Aufgabe des Nutzers?",
+  "fails_task.question": "Ist es eine schlechte Antwort, wenn man die Aufgabe sieht?",
   "not_appropriate": "Nicht angemessen",
   "pii": "Personenbezogene Daten",
   "hate_speech": "Hassrede",

--- a/website/public/locales/en/labelling.json
+++ b/website/public/locales/en/labelling.json
@@ -6,7 +6,7 @@
   "label_message_flag_instruction": "Select any that apply to the message:",
   "label_message_likert_instruction": "Rate the message:",
   "spam.question": "Is the message spam?",
-  "fails_task.question": "Does the reply fail the prompter's task?",
+  "fails_task.question": "Is it a bad reply, as an answer to the prompt task?",
   "not_appropriate": "Not Appropriate",
   "pii": "Contains PII",
   "hate_speech": "Hate Speech",

--- a/website/public/locales/es/labelling.json
+++ b/website/public/locales/es/labelling.json
@@ -6,11 +6,11 @@
   "label_message_flag_instruction": "Selecciona cualquiera que sea adecuada para el mensaje:",
   "label_message_likert_instruction": "Califica el mensaje:",
   "spam.question": "¿Es el mensaje spam?",
-  "fails_task.question": "¿Fracasa la respuesta en la tarea de las instrucciones?",
+  "fails_task.question": "¿Es una mala respuesta, según la tarea pedida?",
   "not_appropriate": "No apropiada",
   "pii": "Contiene información de identificación personal (PII)",
   "hate_speech": "Incitación al odio",
   "sexual_content": "Contenido sexual",
   "moral_judgement": "Juzga moralmente",
-  "political_content": "Político"
+  "political_content": "Contenido político"
 }


### PR DESCRIPTION
The existing label to tag the bot reply:

_Does the reply fail the prompter's task?_

is somehow confusing: the tag when the bot reply is correct should be `No` (since it has **not** failed the task). That is, the question is an implicit negative ("fail"), which makes thinking about the correct tag more difficult.

I propose to change it to a more direct question:

_Is it a bad reply, as an answer to the prompt task?_

... which makes the tag more unambigouos, while keeping the semantics of the tag: saying "Yes" means it's _bad_, saying "No" means it's a _good_ reply. It's also better aligned with the other question _Is it spam?_

PS: Please review the label for German, I'm not confident enough it's correct.