### PR TITLE
ui: move theme button to header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Open-Assistant",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -8,6 +8,7 @@ import { Flags } from "react-feature-flags";
 import { LanguageSelector } from "src/components/LanguageSelector";
 
 import { UserMenu } from "./UserMenu";
+import { ThemeButton } from "./ThemeButton";
 
 function AccountButton() {
   const { data: session } = useSession();
@@ -46,6 +47,7 @@ export function Header() {
           <Flags authorizedFlags={["flagTest"]}>
             <Text>FlagTest</Text>
           </Flags>
+          <ThemeButton />
           <LanguageSelector />
           <AccountButton />
           <UserMenu />

--- a/website/src/components/Header/ThemeButton.tsx
+++ b/website/src/components/Header/ThemeButton.tsx
@@ -1,0 +1,18 @@
+import { IconButton, Tooltip, useColorMode } from "@chakra-ui/react";
+import { Moon, Sun } from "lucide-react";
+
+export function ThemeButton() {
+  const { colorMode, toggleColorMode } = useColorMode();
+
+  return (
+    <Tooltip fontFamily="inter" label="Toggle Dark Mode" placement="right" className="hidden lg:hidden sm:block">
+      <IconButton
+        aria-label="Toggle Dark Mode"
+        size="md"
+        onClick={toggleColorMode}
+        variant="outline"
+        icon={colorMode === "light" ? <Sun size={"1em"} /> : <Moon size={"1em"} />}
+      />
+    </Tooltip>
+  );
+}

--- a/website/src/components/SideMenu.tsx
+++ b/website/src/components/SideMenu.tsx
@@ -1,5 +1,4 @@
 import { Button, Card, Text, Tooltip, useColorMode } from "@chakra-ui/react";
-import { useTranslation } from "next-i18next";
 import { LucideIcon, Sun } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
@@ -16,8 +15,6 @@ export interface SideMenuProps {
 
 export function SideMenu(props: SideMenuProps) {
   const router = useRouter();
-  const { colorMode, toggleColorMode } = useColorMode();
-  const { t } = useTranslation(["side_menu", "common"]);
 
   return (
     <main className="sticky top-0 sm:h-full">
@@ -57,16 +54,6 @@ export function SideMenu(props: SideMenuProps) {
             </Tooltip>
           ))}
         </nav>
-        <div>
-          <Tooltip fontFamily="inter" label="Toggle Dark Mode" placement="right" className="hidden lg:hidden sm:block">
-            <Button size="lg" width="full" justifyContent="center" onClick={toggleColorMode} gap="2">
-              <Sun size={"1em"} />
-              <Text fontWeight="normal" className="hidden lg:block">
-                {colorMode === "light" ? t("common:dark_mode") : t("common:light_mode")}
-              </Text>
-            </Button>
-          </Tooltip>
-        </div>
       </Card>
     </main>
   );


### PR DESCRIPTION
A small UI suggestion to move the theme button from sidebar to header.
![ui_change_fix](https://user-images.githubusercontent.com/83858160/216822589-d39877b0-63a0-4fac-848a-363154a9a9dc.png)
