### PR TITLE
Trollboard expandable

### DIFF
--- a/website/src/components/DataTable/DataTable.tsx
+++ b/website/src/components/DataTable/DataTable.tsx
@@ -23,13 +23,23 @@ import {
   Tr,
   useDisclosure,
 } from "@chakra-ui/react";
-import { Cell, ColumnDef, flexRender, getCoreRowModel, Row, useReactTable } from "@tanstack/react-table";
+import {
+  Cell,
+  ColumnDef,
+  ExpandedState,
+  flexRender,
+  getCoreRowModel,
+  getExpandedRowModel,
+  Row,
+  useReactTable,
+} from "@tanstack/react-table";
 import { Filter } from "lucide-react";
 import { useTranslation } from "next-i18next";
-import { ChangeEvent, ReactNode } from "react";
+import { ChangeEvent, ReactNode, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
-export type DataTableColumnDef<T> = ColumnDef<T> & {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type DataTableColumnDef<T> = ColumnDef<T, any> & {
   filterable?: boolean;
   span?: number | ((cell: Cell<T, unknown>) => number | undefined);
 };
@@ -54,6 +64,7 @@ export type DataTableProps<T> = {
   disablePrevious?: boolean;
   disablePagination?: boolean;
   rowProps?: TableRowProps | DataTableRowPropsCallback<T>;
+  getSubRows?: (row: T) => T[] | undefined;
 };
 
 export const DataTable = <T,>({
@@ -68,12 +79,21 @@ export const DataTable = <T,>({
   disablePrevious,
   disablePagination,
   rowProps,
+  getSubRows,
 }: DataTableProps<T>) => {
   const { t } = useTranslation("leaderboard");
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+
   const { getHeaderGroups, getRowModel } = useReactTable<T>({
     data,
     columns,
     getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    state: {
+      expanded,
+    },
+    getSubRows,
+    onExpandedChange: setExpanded,
   });
 
   const handleFilterChange = (value: FilterItem) => {

--- a/website/src/components/DataTable/jsonExpandRowModel.tsx
+++ b/website/src/components/DataTable/jsonExpandRowModel.tsx
@@ -2,16 +2,13 @@ import { Card, CardBody, Flex } from "@chakra-ui/react";
 import { Cell, CellContext } from "@tanstack/react-table";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
-interface ExpandableRow {
+type ExpandableRow<T> = Omit<T, "shouldExpand"> & {
   shouldExpand?: boolean;
-}
+};
 
-export const createJsonExpandRowModel = <
-  T,
-  U extends Omit<T, "shouldExpand"> & ExpandableRow = Omit<T, "shouldExpand"> & ExpandableRow
->() => {
+export const createJsonExpandRowModel = <T,>() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const renderCell = ({ row, getValue }: CellContext<U, any>) => {
+  const renderCell = ({ row, getValue }: CellContext<ExpandableRow<T>, any>) => {
     if (!row.original.shouldExpand) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { shouldExpand, ...res } = row.original;
@@ -42,9 +39,10 @@ export const createJsonExpandRowModel = <
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const span = (cell: Cell<U, any>) => (cell.row.original.shouldExpand ? undefined : cell.row.getVisibleCells().length);
+  const span = (cell: Cell<ExpandableRow<T>, any>) =>
+    cell.row.original.shouldExpand ? undefined : cell.row.getVisibleCells().length;
 
-  const getSubRows = (row: U) =>
+  const getSubRows = (row: ExpandableRow<T>) =>
     row.shouldExpand
       ? [
           {
@@ -54,10 +52,8 @@ export const createJsonExpandRowModel = <
         ]
       : undefined;
 
-  const toExpandable = function (arr: T[] | undefined, val = true): U[] {
-    // TODO remove `any` workaround
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return !arr ? [] : (arr.map((element) => ({ ...element, shouldExpand: val })) as any);
+  const toExpandable = function (arr: T[] | undefined, val = true): ExpandableRow<T>[] {
+    return !arr ? [] : arr.map((element) => ({ ...element, shouldExpand: val }));
   };
 
   return { renderCell, span, getSubRows, toExpandable };

--- a/website/src/components/DataTable/jsonExpandRowModel.tsx
+++ b/website/src/components/DataTable/jsonExpandRowModel.tsx
@@ -23,7 +23,7 @@ export const createJsonExpandRowModel = <
         </Card>
       );
     }
-    console.log(row.getCanExpand());
+
     return (
       <Flex alignItems="center">
         {row.getCanExpand() ? (

--- a/website/src/components/DataTable/jsonExpandRowModel.tsx
+++ b/website/src/components/DataTable/jsonExpandRowModel.tsx
@@ -2,13 +2,16 @@ import { Card, CardBody, Flex } from "@chakra-ui/react";
 import { Cell, CellContext } from "@tanstack/react-table";
 import { ChevronDown, ChevronRight } from "lucide-react";
 
-type ExpandableRow = {
-  shouldExpand: boolean;
-};
+interface ExpandableRow {
+  shouldExpand?: boolean;
+}
 
-export const createJsonExpandRowModel = <T extends ExpandableRow>() => {
+export const createJsonExpandRowModel = <
+  T,
+  U extends Omit<T, "shouldExpand"> & ExpandableRow = Omit<T, "shouldExpand"> & ExpandableRow
+>() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const renderCell = ({ row, getValue }: CellContext<T, any>) => {
+  const renderCell = ({ row, getValue }: CellContext<U, any>) => {
     if (!row.original.shouldExpand) {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const { shouldExpand, ...res } = row.original;
@@ -20,6 +23,7 @@ export const createJsonExpandRowModel = <T extends ExpandableRow>() => {
         </Card>
       );
     }
+    console.log(row.getCanExpand());
     return (
       <Flex alignItems="center">
         {row.getCanExpand() ? (
@@ -38,9 +42,9 @@ export const createJsonExpandRowModel = <T extends ExpandableRow>() => {
   };
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const span = (cell: Cell<T, any>) => (cell.row.original.shouldExpand ? undefined : cell.row.getVisibleCells().length);
+  const span = (cell: Cell<U, any>) => (cell.row.original.shouldExpand ? undefined : cell.row.getVisibleCells().length);
 
-  const getSubRows = (row: T) =>
+  const getSubRows = (row: U) =>
     row.shouldExpand
       ? [
           {
@@ -50,5 +54,11 @@ export const createJsonExpandRowModel = <T extends ExpandableRow>() => {
         ]
       : undefined;
 
-  return { renderCell, span, getSubRows };
+  const toExpandable = function (arr: T[] | undefined, val = true): U[] {
+    // TODO remove `any` workaround
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return !arr ? [] : (arr.map((element) => ({ ...element, shouldExpand: val })) as any);
+  };
+
+  return { renderCell, span, getSubRows, toExpandable };
 };

--- a/website/src/components/DataTable/jsonExpandRowModel.tsx
+++ b/website/src/components/DataTable/jsonExpandRowModel.tsx
@@ -1,0 +1,54 @@
+import { Card, CardBody, Flex } from "@chakra-ui/react";
+import { Cell, CellContext } from "@tanstack/react-table";
+import { ChevronDown, ChevronRight } from "lucide-react";
+
+type ExpandableRow = {
+  shouldExpand: boolean;
+};
+
+export const createJsonExpandRowModel = <T extends ExpandableRow>() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const renderCell = ({ row, getValue }: CellContext<T, any>) => {
+    if (!row.original.shouldExpand) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { shouldExpand, ...res } = row.original;
+      return (
+        <Card variant="json">
+          <CardBody>
+            <pre>{JSON.stringify(res, null, 2)}</pre>
+          </CardBody>
+        </Card>
+      );
+    }
+    return (
+      <Flex alignItems="center">
+        {row.getCanExpand() ? (
+          <button
+            {...{
+              onClick: row.getToggleExpandedHandler(),
+              style: { cursor: "pointer" },
+            }}
+          >
+            {row.getIsExpanded() ? <ChevronDown /> : <ChevronRight />}
+          </button>
+        ) : null}{" "}
+        {getValue()}
+      </Flex>
+    );
+  };
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const span = (cell: Cell<T, any>) => (cell.row.original.shouldExpand ? undefined : cell.row.getVisibleCells().length);
+
+  const getSubRows = (row: T) =>
+    row.shouldExpand
+      ? [
+          {
+            ...row,
+            shouldExpand: false,
+          },
+        ]
+      : undefined;
+
+  return { renderCell, span, getSubRows };
+};

--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -7,7 +7,7 @@ import { useTranslation } from "next-i18next";
 import React, { useMemo } from "react";
 import { LeaderboardEntity, LeaderboardReply, LeaderboardTimeFrame } from "src/types/Leaderboard";
 
-import { DataTable, DataTableColumnDef } from "../DataTable";
+import { DataTable, DataTableColumnDef } from "../DataTable/DataTable";
 import { useBoardPagination } from "./useBoardPagination";
 import { useBoardRowProps } from "./useBoardRowProps";
 import { useFetchBoard } from "./useFetchBoard";
@@ -41,7 +41,7 @@ export const LeaderboardTable = ({
   );
   const { data: session } = useSession();
 
-  const isAdmin = session?.user?.role === "admin";
+  const isAdmin = usehasro;
   const columns: DataTableColumnDef<WindowLeaderboardEntity>[] = useMemo(
     () => [
       {

--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -43,7 +43,6 @@ export const LeaderboardTable = ({
 
   const isAdmin = useHasRole("admin");
 
-  console.log(isAdmin);
   const columns: DataTableColumnDef<WindowLeaderboardEntity>[] = useMemo(
     () => [
       {

--- a/website/src/components/LeaderboardTable/TrollboardTable.tsx
+++ b/website/src/components/LeaderboardTable/TrollboardTable.tsx
@@ -3,7 +3,6 @@ import { createColumnHelper } from "@tanstack/react-table";
 import { Mail, ThumbsDown, ThumbsUp, User } from "lucide-react";
 import NextLink from "next/link";
 import { FetchTrollBoardResponse, TrollboardEntity, TrollboardTimeFrame } from "src/types/Trollboard";
-import { ElementOf } from "src/types/utils";
 
 import { DataTable, DataTableColumnDef } from "../DataTable/DataTable";
 import { createJsonExpandRowModel } from "../DataTable/jsonExpandRowModel";
@@ -12,13 +11,11 @@ import { useBoardPagination } from "./useBoardPagination";
 import { useBoardRowProps } from "./useBoardRowProps";
 import { useFetchBoard } from "./useFetchBoard";
 
-type ExpandableTrollboardEntity = TrollboardEntity;
-
-const columnHelper = createColumnHelper<ExpandableTrollboardEntity>();
+const columnHelper = createColumnHelper<TrollboardEntity>();
 const toPercentage = (num: number) => `${Math.round(num * 100)}%`;
-const jsonExpandRowModel = createJsonExpandRowModel<ExpandableTrollboardEntity>();
+const jsonExpandRowModel = createJsonExpandRowModel<TrollboardEntity>();
 
-const columns: DataTableColumnDef<ExpandableTrollboardEntity>[] = [
+const columns: DataTableColumnDef<TrollboardEntity>[] = [
   {
     ...columnHelper.accessor("rank", {
       cell: jsonExpandRowModel.renderCell,
@@ -124,12 +121,12 @@ export const TrollboardTable = ({
     lastUpdated,
   } = useFetchBoard<FetchTrollBoardResponse>(`/api/admin/trollboard?time_frame=${timeFrame}&limit=${limit}`);
 
-  const { data, ...paginationProps } = useBoardPagination<ExpandableTrollboardEntity>({
+  const { data, ...paginationProps } = useBoardPagination<TrollboardEntity>({
     rowPerPage,
     data: jsonExpandRowModel.toExpandable(trollboardRes?.trollboard),
     limit,
   });
-  const rowProps = useBoardRowProps<ExpandableTrollboardEntity>();
+  const rowProps = useBoardRowProps<TrollboardEntity>();
   if (isLoading) {
     return <CircularProgress isIndeterminate></CircularProgress>;
   }
@@ -146,7 +143,7 @@ export const TrollboardTable = ({
         },
       }}
     >
-      <DataTable<ElementOf<typeof data>>
+      <DataTable
         data={data}
         columns={columns}
         caption={lastUpdated}

--- a/website/src/components/LeaderboardTable/TrollboardTable.tsx
+++ b/website/src/components/LeaderboardTable/TrollboardTable.tsx
@@ -61,37 +61,9 @@ const columns: DataTableColumnDef<TrollboardEntity>[] = [
   columnHelper.accessor((row) => row.spam + row.spam_prompts, {
     header: "Spam",
   }),
-  // columnHelper.accessor("lang_mismach", {
-  //   header: "Lang mismach",
-  // }),
-  // columnHelper.accessor("not_appropriate", {
-  //   header: "Not appropriate",
-  // }),
-  // columnHelper.accessor("pii", {}),
-  // columnHelper.accessor("hate_speech", {
-  //   header: "Hate speech",
-  // }),
-  // columnHelper.accessor("sexual_content", {
-  //   header: "Sexual",
-  // }),
-  // columnHelper.accessor("political_content", {
-  //   header: "Political",
-  // }),
   columnHelper.accessor("toxicity", {
     cell: ({ getValue }) => toPercentage(getValue() || 0),
   }),
-  // columnHelper.accessor("quality", {
-  //   cell: ({ getValue }) => toPercentage(getValue() || 0),
-  // }),
-  // columnHelper.accessor("helpfulness", {
-  //   cell: ({ getValue }) => toPercentage(getValue() || 0),
-  // }),
-  // columnHelper.accessor("humor", {
-  //   cell: ({ getValue }) => toPercentage(getValue() || 0),
-  // }),
-  // columnHelper.accessor("violence", {
-  //   cell: ({ getValue }) => toPercentage(getValue() || 0),
-  // }),
   columnHelper.accessor((row) => row.user_id, {
     header: "Actions",
     cell: ({ row }) => (

--- a/website/src/components/LeaderboardTable/useBoardRowProps.ts
+++ b/website/src/components/LeaderboardTable/useBoardRowProps.ts
@@ -2,7 +2,7 @@ import { useColorModeValue, useToken } from "@chakra-ui/react";
 import { useCallback } from "react";
 import { colors } from "src/styles/Theme/colors";
 
-import { DataTableRowPropsCallback } from "../DataTable";
+import { DataTableRowPropsCallback } from "../DataTable/DataTable";
 
 export const useBoardRowProps = <T extends { highlighted: boolean }>() => {
   const borderColor = useToken("colors", useColorModeValue(colors.light.active, colors.dark.active));

--- a/website/src/components/UserTable.tsx
+++ b/website/src/components/UserTable.tsx
@@ -7,7 +7,7 @@ import { get } from "src/lib/api";
 import type { FetchUsersResponse, User } from "src/types/Users";
 import useSWR from "swr";
 
-import { DataTable, DataTableColumnDef, FilterItem } from "./DataTable";
+import { DataTable, DataTableColumnDef, FilterItem } from "./DataTable/DataTable";
 
 interface Pagination {
   /**

--- a/website/src/pages/admin/trollboard.tsx
+++ b/website/src/pages/admin/trollboard.tsx
@@ -18,7 +18,7 @@ const Leaderboard = () => {
       <AdminArea>
         <Box display="flex" flexDirection="column">
           <Heading fontSize="2xl" fontWeight="bold" pb="4">
-            {t("leaderboard")}
+            Trollboard
           </Heading>
           <Card>
             <CardBody>

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": true,
+    "strict": false,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,

--- a/website/tsconfig.json
+++ b/website/tsconfig.json
@@ -4,7 +4,7 @@
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "incremental": true,


### PR DESCRIPTION
- Refactor trollboard UI to drop some columns.
- Allow to expand trollboard and leaderboard (admin only) for more information
- Add expand row feature to DataTable component

![image](https://user-images.githubusercontent.com/33456881/217513796-f27f88a3-12b8-4bf2-b9cb-37b79d5ac209.png)
