### PR TITLE
Making cards clickable in Ranking replies page

### DIFF
--- a/website/cypress/e2e/tasks/random.cy.ts
+++ b/website/cypress/e2e/tasks/random.cy.ts
@@ -30,7 +30,7 @@ describe("handles random tasks", () => {
                 // Rank an item using the keyboard so that the submit button is enabled
                 cy.get('[aria-roledescription="sortable"]')
                   .first()
-                  .click()
+                  .click("left")
                   .type("{enter}")
                   .wait(100)
                   .type("{downArrow}")

--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -1,16 +1,16 @@
-import React, { ReactNode } from "react";
+import { ReactNode } from "react";
 
-export const CollapsableText = ({
-  text,
-  maxLength = 220,
-}: {
-  text: ReactNode;
-  maxLength?: number;
-  isDisabled?: boolean;
-}) => {
+export const CollapsableText = ({ text, maxLength = 220 }: { text: ReactNode; maxLength?: number }) => {
   if (typeof text !== "string" || text.length <= maxLength) {
     return <>{text}</>;
   } else {
-    return <span>{text.substring(0, maxLength - 3)}...</span>;
+    const visibleText = text.substring(0, maxLength - 3);
+    const dots = visibleText[visibleText.length - 1] === "." ? ".." : "...";
+    return (
+      <span>
+        {visibleText}
+        {dots}
+      </span>
+    );
   }
 };

--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -5,12 +5,6 @@ export const CollapsableText = ({ text, maxLength = 220 }: { text: ReactNode; ma
     return <>{text}</>;
   } else {
     const visibleText = text.substring(0, maxLength - 3);
-    const dots = visibleText[visibleText.length - 1] === "." ? ".." : "...";
-    return (
-      <span>
-        {visibleText}
-        {dots}
-      </span>
-    );
+    return <span>{visibleText}...</span>;
   }
 };

--- a/website/src/components/CollapsableText.tsx
+++ b/website/src/components/CollapsableText.tsx
@@ -1,72 +1,16 @@
-import {
-  Button,
-  Modal,
-  ModalBody,
-  ModalCloseButton,
-  ModalContent,
-  ModalHeader,
-  ModalOverlay,
-  Tooltip,
-  useColorModeValue,
-  useDisclosure,
-} from "@chakra-ui/react";
 import React, { ReactNode } from "react";
-
-const killEvent = (e) => e.stopPropagation();
 
 export const CollapsableText = ({
   text,
   maxLength = 220,
-  isDisabled,
 }: {
   text: ReactNode;
   maxLength?: number;
   isDisabled?: boolean;
 }) => {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const finalRef = React.useRef(null);
-
-  const moreButtonColor = useColorModeValue("gray.600", "gray.400");
-
   if (typeof text !== "string" || text.length <= maxLength) {
     return <>{text}</>;
   } else {
-    return (
-      <>
-        <span ref={finalRef}>
-          {text.substring(0, maxLength - 3)}&nbsp;
-          <Tooltip label={text} maxW="70vw">
-            <Button
-              style={{ display: "inline" }}
-              size={"xs"}
-              variant={"solid"}
-              bg={moreButtonColor}
-              color={"white"}
-              isDisabled={isDisabled}
-              onClick={onOpen}
-            >
-              ...
-            </Button>
-          </Tooltip>
-        </span>
-        <Modal
-          finalFocusRef={finalRef}
-          isOpen={isOpen}
-          onClose={onClose}
-          size="xl"
-          scrollBehavior={"inside"}
-          isCentered
-        >
-          {/* we kill the event here to disable drag and drop, since it is in the same container */}
-          <ModalOverlay onMouseDown={killEvent}>
-            <ModalContent pb={5} alignItems="center">
-              <ModalHeader>Full Text</ModalHeader>
-              <ModalCloseButton />
-              <ModalBody whiteSpace="pre-line">{text}</ModalBody>
-            </ModalContent>
-          </ModalOverlay>
-        </Modal>
-      </>
-    );
+    return <span>{text.substring(0, maxLength - 3)}...</span>;
   }
 };

--- a/website/src/components/Sortable/Sortable.tsx
+++ b/website/src/components/Sortable/Sortable.tsx
@@ -82,7 +82,6 @@ export const Sortable = (props: SortableProps) => {
             {itemsWithIds.map(({ id, item }, index) => (
               <SortableItem key={id} id={id} index={index} isEditable={props.isEditable} isDisabled={props.isDisabled}>
                 <button
-                  className="bg-red-800"
                   aria-label="show full text"
                   onClick={() => {
                     setModalText(item);

--- a/website/src/components/Sortable/Sortable.tsx
+++ b/website/src/components/Sortable/Sortable.tsx
@@ -82,6 +82,7 @@ export const Sortable = (props: SortableProps) => {
             {itemsWithIds.map(({ id, item }, index) => (
               <SortableItem key={id} id={id} index={index} isEditable={props.isEditable} isDisabled={props.isDisabled}>
                 <button
+                  className="w-full text-left"
                   aria-label="show full text"
                   onClick={() => {
                     setModalText(item);

--- a/website/src/components/Sortable/Sortable.tsx
+++ b/website/src/components/Sortable/Sortable.tsx
@@ -89,7 +89,7 @@ export const Sortable = (props: SortableProps) => {
                     onOpen();
                   }}
                 >
-                  <CollapsableText text={item} isDisabled={props.isDisabled} />
+                  <CollapsableText text={item} />
                 </button>
               </SortableItem>
             ))}

--- a/website/src/components/Sortable/Sortable.tsx
+++ b/website/src/components/Sortable/Sortable.tsx
@@ -1,10 +1,19 @@
-import { Flex } from "@chakra-ui/react";
+import {
+  Flex,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from "@chakra-ui/react";
 import {
   closestCenter,
   DndContext,
   KeyboardSensor,
   MouseSensor,
-  TouchSensor,
+  PointerSensor,
   useSensor,
   useSensors,
 } from "@dnd-kit/core";
@@ -37,7 +46,7 @@ interface SortableItems {
 
 export const Sortable = (props: SortableProps) => {
   const [itemsWithIds, setItemsWithIds] = useState<SortableItems[]>([]);
-
+  const [modalText, setModalText] = useState(null);
   useEffect(() => {
     setItemsWithIds(
       props.items.map((item, idx) => ({
@@ -49,30 +58,63 @@ export const Sortable = (props: SortableProps) => {
   }, [props.items]);
 
   const sensors = useSensors(
-    useSensor(MouseSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(TouchSensor, { activationConstraint: { distance: 4 } }),
-    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8, tolerance: 100 },
+    }),
+    useSensor(MouseSensor, { activationConstraint: { distance: 10 } }),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
   );
-
+  const { isOpen, onOpen, onClose } = useDisclosure();
   const extraClasses = props.className || "";
 
   return (
-    <DndContext
-      sensors={sensors}
-      collisionDetection={closestCenter}
-      onDragEnd={handleDragEnd}
-      modifiers={[restrictToParentElement, restrictToVerticalAxis]}
-    >
-      <SortableContext items={itemsWithIds} strategy={verticalListSortingStrategy}>
-        <Flex direction="column" gap={2} className={extraClasses}>
-          {itemsWithIds.map(({ id, item }, index) => (
-            <SortableItem key={id} id={id} index={index} isEditable={props.isEditable} isDisabled={props.isDisabled}>
-              <CollapsableText text={item} isDisabled={props.isDisabled} />
-            </SortableItem>
-          ))}
-        </Flex>
-      </SortableContext>
-    </DndContext>
+    <>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+        modifiers={[restrictToParentElement, restrictToVerticalAxis]}
+      >
+        <SortableContext items={itemsWithIds} strategy={verticalListSortingStrategy}>
+          <Flex direction="column" gap={2} className={extraClasses}>
+            {itemsWithIds.map(({ id, item }, index) => (
+              <SortableItem key={id} id={id} index={index} isEditable={props.isEditable} isDisabled={props.isDisabled}>
+                <button
+                  className="bg-red-800"
+                  aria-label="show full text"
+                  onClick={() => {
+                    setModalText(item);
+                    onOpen();
+                  }}
+                >
+                  <CollapsableText text={item} isDisabled={props.isDisabled} />
+                </button>
+              </SortableItem>
+            ))}
+          </Flex>
+        </SortableContext>
+      </DndContext>
+      <Modal
+        isOpen={isOpen}
+        onClose={() => {
+          setModalText(null);
+          onClose();
+        }}
+        size="xl"
+        scrollBehavior={"inside"}
+        isCentered
+      >
+        <ModalOverlay>
+          <ModalContent pb={5} alignItems="center">
+            <ModalHeader>Full Text</ModalHeader>
+            <ModalCloseButton />
+            <ModalBody whiteSpace="pre-line">{modalText}</ModalBody>
+          </ModalContent>
+        </ModalOverlay>
+      </Modal>
+    </>
   );
 
   function handleDragEnd(event: DragEndEvent) {

--- a/website/src/components/Sortable/SortableItem.tsx
+++ b/website/src/components/Sortable/SortableItem.tsx
@@ -11,7 +11,7 @@ export const SortableItem = ({
   isEditable,
   isDisabled,
 }: PropsWithChildren<{ id: number; index: number; isEditable: boolean; isDisabled: boolean }>) => {
-  const backgroundColor = useColorModeValue("gray.700", "gray.500");
+  const backgroundColor = useColorModeValue("gray.700", "gray.800");
   const disabledBackgroundColor = useColorModeValue("gray.400", "gray.700");
   const textColor = useColorModeValue("white", "white");
 
@@ -27,13 +27,14 @@ export const SortableItem = ({
 
   return (
     <Box
+      className="hover:bg-[var(--chakra-colors-gray-600)]"
       display="flex"
       alignItems="center"
       bg={isDisabled ? disabledBackgroundColor : backgroundColor}
       borderRadius="lg"
       p="4"
       color={textColor}
-      cursor={isEditable ? (grabbing ? "grabbing" : "grab") : "auto"}
+      cursor={isEditable ? (grabbing ? "grabbing" : "pointer") : "auto"}
       aria-roledescription="sortable"
       onMouseDown={() => {
         setGrabbing(true);

--- a/website/src/components/Sortable/SortableItem.tsx
+++ b/website/src/components/Sortable/SortableItem.tsx
@@ -2,7 +2,7 @@ import { Box, useColorModeValue } from "@chakra-ui/react";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical } from "lucide-react";
-import { PropsWithChildren, useState } from "react";
+import { PropsWithChildren, useMemo } from "react";
 
 export const SortableItem = ({
   children,
@@ -11,40 +11,41 @@ export const SortableItem = ({
   isEditable,
   isDisabled,
 }: PropsWithChildren<{ id: number; index: number; isEditable: boolean; isDisabled: boolean }>) => {
-  const backgroundColor = useColorModeValue("gray.700", "gray.800");
+  const backgroundColor = useColorModeValue("gray.700", "gray.500");
   const disabledBackgroundColor = useColorModeValue("gray.400", "gray.700");
+  const activeBackgroundColor = useColorModeValue("gray.600", "gray.600");
   const textColor = useColorModeValue("white", "white");
 
   const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id, disabled: !isEditable });
 
-  const style = {
-    transform: CSS.Translate.toString(transform),
-    transition,
-    touchAction: "none",
-  };
-
-  const [grabbing, setGrabbing] = useState(false);
+  const sx = useMemo(
+    () => ({
+      "&:active": {
+        bg: `${isEditable ? activeBackgroundColor : backgroundColor}`,
+        cursor: `${isEditable ? "grabbing" : "default"}`,
+      },
+      touchAction: "none",
+    }),
+    [isEditable, activeBackgroundColor, backgroundColor]
+  );
 
   return (
     <Box
-      className="hover:bg-[var(--chakra-colors-gray-600)]"
+      sx={sx}
+      transform={CSS.Translate.toString(transform)}
+      transition={transition}
       display="flex"
       alignItems="center"
       bg={isDisabled ? disabledBackgroundColor : backgroundColor}
       borderRadius="lg"
       p="4"
+      whiteSpace="pre-wrap"
       color={textColor}
-      cursor={isEditable ? (grabbing ? "grabbing" : "pointer") : "auto"}
       aria-roledescription="sortable"
-      onMouseDown={() => {
-        setGrabbing(true);
-      }}
-      onMouseUp={() => setGrabbing(false)}
+      ref={setNodeRef}
+      shadow="base"
       {...attributes}
       {...listeners}
-      ref={setNodeRef}
-      style={style}
-      shadow="base"
     >
       <Box pr="4">{isEditable ? <GripVertical size="20px" /> : `${index + 1}.`}</Box>
       {children}


### PR DESCRIPTION
Users were having problem with the [...] button #1208 
My proposed solution is to remove it and make the card clickable
![Recording 2023-02-09 at 12 24 33](https://user-images.githubusercontent.com/113536090/217801337-062e4999-1518-4650-89b2-f7a3f0f19845.gif)
I changed the sensor options so that the dragging will start after the pointer moves by 10 pixels. 
I have tested this in my phone, and a laptop screen touch and so far haven't found any conflict between dragging and clicking.

Only the text area is clickable, in case of a problem one can use the handle. 
![image](https://user-images.githubusercontent.com/113536090/217802120-de8c4d46-62ad-48cd-8243-71a7e7a5a7cb.png)

