### PR TITLE
Only check for language conflict on review

### DIFF
--- a/website/src/components/Survey/TrackedTextarea.tsx
+++ b/website/src/components/Survey/TrackedTextarea.tsx
@@ -1,15 +1,13 @@
 import {} from "@chakra-ui/react";
 import lande from "lande";
 import { LanguageAbbreviations } from "src/lib/iso6393";
-import { useCookies } from "react-cookie";
-import React from "react";
+import React, { useEffect } from "react";
 import {
   Progress,
   Stack,
   Textarea,
   TextareaProps,
   useColorModeValue,
-  Button,
   Modal,
   ModalBody,
   ModalCloseButton,
@@ -33,52 +31,8 @@ interface TrackedTextboxProps {
 const killEvent = (e) => e.stopPropagation();
 
 export const TrackedTextarea = (props: TrackedTextboxProps) => {
-  const [wordLimitForLangDetection, setWordLimitForLangDetection] = React.useState(10);
   const backgroundColor = useColorModeValue("gray.100", "gray.900");
-  const [cookies] = useCookies(["NEXT_LOCALE"]);
   const wordCount = (props.text.match(/\w+/g) || []).length;
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const currentLanguage = cookies["NEXT_LOCALE"];
-
-  const closeTemporaryIgnoreLanguageDetection = () => {
-    setWordLimitForLangDetection(2 * wordCount);
-    onClose();
-  };
-
-  console.log("", wordCount, wordLimitForLangDetection);
-  if (wordCount > wordLimitForLangDetection) {
-    let mostProbableLanguage;
-    try {
-      mostProbableLanguage = LanguageAbbreviations[lande(props.text)[0][0]];
-    } catch (error) {
-      mostProbableLanguage = "";
-    }
-
-    /*const mostProbableLanguage = lande(props.text);*/
-    if (mostProbableLanguage !== currentLanguage) {
-      setTimeout(() => {
-        onOpen();
-      }, 200);
-
-      return (
-        <>
-          <Modal isOpen={isOpen} onClose={closeTemporaryIgnoreLanguageDetection} size="xl" scrollBehavior={"inside"}>
-            {/* we kill the event here to disable drag and drop, since it is in the same container */}
-            <ModalOverlay onMouseDown={killEvent}>
-              <ModalContent alignItems="center">
-                <ModalHeader>Switch Language?</ModalHeader>
-                <ModalCloseButton />
-                <ModalBody>
-                  Do you want to switch language? The detected language is <b>{mostProbableLanguage}</b>, whereas your
-                  chosen language is <b>{currentLanguage}</b>. The language can be changed on the top right.
-                </ModalBody>
-              </ModalContent>
-            </ModalOverlay>
-          </Modal>
-        </>
-      );
-    }
-  }
 
   let progressColor: string;
   switch (true) {
@@ -114,3 +68,49 @@ export const TrackedTextarea = (props: TrackedTextboxProps) => {
     </Stack>
   );
 };
+
+export function getMostProbableLanguage(text: string) {
+  let mostProbableLanguage;
+  try {
+    mostProbableLanguage = LanguageAbbreviations[lande(text)[0][0]];
+  } catch (error) {
+    mostProbableLanguage = "";
+  }
+
+  return mostProbableLanguage;
+}
+
+export function DifferentLanguageModal({ mostProbableLanguage, currentLanguage, setMostProbableLanguage }) {
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  useEffect(() => {
+    if (mostProbableLanguage !== currentLanguage) {
+      onOpen();
+    }
+  }, []);
+
+  return (
+    <>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          setMostProbableLanguage("");
+          onClose();
+        }}
+        size="xl"
+        scrollBehavior={"inside"}
+      >
+        {/* we kill the event here to disable drag and drop, since it is in the same container */}
+        <ModalOverlay onMouseDown={killEvent}>
+          <ModalContent alignItems="center">
+            <ModalHeader>Switch Language?</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody>
+              Do you want to switch language? The detected language is <b>{mostProbableLanguage}</b>, whereas your
+              chosen language is <b>{currentLanguage}</b>. The language can be changed on the top right.
+            </ModalBody>
+          </ModalContent>
+        </ModalOverlay>
+      </Modal>
+    </>
+  );
+}

--- a/website/src/components/Tasks/Task/Task.tsx
+++ b/website/src/components/Tasks/Task/Task.tsx
@@ -142,29 +142,25 @@ export const Task = () => {
     switch (taskInfo.category) {
       case TaskCategory.Create:
         return (
-          <>
-            <CreateTask
-              task={task as CreateTaskType}
-              taskType={taskInfo}
-              isEditable={taskStatus.mode === "EDIT"}
-              isDisabled={taskStatus.mode === "SUBMITTED"}
-              onReplyChanged={onReplyChanged}
-              onValidityChanged={updateValidity}
-            />
-          </>
+          <CreateTask
+            task={task as CreateTaskType}
+            taskType={taskInfo}
+            isEditable={taskStatus.mode === "EDIT"}
+            isDisabled={taskStatus.mode === "SUBMITTED"}
+            onReplyChanged={onReplyChanged}
+            onValidityChanged={updateValidity}
+          />
         );
       case TaskCategory.Evaluate:
         return (
-          <>
-            <EvaluateTask
-              task={task as RankTaskType}
-              taskType={taskInfo}
-              isEditable={taskStatus.mode === "EDIT"}
-              isDisabled={taskStatus.mode === "SUBMITTED"}
-              onReplyChanged={onReplyChanged}
-              onValidityChanged={updateValidity}
-            />
-          </>
+          <EvaluateTask
+            task={task as RankTaskType}
+            taskType={taskInfo}
+            isEditable={taskStatus.mode === "EDIT"}
+            isDisabled={taskStatus.mode === "SUBMITTED"}
+            onReplyChanged={onReplyChanged}
+            onValidityChanged={updateValidity}
+          />
         );
       case TaskCategory.Label:
         return (


### PR DESCRIPTION
#1271 
Sometimes the language detector mistakes french for other languages, and the users get spammed with a modal whenever they double the word count (starting from 10).
This solution checks for language conflict only when the user submit for review.