### PR TITLE
Force full page reload on language change

### DIFF
--- a/website/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/website/src/components/LanguageSelector/LanguageSelector.tsx
@@ -37,7 +37,8 @@ const LanguageSelector = () => {
       const locale = option.target.value;
       setCookie("NEXT_LOCALE", locale, { path: "/" });
       const path = router.asPath;
-      return router.push(path, path, { locale });
+      await router.push(path, path, { locale });
+      router.reload();
     },
     [router]
   );


### PR DESCRIPTION
Fixes #1287 by reloading the page every time a user changes their language.  When a user changes their language during the a task page, it will re-fetch the task and show either a proper task in their language or show that none exist for that task type.