### PR TITLE
Putting a button for toggling the light/dark color mode right into the navigation bar

### DIFF
--- a/website/src/components/Header/ColorModeToggler.jsx
+++ b/website/src/components/Header/ColorModeToggler.jsx
@@ -5,8 +5,8 @@ const ColorModeToggler = () => {
   const { colorMode, toggleColorMode } = useColorMode();
 
   return (
-    <Button size="md" width="70px" justifyContent="center" onClick={toggleColorMode} gap="4" variant="ghost">
-      <Sun size={"2em"} />
+    <Button size="md" p="0px" justifyContent="center" onClick={toggleColorMode} gap="4" variant="ghost">
+      <Sun size={"1.5em"} />
     </Button>
   );
 };

--- a/website/src/components/Header/ColorModeToggler.jsx
+++ b/website/src/components/Header/ColorModeToggler.jsx
@@ -1,0 +1,14 @@
+import { Button, useColorMode } from "@chakra-ui/react";
+import { Sun } from "lucide-react";
+
+const ColorModeToggler = () => {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  return (
+    <Button size="md" width="70px" justifyContent="center" onClick={toggleColorMode} gap="4" variant="outline">
+      <Sun size={"2em"} />
+    </Button>
+  );
+};
+
+export { ColorModeToggler };

--- a/website/src/components/Header/ColorModeToggler.jsx
+++ b/website/src/components/Header/ColorModeToggler.jsx
@@ -5,7 +5,7 @@ const ColorModeToggler = () => {
   const { colorMode, toggleColorMode } = useColorMode();
 
   return (
-    <Button size="md" width="70px" justifyContent="center" onClick={toggleColorMode} gap="4" variant="outline">
+    <Button size="md" width="70px" justifyContent="center" onClick={toggleColorMode} gap="4" variant="ghost">
       <Sun size={"2em"} />
     </Button>
   );

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -42,7 +42,7 @@ export function Header() {
           </Flex>
         </Link>
 
-        <Flex alignItems="center" gap="4">
+        <Flex alignItems="center" gap={["2", "4"]}>
           <Flags authorizedFlags={["flagTest"]}>
             <Text>FlagTest</Text>
           </Flags>

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -6,7 +6,7 @@ import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
 import { Flags } from "react-feature-flags";
 import { LanguageSelector } from "src/components/LanguageSelector";
-
+import { ColorModeToggler } from "./ColorModeToggler";
 import { UserMenu } from "./UserMenu";
 
 function AccountButton() {
@@ -49,6 +49,7 @@ export function Header() {
           <LanguageSelector />
           <AccountButton />
           <UserMenu />
+          <ColorModeToggler />
         </Flex>
       </Box>
     </nav>

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export function Header() {
         <Link href={homeURL} aria-label="Home">
           <Flex alignItems="center">
             <Image src="/images/logos/logo.svg" className="mx-auto object-fill" width="50" height="50" alt="logo" />
-            <Text fontFamily="inter" fontSize="2xl" fontWeight="bold" ml="3">
+            <Text fontFamily="inter" fontSize={["lg", "2xl"]} fontWeight="bold" ml="3">
               {t("title")}
             </Text>
           </Flex>


### PR DESCRIPTION
Hey! The user can only change the UI color mode when s/he is signed in. Also, the current color toggle button in the dashboard seems a bit misplaced.

### Solution:
Putting the button for toggling the light/dark color mode right into the navigation bar. The button could just display the sun icon in order to not take away too much space and be on the right side of the header.

### Example images:
![oa_color_mode_light](https://user-images.githubusercontent.com/25230234/216787127-c521b29d-247d-4fe1-8cfe-55fb774d27aa.png)
![oa_color_mode_dark](https://user-images.githubusercontent.com/25230234/216787128-a7ac3995-faa3-48c8-a821-37068e24edb8.png)

I haven't removed the current button in the dashboard, but if the button works fine in the navigation bar, it could probably be removed.