### PR TITLE
add posthog for product analytics

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -37,6 +37,7 @@
         "next": "13.0.6",
         "next-auth": "^4.18.6",
         "next-i18next": "^13.0.3",
+        "next-use-posthog": "^1.16.4",
         "nodemailer": "^6.8.0",
         "npm": "^9.2.0",
         "postcss-focus-visible": "^7.1.0",
@@ -6222,6 +6223,14 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
@@ -19945,6 +19954,11 @@
       "integrity": "sha512-uJQyMrX5IJZkhoEUBQ3EjxkeiZkppBd5jS/fMTJmfZxLSiaQjv2zD0kTvuvkSH89uFvgSlB6ueGpjD3HWN7Bxw==",
       "dev": true
     },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "node_modules/figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -28194,6 +28208,17 @@
         "react-i18next": "^12.1.1"
       }
     },
+    "node_modules/next-use-posthog": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/next-use-posthog/-/next-use-posthog-1.16.4.tgz",
+      "integrity": "sha512-h35P8ev5zFY88DGOMtoNnL7kgaEM8dPx445DsjCpduXoFre7DrnvZdu+MiRXVcvri0LEIFcT9O+gruyZvjl1tg==",
+      "dependencies": {
+        "posthog-js": "^1.38.0"
+      },
+      "peerDependencies": {
+        "react": "^16.13.1 || ^17 || ^18"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
@@ -32632,6 +32657,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "node_modules/posthog-js": {
+      "version": "1.42.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.42.3.tgz",
+      "integrity": "sha512-+HdPY1PRsENcqjKyjw8CGbcGzBXcElPikSUSFffjKVJKmkMqEgMFpEKhIY5UBbrU6xtgcvnQmidn+8gRhCBa5g==",
+      "dependencies": {
+        "@sentry/types": "7.22.0",
+        "fflate": "^0.4.1",
+        "rrweb-snapshot": "^1.1.14"
+      }
+    },
     "node_modules/preact": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
@@ -34088,6 +34123,11 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "node_modules/rrweb-snapshot": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz",
+      "integrity": "sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ=="
     },
     "node_modules/rsvp": {
       "version": "4.8.5",
@@ -42987,6 +43027,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.2.0.tgz",
       "integrity": "sha512-sXo/qW2/pAcmT43VoRKOJbDOfV3cYpq3szSVfIThQXNt+E4DfKj361vaAt3c88U5tPUxzEswam7GW48PJqtKAg=="
+    },
+    "@sentry/types": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.22.0.tgz",
+      "integrity": "sha512-LhCL+wb1Jch+OesB2CIt6xpfO1Ab6CRvoNYRRzVumWPLns1T3ZJkarYfhbLaOEIb38EIbPgREdxn2AJT560U4Q=="
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
@@ -53682,6 +53727,11 @@
       "integrity": "sha512-uJQyMrX5IJZkhoEUBQ3EjxkeiZkppBd5jS/fMTJmfZxLSiaQjv2zD0kTvuvkSH89uFvgSlB6ueGpjD3HWN7Bxw==",
       "dev": true
     },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
+    },
     "figgy-pudding": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
@@ -59930,6 +59980,14 @@
         "i18next-fs-backend": "^2.1.0"
       }
     },
+    "next-use-posthog": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/next-use-posthog/-/next-use-posthog-1.16.4.tgz",
+      "integrity": "sha512-h35P8ev5zFY88DGOMtoNnL7kgaEM8dPx445DsjCpduXoFre7DrnvZdu+MiRXVcvri0LEIFcT9O+gruyZvjl1tg==",
+      "requires": {
+        "posthog-js": "^1.38.0"
+      }
+    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -63021,6 +63079,16 @@
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="
     },
+    "posthog-js": {
+      "version": "1.42.3",
+      "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.42.3.tgz",
+      "integrity": "sha512-+HdPY1PRsENcqjKyjw8CGbcGzBXcElPikSUSFffjKVJKmkMqEgMFpEKhIY5UBbrU6xtgcvnQmidn+8gRhCBa5g==",
+      "requires": {
+        "@sentry/types": "7.22.0",
+        "fflate": "^0.4.1",
+        "rrweb-snapshot": "^1.1.14"
+      }
+    },
     "preact": {
       "version": "10.11.3",
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
@@ -64094,6 +64162,11 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "rrweb-snapshot": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/rrweb-snapshot/-/rrweb-snapshot-1.1.14.tgz",
+      "integrity": "sha512-eP5pirNjP5+GewQfcOQY4uBiDnpqxNRc65yKPW0eSoU1XamDfc4M8oqpXGMyUyvLyxFDB0q0+DChuxxiU2FXBQ=="
     },
     "rsvp": {
       "version": "4.8.5",

--- a/website/package.json
+++ b/website/package.json
@@ -55,6 +55,7 @@
     "next": "13.0.6",
     "next-auth": "^4.18.6",
     "next-i18next": "^13.0.3",
+    "next-use-posthog": "^1.16.4",
     "nodemailer": "^6.8.0",
     "npm": "^9.2.0",
     "postcss-focus-visible": "^7.1.0",

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -12,6 +12,7 @@ import { SWRConfig, SWRConfiguration } from "swr";
 
 import nextI18NextConfig from "../../next-i18next.config.js";
 import { Chakra, getServerSideProps } from "../styles/Chakra";
+import { usePostHog } from 'next-use-posthog'
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
@@ -26,6 +27,8 @@ function MyApp({ Component, pageProps: { session, cookies, ...pageProps } }: App
   const getLayout = Component.getLayout ?? getDefaultLayout;
   const page = getLayout(<Component {...pageProps} />);
   const { t } = useTranslation();
+
+  usePostHog('phc_wc7zBlfP0U9E4WiSDgSpiyOYd6Wel8rG8qQkzGTVhGe', { api_host: 'https://app.posthog.com' })
 
   return (
     <>

--- a/website/src/pages/_app.tsx
+++ b/website/src/pages/_app.tsx
@@ -12,7 +12,7 @@ import { SWRConfig, SWRConfiguration } from "swr";
 
 import nextI18NextConfig from "../../next-i18next.config.js";
 import { Chakra, getServerSideProps } from "../styles/Chakra";
-import { usePostHog } from 'next-use-posthog'
+import { usePostHog } from "next-use-posthog";
 
 type AppPropsWithLayout = AppProps & {
   Component: NextPageWithLayout;
@@ -28,7 +28,7 @@ function MyApp({ Component, pageProps: { session, cookies, ...pageProps } }: App
   const page = getLayout(<Component {...pageProps} />);
   const { t } = useTranslation();
 
-  usePostHog('phc_wc7zBlfP0U9E4WiSDgSpiyOYd6Wel8rG8qQkzGTVhGe', { api_host: 'https://app.posthog.com' })
+  usePostHog("phc_wc7zBlfP0U9E4WiSDgSpiyOYd6Wel8rG8qQkzGTVhGe", { api_host: "https://app.posthog.com" });
 
   return (
     <>


### PR DESCRIPTION
This PR adds PostHog for product analytics telemetry. I set it up as per docs [here](https://posthog.com/docs/integrate/third-party/next-js). 

End result is events (pageviews and click events) coming into the PostHog project like this: 

<img width="937" alt="image" src="https://user-images.githubusercontent.com/2178292/216849025-b653d06a-0beb-43ab-8208-6d2760885515.png">

You can then define "Actions" based on events - so for example this is the "Submit" action, based on the data attributes of what was clicked. 

<img width="687" alt="image" src="https://user-images.githubusercontent.com/2178292/216849455-9ba9f32e-5d7c-41c3-a651-ff9f18257009.png">

Anyway - anyone can feel free to play with this - maybe just dm me on discord and i can add you to the PostHog project so you can then click around locally and see how the events flow though in PostHog. 

Really i just wanted to do this as a quick POC to show what i mean by using a tool like PostHog for product analytics which could be useful for insights on usage and even sharing public dashboards back with the user community etc. Obviously is a bigger decision or discussion around tools and things like that. 