### PR TITLE
Hotfix for Hungarian language

### DIFF
--- a/website/public/locales/hu/labelling.json
+++ b/website/public/locales/hu/labelling.json
@@ -6,7 +6,7 @@
   "label_message_flag_instruction": "Jelöld be, melyek vonatkoznak erre az üzenetre:",
   "label_message_likert_instruction": "Értékeld ezt az üzenetet:",
   "spam.question": "Ez az üzenet SPAM?",
-  "fails_task.question": "Ez a válasz nem a feladatnak megfelelő?",
+  "fails_task.question": "Baj van ezzel az üzenettel, amiért nem a kérdésre válaszol?",
   "not_appropriate": "Nem Helyénvaló",
   "not_appropriate.explanation": "Nem ügyfél-asszisztenshez méltó válasz.",
   "pii": "Személyes Adat",

--- a/website/public/locales/hu/tasks.json
+++ b/website/public/locales/hu/tasks.json
@@ -17,14 +17,14 @@
   "reply_as_user": {
     "label": "Válaszolj a Felhasználó Helyett",
     "desc": "Csinálj úgy, mintha chatelnél az Asszisztenssel, hogy fejlődhessen.",
-    "overview": "Írj egy ideillő választ az eddigi beszélgetésre",
+    "overview": "Írj egy ideillő üzenetet az eddigi beszélgetésre, mint Felhasználó",
     "instruction": "Találj ki Felhasználói Válaszokat",
     "response_placeholder": "Ide írd a választ..."
   },
   "reply_as_assistant": {
     "label": "Válaszolj az Asszisztens Helyett",
     "desc": "Mjutasd meg az Asszisztensnek, hogy milyen válaszokat küldjön a felhasználói kérdésekre.",
-    "overview": "Írj egy ideillő választ az eddigi beszélgetésre",
+    "overview": "Írj egy ideillő választ az eddigi beszélgetésre, mintha te lennél az Asszisztens",
     "response_placeholder": "Ide írd a választ..."
   },
   "rank_user_replies": {


### PR DESCRIPTION
The fails_task.question was ambigous in Hungarian:
the original translation for "Is it a bad reply, as an answer to the prompt task?" was confusing as the question would require a different answer than yes or no in Hungarian.
The new translation is roughly "Do you think there is something wrong with this message, as it is not an answer to the question?"