### PR TITLE
Show a bit more text for the ranking options

### DIFF
--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -1,5 +1,6 @@
 import {
   Button,
+  Tooltip,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -23,6 +24,7 @@ export const CollapsableText = ({
   isDisabled?: boolean;
 }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
+  const finalRef = React.useRef(null);
 
   const moreButtonColor = useColorModeValue("gray.600", "gray.400");
 
@@ -31,24 +33,33 @@ export const CollapsableText = ({
   } else {
     return (
       <>
-        <span>
+        <span ref={finalRef}>
           {text.substring(0, maxLength - 3)}&nbsp;
-          <Button
-            style={{ display: "inline" }}
-            size={"xs"}
-            variant={"solid"}
-            bg={moreButtonColor}
-            color={"white"}
-            isDisabled={isDisabled}
-            onClick={onOpen}
-          >
-            ...
-          </Button>
+          <Tooltip label={text} size="lg">
+            <Button
+              style={{ display: "inline" }}
+              size={"xs"}
+              variant={"solid"}
+              bg={moreButtonColor}
+              color={"white"}
+              isDisabled={isDisabled}
+              onClick={onOpen}
+            >
+              ...
+            </Button>
+          </Tooltip>
         </span>
-        <Modal isOpen={isOpen} onClose={onClose} size="xl" scrollBehavior={"inside"}>
+        <Modal
+          finalFocusRef={finalRef}
+          isOpen={isOpen}
+          onClose={onClose}
+          size="xl"
+          scrollBehavior={"inside"}
+          isCentered
+        >
           {/* we kill the event here to disable drag and drop, since it is in the same container */}
           <ModalOverlay onMouseDown={killEvent}>
-            <ModalContent alignItems="center">
+            <ModalContent pb={5} alignItems="center">
               <ModalHeader>Full Text</ModalHeader>
               <ModalCloseButton />
               <ModalBody style={{ whiteSpace: "pre-line" }}>{text}</ModalBody>


### PR DESCRIPTION
Related to this issue: #969 

- Centering the modal vertically to reduce user's mouse movement
- Add padding-bottom to the modal
- Add Tooltips to show text on hover

<img width="1516" alt="Screenshot 2023-02-05 at 3 33 47 AM" src="https://user-images.githubusercontent.com/11500136/216786358-93bf6282-4128-43f0-ba5c-b70ee99d6dc5.png">

<img width="1516" alt="Screenshot 2023-02-05 at 3 33 59 AM" src="https://user-images.githubusercontent.com/11500136/216786365-b8f0d44c-34e7-46e3-aa95-620eb9d45845.png">
