### PR TITLE
website: Fix locales side menu hydration error

### DIFF
--- a/website/public/locales/en/common.json
+++ b/website/public/locales/en/common.json
@@ -5,6 +5,7 @@
   "connect": "Connect",
   "conversational": "Conversational AI for everyone.",
   "dashboard": "Dashboard",
+  "delete": "Delete",
   "discord": "Discord",
   "docs": "Docs",
   "github": "GitHub",
@@ -19,5 +20,6 @@
   "terms_of_service": "Terms of Service",
   "title": "Open Assistant",
   "yes": "Yes",
-  "delete": "Delete"
+  "dark_mode": "Dark Mode",
+  "light_mode": "Light Mode"
 }

--- a/website/public/locales/en/side_menu.json
+++ b/website/public/locales/en/side_menu.json
@@ -8,7 +8,5 @@
   "users": "Users",
   "users_dashboard": "Users Dashboard",
   "status": "Status",
-  "status_dashboard": "Status Dashboard",
-  "dark_mode": "Dark Mode",
-  "ligth_mode": "Ligth Mode"
+  "status_dashboard": "Status Dashboard"
 }

--- a/website/public/locales/es/common.json
+++ b/website/public/locales/es/common.json
@@ -18,5 +18,7 @@
   "sign_out": "Cerrar sesión",
   "terms_of_service": "Términos de servicio",
   "title": "Open Assistant",
-  "yes": "Sí"
+  "yes": "Sí",
+  "dark_mode": "Modo oscuro",
+  "light_mode": "Modo claro"
 }

--- a/website/public/locales/es/side_menu.json
+++ b/website/public/locales/es/side_menu.json
@@ -8,7 +8,5 @@
   "users": "Usuarios",
   "users_dashboard": "Tablón de usuarios",
   "status": "Estado",
-  "status_dashboard": "Tablón de estado",
-  "dark_mode": "Modo oscuro",
-  "ligth_mode": "Modo claro"
+  "status_dashboard": "Tablón de estado"
 }

--- a/website/src/components/SideMenu.tsx
+++ b/website/src/components/SideMenu.tsx
@@ -17,7 +17,7 @@ export interface SideMenuProps {
 export function SideMenu(props: SideMenuProps) {
   const router = useRouter();
   const { colorMode, toggleColorMode } = useColorMode();
-  const { t } = useTranslation(["side_menu"]);
+  const { t } = useTranslation(["side_menu", "common"]);
 
   return (
     <main className="sticky top-0 sm:h-full">
@@ -62,7 +62,7 @@ export function SideMenu(props: SideMenuProps) {
             <Button size="lg" width="full" justifyContent="center" onClick={toggleColorMode} gap="2">
               <Sun size={"1em"} />
               <Text fontWeight="normal" className="hidden lg:block">
-                {colorMode === "light" ? t("dark_mode") : t("ligth_mode")}
+                {colorMode === "light" ? t("common:dark_mode") : t("common:light_mode")}
               </Text>
             </Button>
           </Tooltip>


### PR DESCRIPTION
Hey!

An issue with the `/messages/[id]` endpoint was introduced in #1079, causing a problem with SSR hydration. To reproduce refresh the page on the `/messages/[id]` page. Additionally, duplicate translation keys were added, such as "dashboard" in both `side_menu.json` and `dashboard.json`. To resolve this, it is recommended to move common translations to the `common.json` file and also include any necessary SSR translations here. This pull request resolves the SSR hydration issue.