### PR TITLE
Allow to export filtered by tree state and/or only prompts

### DIFF
--- a/backend/export.py
+++ b/backend/export.py
@@ -118,7 +118,11 @@ def parse_args():
         type=str,
         help="all|prompt_lottery_waiting|growing|ready_for_export|aborted_low_grade|halted_by_moderator|backlog_ranking",
     )
-    parser.add_argument("--prompts-only", action="store_true", help="Export a list of initial prompt messages")
+    parser.add_argument(
+        "--prompts-only",
+        action="store_true",
+        help="Export a list of initial prompt messages",
+    )
 
     args = parser.parse_args()
     return args

--- a/backend/export.py
+++ b/backend/export.py
@@ -1,36 +1,31 @@
 import argparse
-import json
-import sys
 from pathlib import Path
 from typing import List, Optional
 from uuid import UUID
 
-from fastapi.encoders import jsonable_encoder
 from loguru import logger
 from oasst_backend.database import engine
-from oasst_backend.models import Message, MessageTreeState, message_tree_state
+from oasst_backend.models import Message, MessageTreeState
+from oasst_backend.models.message_tree_state import State as TreeState
 from oasst_backend.utils import tree_export
-from sqlmodel import Session, not_
+from sqlmodel import Session
 
 
-def fetch_tree_ids(db: Session, ready_only: bool = False):
+def fetch_tree_ids(db: Session, state_filter: Optional[TreeState] = None) -> list[tuple[UUID, TreeState]]:
     tree_qry = db.query(MessageTreeState)
 
-    if ready_only:
-        tree_qry = tree_qry.filter(MessageTreeState.state == message_tree_state.State.READY_FOR_EXPORT)
+    if state_filter:
+        tree_qry = tree_qry.filter(MessageTreeState.state == state_filter)
 
-    message_trees = tree_qry.all()
-
-    message_tree_ids = [tree.message_tree_id for tree in message_trees]
-    return message_tree_ids
+    return [(tree.message_tree_id, tree.state) for tree in tree_qry]
 
 
-def fetch_message_ids(
+def fetch_tree_messages(
     db: Session,
     message_tree_id: Optional[UUID] = None,
     user_id: Optional[UUID] = None,
-    include_deleted: bool = False,
-    deleted_only: bool = False,
+    deleted: bool = None,
+    prompts_only: bool = False,
 ) -> List[Message]:
     qry = db.query(Message)
 
@@ -38,10 +33,10 @@ def fetch_message_ids(
         qry = qry.filter(Message.message_tree_id == message_tree_id)
     if user_id:
         qry = qry.filter(Message.user_id == user_id)
-    if not include_deleted:
-        qry = qry.filter(not_(Message.deleted))
-    if deleted_only:
-        qry = qry.filter(Message.deleted)
+    if deleted is not None:
+        qry = qry.filter(Message.deleted == deleted)
+    if prompts_only:
+        qry = qry.filter(Message.parent_id.is_(None))
 
     return qry.all()
 
@@ -50,31 +45,36 @@ def export_trees(
     db: Session,
     export_file: Optional[Path] = None,
     use_compression: bool = False,
-    ready_only: bool = False,
-    include_deleted: bool = False,
-    deleted_only: bool = False,
+    deleted: bool = False,
     user_id: Optional[UUID] = None,
-):
+    prompts_only: bool = False,
+    state_filter: Optional[TreeState] = None,
+) -> None:
     trees_to_export: List[tree_export.ExportMessageTree] = []
 
     if user_id:
-        messages = fetch_message_ids(db, user_id=user_id, include_deleted=include_deleted, deleted_only=deleted_only)
-        message_tree_ids = [msg.message_tree_id for msg in messages]
+        messages = fetch_tree_messages(db, user_id=user_id, deleted=deleted, prompts_only=prompts_only)
+        tree_export.write_messages_to_file(export_file, messages, use_compression)
     else:
-        message_tree_ids = fetch_tree_ids(db, ready_only)
+        message_tree_ids = fetch_tree_ids(db, state_filter)
 
-    message_trees = [
-        fetch_message_ids(db, message_tree_id=tree_id, include_deleted=include_deleted, deleted_only=deleted_only)
-        for tree_id in message_tree_ids
-    ]
+        message_trees = [
+            fetch_tree_messages(
+                db,
+                message_tree_id=tree_id,
+                deleted=deleted,
+                prompts_only=prompts_only,
+            )
+            for (tree_id, _) in message_tree_ids
+        ]
 
-    for message_tree_id, message_tree in zip(message_tree_ids, message_trees):
-        trees_to_export.append(tree_export.build_export_tree(message_tree_id, message_tree))
+        for (message_tree_id, message_tree_state), message_tree in zip(message_tree_ids, message_trees):
+            t = tree_export.build_export_tree(message_tree_id, message_tree_state, message_tree)
+            if prompts_only:
+                t.prompt.replies = None
+            trees_to_export.append(t)
 
-    if export_file:
         tree_export.write_trees_to_file(export_file, trees_to_export, use_compression)
-    else:
-        sys.stdout.write(json.dumps(jsonable_encoder(trees_to_export), indent=2))
 
 
 def validate_args(args):
@@ -83,8 +83,8 @@ def validate_args(args):
 
     args.use_compression = args.export_file is not None and ".gz" in args.export_file
 
-    if args.ready_only and args.user_id is not None:
-        raise ValueError("Cannot use --ready-only when specifying a user ID")
+    if args.state and args.user is not None:
+        raise ValueError("Cannot use --state when specifying a user ID")
 
     if args.export_file is None:
         logger.warning("No export file provided, output will be sent to STDOUT")
@@ -99,11 +99,6 @@ def parse_args():
         help="Name of file to export trees to. If not provided, output will be sent to STDOUT",
     )
     parser.add_argument(
-        "--ready-only",
-        action="store_true",
-        help="Only export trees which are ready for use",
-    )
-    parser.add_argument(
         "--include-deleted",
         action="store_true",
         help="Include deleted messages in export",
@@ -116,8 +111,14 @@ def parse_args():
     parser.add_argument(
         "--user",
         type=str,
-        help="Only export trees involving the user with the specified ID. Incompatible with --ready-only.",
+        help="Only export trees involving the user with the specified ID. Incompatible with --state.",
     )
+    parser.add_argument(
+        "--state",
+        type=str,
+        help="all|prompt_lottery_waiting|growing|ready_for_export|aborted_low_grade|halted_by_moderator|backlog_ranking",
+    )
+    parser.add_argument("--prompts-only", action="store_true", help="Export a list of initial prompt messages")
 
     args = parser.parse_args()
     return args
@@ -127,15 +128,27 @@ def main():
     args = parse_args()
     validate_args(args)
 
+    state_filter: Optional[TreeState] = None
+    if args.state is None:
+        state_filter = TreeState.READY_FOR_EXPORT
+    elif args.state != "all":
+        state_filter = TreeState(args.state)
+
+    deleted: Optional[bool] = False
+    if args.include_deleted:
+        deleted = None
+    if args.deleted_only:
+        deleted = True
+
     with Session(engine) as db:
         export_trees(
             db,
             Path(args.export_file) if args.export_file is not None else None,
             args.use_compression,
-            args.ready_only,
-            args.include_deleted,
-            args.deleted_only,
-            UUID(args.user) if args.user is not None else None,
+            deleted=deleted,
+            user_id=UUID(args.user) if args.user is not None else None,
+            prompts_only=args.prompts_only,
+            state_filter=state_filter,
         )
 
 

--- a/backend/export.py
+++ b/backend/export.py
@@ -90,13 +90,18 @@ def export_trees(
             for (tree_id, _) in message_tree_ids
         ]
 
-        for (message_tree_id, message_tree_state), message_tree in zip(message_tree_ids, message_trees):
-            t = tree_export.build_export_tree(message_tree_id, message_tree_state, message_tree)
-            if prompts_only:
-                t.prompt.replies = None
-            trees_to_export.append(t)
+        # when exporting only-deleted we don't have a porper tree structure, export as list
+        if deleted is True:
+            messages = [m for t in message_trees for m in t]
+            tree_export.write_messages_to_file(export_file, messages, use_compression)
+        else:
+            for (message_tree_id, message_tree_state), message_tree in zip(message_tree_ids, message_trees):
+                t = tree_export.build_export_tree(message_tree_id, message_tree_state, message_tree)
+                if prompts_only:
+                    t.prompt.replies = None
+                trees_to_export.append(t)
 
-        tree_export.write_trees_to_file(export_file, trees_to_export, use_compression)
+            tree_export.write_trees_to_file(export_file, trees_to_export, use_compression)
 
 
 def validate_args(args):

--- a/backend/oasst_backend/prompt_repository.py
+++ b/backend/oasst_backend/prompt_repository.py
@@ -656,12 +656,6 @@ class PromptRepository:
             qry = qry.filter(not_(Message.deleted))
         return self._add_user_emojis_all(qry)
 
-    def fetch_message_trees_ready_for_export(self) -> list[MessageTreeState]:
-        qry = self.db.query(MessageTreeState).filter(
-            MessageTreeState.state == message_tree_state.State.READY_FOR_EXPORT
-        )
-        return qry.all()
-
     def fetch_multiple_random_replies(self, max_size: int = 5, message_role: str = None):
         """
         Fetch a conversation with multiple possible replies to it.

--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -1,6 +1,4 @@
-import json
 import random
-import sys
 from datetime import datetime, timedelta
 from enum import Enum
 from http import HTTPStatus
@@ -10,7 +8,6 @@ from uuid import UUID
 import numpy as np
 import pydantic
 import sqlalchemy as sa
-from fastapi.encoders import jsonable_encoder
 from loguru import logger
 from oasst_backend.api.v1.utils import prepare_conversation, prepare_conversation_message_list
 from oasst_backend.config import TreeManagerConfiguration, settings
@@ -25,7 +22,6 @@ from oasst_backend.models import (
     message_tree_state,
 )
 from oasst_backend.prompt_repository import PromptRepository
-from oasst_backend.utils import tree_export
 from oasst_backend.utils.database_utils import (
     CommitMode,
     async_managed_tx_method,
@@ -1662,44 +1658,6 @@ DELETE FROM user_stats WHERE user_id = :user_id;
         if ban:
             self.db.execute(update(User).filter(User.id == user_id).values(deleted=True, enabled=False))
 
-    def export_trees_to_file(
-        self,
-        message_tree_ids: list[str],
-        file=None,
-        reviewed: bool = True,
-        include_deleted: bool = False,
-        use_compression: bool = False,
-    ) -> None:
-        trees_to_export: List[tree_export.ExportMessageTree] = []
-
-        for message_tree_id in message_tree_ids:
-            messages: List[Message] = self.pr.fetch_message_tree(message_tree_id, reviewed, include_deleted)
-            trees_to_export.append(tree_export.build_export_tree(message_tree_id, messages))
-
-        if file:
-            tree_export.write_trees_to_file(file, trees_to_export, use_compression)
-        else:
-            sys.stdout.write(json.dumps(jsonable_encoder(trees_to_export), indent=2))
-
-    def export_all_ready_trees(
-        self, file: str, reviewed: bool = True, include_deleted: bool = False, use_compression: bool = False
-    ) -> None:
-        message_tree_states: MessageTreeState = self.pr.fetch_message_trees_ready_for_export()
-        message_tree_ids = [ms.message_tree_id for ms in message_tree_states]
-        self.export_trees_to_file(message_tree_ids, file, reviewed, include_deleted, use_compression)
-
-    def export_all_user_trees(
-        self,
-        user_id: str,
-        file: str,
-        reviewed: bool = True,
-        include_deleted: bool = False,
-        use_compression: bool = False,
-    ) -> None:
-        messages = self.pr.fetch_user_message_trees(UUID(user_id))
-        message_tree_ids = [ms.message_tree_id for ms in messages]
-        self.export_trees_to_file(message_tree_ids, file, reviewed, include_deleted, use_compression)
-
     @managed_tx_method(CommitMode.COMMIT)
     def retry_scoring_failed_message_trees(self):
         query = self.db.query(MessageTreeState).filter(
@@ -1766,5 +1724,3 @@ if __name__ == "__main__":
         # print(
         #     ".query_tree_ranking_results", tm.query_tree_ranking_results(UUID("21f9d585-d22c-44ab-a696-baa3d83b5f1b"))
         # )
-
-        # print(tm.export_trees_to_file(message_tree_ids=["7e75fb38-e664-4e2b-817c-b9a0b01b0074"], file="lol.jsonl"))

--- a/backend/oasst_backend/utils/tree_export.py
+++ b/backend/oasst_backend/utils/tree_export.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import contextlib
 import gzip
 import json
+import sys
 from collections import defaultdict
-from typing import Optional, TextIO
+from typing import Iterable, Optional, TextIO
+from uuid import UUID
 
 from fastapi.encoders import jsonable_encoder
 from oasst_backend.models import Message
+from oasst_backend.models.message_tree_state import State as TreeState
 from pydantic import BaseModel
 
 
@@ -41,10 +45,13 @@ class ExportMessageNode(BaseModel):
 
 class ExportMessageTree(BaseModel):
     message_tree_id: str
+    tree_state: Optional[str]
     prompt: Optional[ExportMessageNode]
 
 
-def build_export_tree(message_tree_id: str, messages: list[Message]) -> ExportMessageTree:
+def build_export_tree(
+    message_tree_id: UUID, message_tree_state: TreeState, messages: list[Message]
+) -> ExportMessageTree:
     export_messages = [ExportMessageNode.prep_message_export(m) for m in messages]
 
     messages_by_parent = defaultdict(list)
@@ -59,19 +66,54 @@ def build_export_tree(message_tree_id: str, messages: list[Message]) -> ExportMe
         return node
 
     prompt = assign_replies(messages_by_parent[None][0])
-    return ExportMessageTree(message_tree_id=str(message_tree_id), prompt=prompt)
+    return ExportMessageTree(message_tree_id=str(message_tree_id), tree_state=message_tree_state, prompt=prompt)
 
 
-def write_trees_to_file(file, trees: list[ExportMessageTree], use_compression: bool = True) -> None:
-
-    out_buff: TextIO
-    if use_compression:
-        out_buff = gzip.open(file, "wt", encoding="UTF-8")
+# see https://stackoverflow.com/questions/17602878/how-to-handle-both-with-open-and-sys-stdout-nicely
+@contextlib.contextmanager
+def smart_open(filename: str = None) -> TextIO:
+    if filename and filename != "-":
+        fh = open(filename, "wt", encoding="UTF-8")
     else:
-        out_buff = open(file, "wt", encoding="UTF-8")
+        fh = sys.stdout
+
+    try:
+        yield fh
+    finally:
+        if fh is not sys.stdout:
+            fh.close()
+
+
+def write_trees_to_file(filename: str | None, trees: list[ExportMessageTree], use_compression: bool = True) -> None:
+    out_buff: TextIO
+
+    if use_compression:
+        if not filename:
+            raise RuntimeError("File name must be specified when using compression.")
+        out_buff = gzip.open(filename, "wt", encoding="UTF-8")
+    else:
+        out_buff = smart_open(filename)
 
     with out_buff as f:
         for tree in trees:
-            file_data = jsonable_encoder(tree)
+            file_data = jsonable_encoder(tree, exclude_none=True)
+            json.dump(file_data, f)
+            f.write("\n")
+
+
+def write_messages_to_file(filename: str | None, messages: Iterable[Message], use_compression: bool = True) -> None:
+    out_buff: TextIO
+
+    if use_compression:
+        if not filename:
+            raise RuntimeError("File name must be specified when using compression.")
+        out_buff = gzip.open(filename, "wt", encoding="UTF-8")
+    else:
+        out_buff = smart_open(filename)
+
+    with out_buff as f:
+        for m in messages:
+            export_message = ExportMessageNode.prep_message_export(m)
+            file_data = jsonable_encoder(export_message, exclude_none=True)
             json.dump(file_data, f)
             f.write("\n")


### PR DESCRIPTION
Closes: #1275

- added `--state` and `--prompts-only` command line args
- write user messages as list of messages
- removed separate code paths for STDIO and file writing