### PR TITLE
fix leaderboard when current user doesn't have stats

### DIFF
--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -34,7 +34,7 @@ export const LeaderboardTable = ({
     data: reply,
     isLoading,
     error,
-  } = useSWRImmutable<LeaderboardReply & { user_stats_window: LeaderboardReply["leaderboard"] }>(
+  } = useSWRImmutable<LeaderboardReply & { user_stats_window?: LeaderboardReply["leaderboard"] }>(
     `/api/leaderboard?time_frame=${timeFrame}&limit=${limit}&includeUserStats=${!hideCurrentUserRanking}`,
     get
   );
@@ -79,7 +79,7 @@ export const LeaderboardTable = ({
     const start = (page - 1) * rowPerPage;
     const end = start + rowPerPage;
     const leaderBoardEntities = reply.leaderboard.slice(start, end);
-    if (hideCurrentUserRanking) {
+    if (hideCurrentUserRanking || !reply.user_stats_window) {
       return leaderBoardEntities;
     }
     const userStatsWindow: WindowLeaderboardEntity[] = reply.user_stats_window;

--- a/website/src/pages/api/leaderboard.ts
+++ b/website/src/pages/api/leaderboard.ts
@@ -29,7 +29,7 @@ const handler = withoutRole("banned", async (req, res, token) => {
 
   res.status(200).json({
     ...leaderboard,
-    user_stats_window: user_stats.leaderboard.map((stats) => ({ ...stats, is_window: true })),
+    user_stats_window: user_stats?.leaderboard.map((stats) => ({ ...stats, is_window: true })),
   });
 });
 


### PR DESCRIPTION
Regression from #1263 
The user stats may be null when the user doesn't have statistics (eg: hasn't done any task yet.)
It's happening on our dev instance [https://web.dev.open-assistant.io/leaderboard](https://web.dev.open-assistant.io/leaderboard)