### PR TITLE
hide system emojis starting with '_'

### DIFF
--- a/website/src/components/Messages/MessageTableEntry.tsx
+++ b/website/src/components/Messages/MessageTableEntry.tsx
@@ -98,7 +98,7 @@ export function MessageTableEntry({ message, enabled, highlight }: MessageTableE
           onClick={(e) => e.stopPropagation()}
         >
           {Object.entries(emojiState.emojis)
-            .filter(([k, _]) => !k.startsWith("_"))
+            .filter(([k]) => !k.startsWith("_"))
             .map(([emoji, count]) => (
               <MessageEmojiButton
                 key={emoji}

--- a/website/src/components/Messages/MessageTableEntry.tsx
+++ b/website/src/components/Messages/MessageTableEntry.tsx
@@ -97,14 +97,16 @@ export function MessageTableEntry({ message, enabled, highlight }: MessageTableE
           style={{ float: "right", position: "relative", right: "-0.3em", bottom: "-0em", marginLeft: "1em" }}
           onClick={(e) => e.stopPropagation()}
         >
-          {Object.entries(emojiState.emojis).map(([emoji, count]) => (
-            <MessageEmojiButton
-              key={emoji}
-              emoji={{ name: emoji, count }}
-              checked={emojiState.user_emojis.includes(emoji)}
-              onClick={() => react(emoji, !emojiState.user_emojis.includes(emoji))}
-            />
-          ))}
+          {Object.entries(emojiState.emojis)
+            .filter(([k, _]) => !k.startsWith("_"))
+            .map(([emoji, count]) => (
+              <MessageEmojiButton
+                key={emoji}
+                emoji={{ name: emoji, count }}
+                checked={emojiState.user_emojis.includes(emoji)}
+                onClick={() => react(emoji, !emojiState.user_emojis.includes(emoji))}
+              />
+            ))}
           <MessageActions
             react={react}
             userEmoji={emojiState.user_emojis}


### PR DESCRIPTION
The skip state of messages is stored in special emoji codes... currently they show up as undefined emojis:

![image](https://user-images.githubusercontent.com/9976399/216200377-58729187-e1a6-45da-9dd9-3aaf10ad1528.png)

This PR filters emoji-codes with "_" prefix.