### PR TITLE
ci: switch flake8 by ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,15 +62,16 @@ repos:
     hooks:
       - id: black-jupyter
 
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
+
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.240
+    hooks:
+      - id: ruff
+        args: ["--fix"]
 
   - repo: https://github.com/pre-commit/mirrors-prettier
     rev: v2.7.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,6 +28,15 @@
 
 exclude: build|stubs|^bot/templates/$|openassistant/templates|docs/docs/api/openapi.json
 
+default_language_version:
+  python: python3
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: "[pre-commit.ci] pre-commit suggestions"
+  autoupdate_schedule: quarterly
+  skip: ["next-lint-website"] # list of hook ids to skip only in pre-commit.ci
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,7 +77,7 @@ repos:
       - id: isort
 
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: v0.0.240
+    rev: v0.0.263
     hooks:
       - id: ruff
         args: ["--fix"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,30 @@ line_length = 120
 [tool.black]
 line-length = 120
 target-version = ['py310']
+
+[tool.ruff]
+ line-length = 120
+ select = [
+     "E", "W",  # see: https://pypi.org/project/pycodestyle
+     "F",  # see: https://pypi.org/project/pyflakes
+ ]
+ ignore = [
+    "E501",
+    "E731",
+    "E741",  # Ambiguous variable name: ...
+    "E999",  # SyntaxError: invalid syntax. Got unexpected token Newline
+ ]
+ exclude = [
+    ".eggs",
+    ".git",
+    ".ruff_cache",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "docs"
+ ]
+ ignore-init-module-imports = true
+
+ [tool.ruff.mccabe]
+ max-complexity = 10

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 120
-extend-ignore = E203, W503, E501, E741


### PR DESCRIPTION
Ruff is quite a new linter with impresive speed and offers to add multiple checks...

> Ruff aims to be orders of magnitude faster than alternative tools while integrating more functionality behind a single, common interface.
Ruff can be used to replace [Flake8](https://pypi.org/project/flake8/) (plus dozens of plugins), [isort](https://pypi.org/project/isort/), [pydocstyle](https://pypi.org/project/pydocstyle/), [yesqa](https://github.com/asottile/yesqa), [eradicate](https://pypi.org/project/eradicate/), [pyupgrade](https://pypi.org/project/pyupgrade/), and [autoflake](https://pypi.org/project/autoflake/), all while executing tens or hundreds of times faster than any individual tool.

Also, I would suggest installing pre-commit bot, which helps to fix code within each PR so, lowering developer overhead... see: https://pre-commit.ci/