### PR TITLE
Update README with quick howto for data collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ improving language itself.
 
 ## Do you want to try it out?
 
+### Contributing to Data Collection
+
+The data collection frontend is now live [here](https://open-assistant.io/).
+Log in and start taking on tasks! We want to collect a high volume of quality
+data. By submitting, ranking, and labelling model prompts and responses you
+will be directly helping to improve the capabilities of Open Assistant.
+
+### Running Locally
+
 If you are interested in taking a look at the current state of the project, you
 can set up an entire stack needed to run **Open-Assistant**, including the
 website, backend, and associated dependent services.

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ improving language itself.
 
 ### Contributing to Data Collection
 
-The data collection frontend is now live [here](https://open-assistant.io/).
-Log in and start taking on tasks! We want to collect a high volume of quality
-data. By submitting, ranking, and labelling model prompts and responses you
-will be directly helping to improve the capabilities of Open Assistant.
+The data collection frontend is now live [here](https://open-assistant.io/). Log
+in and start taking on tasks! We want to collect a high volume of quality data.
+By submitting, ranking, and labelling model prompts and responses you will be
+directly helping to improve the capabilities of Open Assistant.
 
 ### Running Locally
 


### PR DESCRIPTION
Currently the main README only contains information on running the project locally for development. This PR adds a note on where to go to contribute to the data collection, to help point potential contributors who find the project through GitHub in the right direction.