### PR TITLE
fix: removed title on the navbar in the mobile view

### DIFF
--- a/website/src/components/Header/Header.tsx
+++ b/website/src/components/Header/Header.tsx
@@ -36,7 +36,7 @@ export function Header() {
         <Link href={homeURL} aria-label="Home">
           <Flex alignItems="center">
             <Image src="/images/logos/logo.svg" className="mx-auto object-fill" width="50" height="50" alt="logo" />
-            <Text fontFamily="inter" fontSize={["lg", "2xl"]} fontWeight="bold" ml="3">
+            <Text fontFamily="inter" fontSize={["lg", "2xl"]} fontWeight="bold" ml="3" className="hidden sm:block">
               {t("title")}
             </Text>
           </Flex>


### PR DESCRIPTION
I make this pr because in mobile devices the navbar have too many elements and the text mix with the language selector, so is better removing the title of the page and using the icon as branding giving more space in the navbar to extra elements.