### PR TITLE
website: Fix bug introduced into optimised build in recent emoji cleanup

### DIFF
--- a/website/src/components/Messages/MessageEmojiButton.tsx
+++ b/website/src/components/Messages/MessageEmojiButton.tsx
@@ -9,7 +9,7 @@ interface MessageEmojiButtonProps {
 }
 
 export const MessageEmojiButton = ({ emoji, checked, onClick }: MessageEmojiButtonProps) => {
-  const EmojiIcon = emojiIcons[emoji.name];
+  const EmojiIcon = emojiIcons.get(emoji.name);
   if (!EmojiIcon) return <></>;
   return (
     <Button

--- a/website/src/components/Messages/MessageTableEntry.tsx
+++ b/website/src/components/Messages/MessageTableEntry.tsx
@@ -134,7 +134,7 @@ const EmojiMenuItem = ({
   react: (emoji: string, state: boolean) => void;
 }) => {
   const activeColor = useColorModeValue(colors.light.active, colors.dark.active);
-  const EmojiIcon = emojiIcons[emoji];
+  const EmojiIcon = emojiIcons.get(emoji);
   return (
     <MenuItem onClick={() => react(emoji, !checked)} justifyContent="center" color={checked ? activeColor : undefined}>
       <EmojiIcon />

--- a/website/src/types/Emoji.ts
+++ b/website/src/types/Emoji.ts
@@ -1,10 +1,12 @@
 import { Flag, LucideIcon, ThumbsDown, ThumbsUp } from "lucide-react";
 
-export const emojiIcons: { [emoji: string]: LucideIcon } = {
-  "+1": ThumbsUp,
-  "-1": ThumbsDown,
-  flag: Flag,
-  red_flag: Flag,
-};
+// Note: we use a Map here rather than just an object because the optimised
+// build "optimises" +1 to just 1 in the emoji name.
+export const emojiIcons = new Map<string, LucideIcon>([
+  ["+1", ThumbsUp],
+  ["-1", ThumbsDown],
+  ["flag", Flag],
+  ["red_flag", Flag],
+]);
 
-export const isKnownEmoji = (emoji: string) => !!emojiIcons[emoji];
+export const isKnownEmoji = (emoji: string) => emojiIcons.has(emoji);


### PR DESCRIPTION
Fixes bug introduced in #1082.

The issue was the optimised build was optimising the "+1" object key name to just "1" causing the context menu to try to shown an undefined emoji icon.