### PR TITLE
Clarify what README Docker instructions are for

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,13 @@ directly helping to improve the capabilities of Open Assistant.
 
 ### Running Locally
 
-If you are interested in taking a look at the current state of the project, you
+**You do not need to run the project locally unless you are contributing to the
+development process. The website link above will take you to the public website
+where you can use the data collection app.**
+
+If you would like to run the data collection app locally for development, you
 can set up an entire stack needed to run **Open-Assistant**, including the
-website, backend, and associated dependent services.
+website, backend, and associated dependent services, with Docker.
 
 ##### To start the demo, run this in the root directory of the repository:
 


### PR DESCRIPTION
Many people enter the Discord thinking that the Docker command is to run the AI model locally and asking how it works. This updates the README instructions to avoid such confusion.