### PR TITLE
Add more obvious docs site link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 
 [open-assistant.io](https://open-assistant.io)
 
+(project documentation lives [here](https://laion-ai.github.io/Open-Assistant/))
+
 # Table of Contents
 
 - [What is Open Assistant?](#what-is-open-assistant)


### PR DESCRIPTION
Add more prominent/obvious link to docs site. People can easily miss it if it's just in the readme badges.