### PR TITLE
feat(ci): enable `pip` caching in CI

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -21,6 +21,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "**/requirements*.txt"
       - uses: pre-commit/action@v3.0.0
       - name: Post PR comment on failure
         if: failure() && github.event_name == 'pull_request_target'

--- a/.github/workflows/test-api-contract.yaml
+++ b/.github/workflows/test-api-contract.yaml
@@ -23,6 +23,8 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "**/requirements*.txt"
       - uses: actions/setup-node@v3
         with:
           node-version: 16


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument of `actions/setup-python` to enable `pip` caching.