### PR TITLE
Fix #1034, split into paragraphs for full text view.

### DIFF
--- a/backend/test_data/realistic/realistic_seed_data.json
+++ b/backend/test_data/realistic/realistic_seed_data.json
@@ -2999,7 +2999,7 @@
     "task_message_id": "z79vpkaj",
     "user_message_id": "gl1xayyu",
     "parent_message_id": "di54e1nb",
-    "text": "I know Singapore is a tiny island just south of Malaysia, which has an estimated population of around 5 million.  The country was first established in 1819 as a trading port by the British, but eventually gained independence in 1959.  The main language is \u201cEnglish\u201d, and while the country has many different ethnic groups, most of the population is ethnically Chinese.  The capital is \u201cSingapore\u201d (this is the same as the country\u2019s name), and this city is where you\u2019ll be based for your business meetings.  It\u2019s the largest and most developed city in the country.",
+    "text": "I know Singapore is a tiny island just south of Malaysia, which has an estimated population of around 5 million. \n The country was first established in 1819 as a trading port by the British, but eventually gained independence in 1959.  The main language is \u201cEnglish\u201d, and while the country has many different ethnic groups, most of the population is ethnically Chinese.  The capital is \u201cSingapore\u201d (this is the same as the country\u2019s name), and this city is where you\u2019ll be based for your business meetings.  It\u2019s the largest and most developed city in the country.",
     "role": "assistant"
   },
   {

--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -29,7 +29,7 @@ export const CollapsableText = ({
   if (typeof text !== "string" || text.length <= maxLength) {
     return <>{text}</>;
   } else {
-    const text_with_breaks = text.split('\n').map((str, index) => <p key={index}>{str}</p>);
+    const text_with_breaks = text.split("\n").map((str, index) => <p key={index}>{str}</p>);
     return (
       <>
         <span>

--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -29,6 +29,7 @@ export const CollapsableText = ({
   if (typeof text !== "string" || text.length <= maxLength) {
     return <>{text}</>;
   } else {
+    const text_with_breaks = text.split('\n').map((str, index) => <p key={index}>{str}</p>);
     return (
       <>
         <span>
@@ -51,7 +52,7 @@ export const CollapsableText = ({
             <ModalContent alignItems="center">
               <ModalHeader>Full Text</ModalHeader>
               <ModalCloseButton />
-              <ModalBody>{text}</ModalBody>
+              <ModalBody>{text_with_breaks}</ModalBody>
             </ModalContent>
           </ModalOverlay>
         </Modal>


### PR DESCRIPTION
This should fix issue #1034. Text is split into paragraphs now, without any additional styling. The change in the dataset was used for testing.