### PR TITLE
Language detection CLI

### DIFF
--- a/backend/oasst_backend/utils/language_classification.py
+++ b/backend/oasst_backend/utils/language_classification.py
@@ -1,0 +1,111 @@
+import os
+import pickle
+from collections import Counter
+
+from sklearn import metrics
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.model_selection import train_test_split
+from sklearn.pipeline import Pipeline
+from sklearn.svm import LinearSVC
+
+
+def load_and_split(foldername, num_words):
+    ls = os.listdir(foldername)
+    X = []
+    Y = []
+    langmap = dict()
+    for idx, x in enumerate(ls):
+        print("loading language", x)
+        with open(foldername + "/" + x, "r") as reader:
+            tmp = reader.read().split(" ")
+            tmp = [" ".join(tmp[i : i + num_words]) for i in range(0, 100_000, num_words)]
+            X.extend(tmp)
+            Y.extend([idx] * len(tmp))
+            langmap[idx] = x
+    x_train, x_test, y_train, y_test = train_test_split(X, Y, test_size=0.90)
+    return x_train, x_test, y_train, y_test, langmap
+
+
+def build_and_train_pipeline(x_train, y_train):
+    vectorizer = TfidfVectorizer(ngram_range=(1, 2), analyzer="char", use_idf=False)
+    clf = Pipeline(
+        [
+            ("vec", vectorizer),
+            # ("nystrom", Nystroem(n_components=1000,n_jobs=6)),
+            ("clf", LinearSVC(C=0.5)),
+            # ("clf",GaussianNB())
+            # ("clf", HistGradientBoostingClassifier())
+        ]
+    )
+    print("fitting model...")
+    clf.fit(x_train, y_train)
+    return clf
+
+
+def benchmark(clf, x_test, y_test, langmap):
+    print("benchmarking model...")
+    y_pred = clf.predict(x_test)
+    names = list(langmap.values())
+    # print(y_test)
+    # print(langmap)
+    print(metrics.classification_report(y_test, y_pred, target_names=names))
+    cm = metrics.confusion_matrix(y_test, y_pred)
+    print(cm)
+
+
+def main(foldername, modelname, num_words):
+    x_train, x_test, y_train, y_test, langmap = load_and_split(foldername=foldername, num_words=num_words)
+    clf = build_and_train_pipeline(x_train, y_train)
+    benchmark(clf, x_test, y_test, langmap)
+    save_model(clf, langmap, num_words, modelname)
+    model = load(modelname)
+    print(
+        "running infernence on long tests",
+        inference_voter(
+            model,
+            """
+    What language is this text written in? Nobody knows until you fill in at least ten words.
+    This test here is to check whether the moving window approach works,
+    so I still need to fill in a little more text.
+    """,
+        ),
+    )
+
+
+def load(modelname):
+    with open(modelname, "rb") as writer:
+        data = pickle.load(writer)
+    return data
+
+
+def save_model(model, idx_to_name, num_words, modelname):
+    out = {
+        "model": model,
+        "idx_to_name": idx_to_name,
+        "num_words": num_words,
+    }
+    with open(modelname, "wb") as writer:
+        pickle.dump(out, writer)
+
+
+def inference_voter(model, text):
+    tmp = text.split()
+    # print(len(tmp), tmp)
+    tmp = [" ".join(tmp[i : i + model["num_words"]]) for i in range(0, len(tmp) - model["num_words"])]
+    predictions = model["model"].predict(tmp)
+    # print("integer predictions", predictions)
+    # print("name predictions", *[model["idx_to_name"][n] for n in predictions])
+    result = Counter(predictions).most_common(1)[0][0]
+    return model["idx_to_name"][result]
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-m", "--model", help="save location for model and metadata")
+    parser.add_argument("-d", "--data", help="specify the folder for data files")
+    parser.add_argument("-n", "--num_words", help="number of words to use for statistics", type=int)
+    args = parser.parse_args()
+    # np.set_printoptions(threshold=np.inf)
+    main(args.data, args.model, args.num_words)

--- a/backend/oasst_backend/utils/language_classification.py
+++ b/backend/oasst_backend/utils/language_classification.py
@@ -1,44 +1,68 @@
+import json
 import os
 import pickle
 from collections import Counter
 
 from sklearn import metrics
+from sklearn.decomposition import TruncatedSVD
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 from sklearn.svm import LinearSVC
 
 
-def load_and_split(foldername, num_words):
+def load_and_split(foldername, num_words, whitelist):
     ls = os.listdir(foldername)
     X = []
     Y = []
     langmap = dict()
-    for idx, x in enumerate(ls):
+    idx = 0
+    for x in ls:
+        if whitelist is not None:
+            if x in whitelist:
+                whitelist.remove(x)
+            else:
+                continue
         print("loading language", x)
+        idx += 1
         with open(foldername + "/" + x, "r") as reader:
             tmp = reader.read().split(" ")
             tmp = [" ".join(tmp[i : i + num_words]) for i in range(0, 100_000, num_words)]
             X.extend(tmp)
             Y.extend([idx] * len(tmp))
             langmap[idx] = x
-    x_train, x_test, y_train, y_test = train_test_split(X, Y, test_size=0.90)
+    print("remaining languages", whitelist)
+    x_train, x_test, y_train, y_test = train_test_split(X, Y, test_size=0.80)
     return x_train, x_test, y_train, y_test, langmap
 
 
 def build_and_train_pipeline(x_train, y_train):
-    vectorizer = TfidfVectorizer(ngram_range=(1, 2), analyzer="char", use_idf=False)
+    vectorizer = TfidfVectorizer(ngram_range=(1, 3), analyzer="char", use_idf=False)
+    print(len(x_train))
     clf = Pipeline(
         [
             ("vec", vectorizer),
-            # ("nystrom", Nystroem(n_components=1000,n_jobs=6)),
-            ("clf", LinearSVC(C=0.5)),
+            (
+                "dim_reduction1",
+                TruncatedSVD(
+                    50,
+                    n_iter=10,
+                ),
+            ),
+            ("standardization", StandardScaler()),
+            # ("transform",PolynomialCountSketch(n_components=400)),
+            # ("nystrom", Nystroem(n_components=1000)),
+            # penalty="l1",dual=False,tol=1e-3
+            ("clf", LinearSVC(C=0.5, max_iter=10_000, tol=1e-3)),
             # ("clf",GaussianNB())
-            # ("clf", HistGradientBoostingClassifier())
+            # ("clf", HistGradientBoostingClassifier(max_iter=100))
         ]
     )
     print("fitting model...")
     clf.fit(x_train, y_train)
+    print("fitted model with sparsity degree of", (clf["clf"].coef_ == 0).mean())
+    # clf["clf"].sparsify()
     return clf
 
 
@@ -54,9 +78,28 @@ def benchmark(clf, x_test, y_test, langmap):
 
 
 def main(foldername, modelname, num_words):
-    x_train, x_test, y_train, y_test, langmap = load_and_split(foldername=foldername, num_words=num_words)
+    whitelist_language = [
+        "English",
+        "Bengali",
+        "German",
+        "Spanish",
+        "French",
+        "Hungarian",
+        "Japanese",
+        "Portuguese",
+        "Russian",
+        "Vietnamese",
+        "Chinese",
+    ]
+    x_train, x_test, y_train, y_test, langmap = load_and_split(
+        foldername=foldername, num_words=num_words, whitelist=whitelist_language
+    )
     clf = build_and_train_pipeline(x_train, y_train)
+    import time
+
+    t = time.time()
     benchmark(clf, x_test, y_test, langmap)
+    print("Ours time taken", time.time() - t)
     save_model(clf, langmap, num_words, modelname)
     model = load(modelname)
     print(
@@ -70,6 +113,7 @@ def main(foldername, modelname, num_words):
     """,
         ),
     )
+    return model
 
 
 def load(modelname):
@@ -88,24 +132,107 @@ def save_model(model, idx_to_name, num_words, modelname):
         pickle.dump(out, writer)
 
 
-def inference_voter(model, text):
+def inference_voter(model, text, converter=None):
     tmp = text.split()
     # print(len(tmp), tmp)
     tmp = [" ".join(tmp[i : i + model["num_words"]]) for i in range(0, len(tmp) - model["num_words"])]
+    if len(tmp) <= model["num_words"]:
+        return None, 0
     predictions = model["model"].predict(tmp)
     # print("integer predictions", predictions)
     # print("name predictions", *[model["idx_to_name"][n] for n in predictions])
-    result = Counter(predictions).most_common(1)[0][0]
-    return model["idx_to_name"][result]
+    result = Counter(predictions).most_common(1)[0]
+    if converter is None:
+        return model["idx_to_name"][result[0]], result[1] / len(tmp)
+    return converter[model["idx_to_name"][result[0]]], result[1] / len(tmp)
+
+
+def infere_names(model, json_path, converter):
+    with open(json_path, "r") as json_file:
+        json_list = list(json_file)
+    correction_results = []
+    corrected_json = []
+    for json_str in json_list:
+        print("step")
+        js = json.loads(json_str)
+        js, reps = helper(model, js, converter)
+        # print(reps)
+        correction_results.extend(reps)
+        corrected_json.append(js)
+    return corrected_json, correction_results
+
+
+def helper(model, js, converter):
+    if js.get("prompt", None) is not None:
+        return helper(model, js["prompt"], converter=converter)
+    elif js.get("replies", None) is not None:
+        # print("replies path")
+        # print(js["text"])
+        # print("checking text:",js["text"])
+        lang, confidence = inference_voter(model, js["text"], converter=converter)
+        tmp = [
+            {
+                "predicted lang": lang,
+                "confidence": confidence,
+                "expected lang": js["lang"],
+                "message_id": js["message_id"],
+                "text": js["text"],
+            }
+        ]
+        reps = []
+        for j in js["replies"]:
+            dc, ls = helper(model, j, converter=converter)
+            reps.append(dc)
+            tmp = tmp + ls
+        js["lang"] = lang if lang is not None else js["lang"]
+        js["replies"] = reps
+        return js, tmp
+    else:
+        return js, []
 
 
 if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser()
+
     parser.add_argument("-m", "--model", help="save location for model and metadata")
+    parser.add_argument(
+        "-t",
+        "--test_data",
+        help="json file containing test data",
+    )
+    parser.add_argument("-l", "--load", help="load model instead of training one", action="store_true")
     parser.add_argument("-d", "--data", help="specify the folder for data files")
     parser.add_argument("-n", "--num_words", help="number of words to use for statistics", type=int)
     args = parser.parse_args()
     # np.set_printoptions(threshold=np.inf)
-    main(args.data, args.model, args.num_words)
+    model = None
+    if not args.load:
+        model = main(args.data, args.model, args.num_words)
+    else:
+        model = load(args.model)
+    converter = {
+        "English": "en",
+        "Bengali": "bn",
+        "German": "de",
+        "Spanish": "es",
+        "French": "fr",
+        "Hungarian": "hu",
+        "Japanese": "ja",
+        "Portuguese": "pt-BR",
+        "Russian": "ru",
+        "Vietnamese": "vi",
+        "Chinese": "zh",
+    }
+    corrected_json, correction_results = infere_names(model, args.test_data, converter)
+    for m in correction_results:
+        if m["predicted lang"] != m["expected lang"] and m["predicted lang"] is not None:
+            print(
+                "mismatch",
+                m["predicted lang"],
+                m["expected lang"],
+                m["message_id"],
+                m["confidence"],
+                m["text"][:50].replace("\n", "\\n"),
+            )


### PR DESCRIPTION
Method to run language classification on a json list file via CLI.
Output is an already fixed dictionary (use with caution: the model is not 100% accurate, especially when it comes to e.g. mathematical notation), and a list of dictonaries containing
- predicted lang, the predicted language
- confidence, the confidence of the classification as produced by the feature-subsampling process
- expected lang, the language that was set in the original message
- message_id, the message id associated with that message
- text, the text of that message

The CLI is built to allow either training a new model and doing inference on the jsonlist, or loading an existing model from a file. 
To use the CLI you have to set
- "--model" which is the save/load location for the model
- "--test_data" which is where the json you want to evaluate lies
- "--num_words" which is how many words are supposed to be used for the character-level statistics. Setting this higher will generally give better results, but also will filter out more examples since I skip messages with less than "num_words" words. Set to something between 5 and 10.

For training you further need to set "--data" which is where the training data lives (I'm using https://lukelindemann.com/wiki_corpus.html). If you just want to load an existing model, use "--load" which will skip the training step and instead use the pretrained model in "--model".

The CLI outputs a formatted list of all mismatched languages.
If you want to use this in another script, use `infere_names(model,json_path,converter)`, where "model" is the model loaded (convenience method `load(modelname)` exists), "json_path" is where you place your data to be checked and "converter" converts the full-length language names, like "English" to their language code "en".

