### PR TITLE
Add message counts grouped by lang tag to system stats query

### DIFF
--- a/backend/oasst_backend/prompt_repository.py
+++ b/backend/oasst_backend/prompt_repository.py
@@ -1012,7 +1012,9 @@ WHERE message.id = cc.id;
         number of deleted and active messages and number of message trees.
         """
         # With columns: lang, deleted, count
-        group_count_query = self.db.query(Message.lang, Message.deleted, func.count()).group_by(Message.lang, Message.deleted)
+        group_count_query = self.db.query(Message.lang, Message.deleted, func.count()).group_by(
+            Message.lang, Message.deleted
+        )
         # With columns: None, None, count
         msg_tree_query = self.db.query(None, None, func.count(Message.id)).filter(Message.parent_id.is_(None))
         # Union both queries, so that we can fetch the counts in one database query
@@ -1022,9 +1024,9 @@ WHERE message.id = cc.id;
         ndeleted = 0
         nactives_by_lang = {}
         nthreads = 0
-        
+
         for lang, deleted, count in query.all():
-            if lang is None: # corresponds to msg_tree_query
+            if lang is None:  # corresponds to msg_tree_query
                 nthreads = count
                 continue
             if deleted is False:  # corresponds to group_count_query (lang, deleted=False)
@@ -1032,7 +1034,7 @@ WHERE message.id = cc.id;
                 nactives += count
             else:  # corresponds to group_count_query (lang, deleted=True)
                 ndeleted += count
-                
+
         return SystemStats(
             all=nactives + ndeleted,
             active=nactives,

--- a/backend/oasst_backend/prompt_repository.py
+++ b/backend/oasst_backend/prompt_repository.py
@@ -1011,16 +1011,34 @@ WHERE message.id = cc.id;
         Get data stats such as number of all messages in the system,
         number of deleted and active messages and number of message trees.
         """
-        deleted = self.db.query(Message.deleted, func.count()).group_by(Message.deleted)
-        nthreads = self.db.query(None, func.count(Message.id)).filter(Message.parent_id.is_(None))
-        query = deleted.union_all(nthreads)
-        result = {k: v for k, v in query.all()}
+        # With columns: lang, deleted, count
+        group_count_query = self.db.query(Message.lang, Message.deleted, func.count()).group_by(Message.lang, Message.deleted)
+        # With columns: None, None, count
+        msg_tree_query = self.db.query(None, None, func.count(Message.id)).filter(Message.parent_id.is_(None))
+        # Union both queries, so that we can fetch the counts in one database query
+        query = group_count_query.union_all(msg_tree_query)
 
+        nactives = 0
+        ndeleted = 0
+        nactives_by_lang = {}
+        nthreads = 0
+        
+        for lang, deleted, count in query.all():
+            if lang is None: # corresponds to msg_tree_query
+                nthreads = count
+                continue
+            if deleted is False:  # corresponds to group_count_query (lang, deleted=False)
+                nactives_by_lang[lang] = count
+                nactives += count
+            else:  # corresponds to group_count_query (lang, deleted=True)
+                ndeleted += count
+                
         return SystemStats(
-            all=result.get(True, 0) + result.get(False, 0),
-            active=result.get(False, 0),
-            deleted=result.get(True, 0),
-            message_trees=result.get(None, 0),
+            all=nactives + ndeleted,
+            active=nactives,
+            active_by_lang=nactives_by_lang,
+            deleted=ndeleted,
+            message_trees=nthreads,
         )
 
     @managed_tx_method()

--- a/oasst-shared/oasst_shared/schemas/protocol.py
+++ b/oasst-shared/oasst_shared/schemas/protocol.py
@@ -436,6 +436,7 @@ AnyInteraction = Union[
 class SystemStats(BaseModel):
     all: int = 0
     active: int = 0
+    active_by_lang: dict[str, int] = {}
     deleted: int = 0
     message_trees: int = 0
 


### PR DESCRIPTION
Related issue:
https://github.com/LAION-AI/Open-Assistant/issues/904
https://github.com/orgs/LAION-AI/projects/3/views/1?filterQuery=grouped&pane=issue&itemId=18706688

Result:
<img width="1516" alt="Screenshot 2023-02-05 at 1 30 09 AM" src="https://user-images.githubusercontent.com/11500136/216781213-86a8dd78-9164-482c-aa8f-4af0634c8219.png">

It is also easy to add `deleted_by_lang` do we need it?