### PR TITLE
minimal fastapi prom metrics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -30,6 +30,7 @@ from oasst_shared.utils import utcnow
 from pydantic import BaseModel
 from sqlmodel import Session, select
 from starlette.middleware.cors import CORSMiddleware
+from prometheus_fastapi_instrumentator import Instrumentator
 
 app = fastapi.FastAPI(title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json")
 startup_time: datetime = utcnow()
@@ -98,6 +99,12 @@ if settings.OFFICIAL_WEB_API_KEY:
                     frontend_type="web",
                     trusted=True,
                 )
+
+
+if settings.ENABLE_PROM_METRICS:
+    @app.on_event("startup")
+    async def enable_prom_metrics():
+        Instrumentator().instrument(app).expose(app)
 
 
 if settings.RATE_LIMIT:

--- a/backend/main.py
+++ b/backend/main.py
@@ -27,10 +27,10 @@ from oasst_backend.utils.database_utils import CommitMode, managed_tx_function
 from oasst_shared.exceptions import OasstError, OasstErrorCode
 from oasst_shared.schemas import protocol as protocol_schema
 from oasst_shared.utils import utcnow
+from prometheus_fastapi_instrumentator import Instrumentator
 from pydantic import BaseModel
 from sqlmodel import Session, select
 from starlette.middleware.cors import CORSMiddleware
-from prometheus_fastapi_instrumentator import Instrumentator
 
 app = fastapi.FastAPI(title=settings.PROJECT_NAME, openapi_url=f"{settings.API_V1_STR}/openapi.json")
 startup_time: datetime = utcnow()
@@ -102,6 +102,7 @@ if settings.OFFICIAL_WEB_API_KEY:
 
 
 if settings.ENABLE_PROM_METRICS:
+
     @app.on_event("startup")
     async def enable_prom_metrics():
         Instrumentator().instrument(app).expose(app)

--- a/backend/oasst_backend/config.py
+++ b/backend/oasst_backend/config.py
@@ -196,6 +196,8 @@ class Settings(BaseSettings):
     HUGGING_FACE_API_KEY: str = ""
 
     ROOT_TOKENS: List[str] = ["1234"]  # supply a string that can be parsed to a json list
+    
+    ENABLE_PROM_METRICS: bool = True  # enable prometheus metrics at /metrics
 
     @validator("DATABASE_URI", pre=True)
     def assemble_db_connection(cls, v: Optional[str], values: Dict[str, Any]) -> Any:

--- a/backend/oasst_backend/config.py
+++ b/backend/oasst_backend/config.py
@@ -196,7 +196,7 @@ class Settings(BaseSettings):
     HUGGING_FACE_API_KEY: str = ""
 
     ROOT_TOKENS: List[str] = ["1234"]  # supply a string that can be parsed to a json list
-    
+
     ENABLE_PROM_METRICS: bool = True  # enable prometheus metrics at /metrics
 
     @validator("DATABASE_URI", pre=True)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,6 +6,7 @@ fastapi-limiter==0.1.5
 fastapi-utils==0.2.1
 loguru==0.6.0
 numpy==1.22.4
+prometheus-fastapi-instrumentator==5.9.1
 psycopg2-binary==2.9.5
 pydantic==1.9.1
 pydantic[email]==1.9.1
@@ -17,4 +18,3 @@ SQLAlchemy==1.4.41
 sqlmodel==0.0.8
 starlette==0.22.0
 uvicorn==0.20.0
-prometheus-fastapi-instrumentator==5.9.1

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ SQLAlchemy==1.4.41
 sqlmodel==0.0.8
 starlette==0.22.0
 uvicorn==0.20.0
+prometheus-fastapi-instrumentator==5.9.1

--- a/inference/server/main.py
+++ b/inference/server/main.py
@@ -10,8 +10,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from oasst_shared.schemas import inference, protocol
 from sse_starlette.sse import EventSourceResponse
+from prometheus_fastapi_instrumentator import Instrumentator
 
 app = fastapi.FastAPI()
+
+# add prometheus metrics at /metrics
+@app.on_event("startup")
+async def enable_prom_metrics():
+    Instrumentator().instrument(app).expose(app)
 
 # Allow CORS
 app.add_middleware(

--- a/inference/server/main.py
+++ b/inference/server/main.py
@@ -9,8 +9,8 @@ import websockets.exceptions
 from fastapi.middleware.cors import CORSMiddleware
 from loguru import logger
 from oasst_shared.schemas import inference, protocol
-from sse_starlette.sse import EventSourceResponse
 from prometheus_fastapi_instrumentator import Instrumentator
+from sse_starlette.sse import EventSourceResponse
 
 app = fastapi.FastAPI()
 
@@ -18,6 +18,7 @@ app = fastapi.FastAPI()
 @app.on_event("startup")
 async def enable_prom_metrics():
     Instrumentator().instrument(app).expose(app)
+
 
 # Allow CORS
 app.add_middleware(

--- a/inference/server/main.py
+++ b/inference/server/main.py
@@ -14,6 +14,7 @@ from sse_starlette.sse import EventSourceResponse
 
 app = fastapi.FastAPI()
 
+
 # add prometheus metrics at /metrics
 @app.on_event("startup")
 async def enable_prom_metrics():

--- a/inference/server/requirements.txt
+++ b/inference/server/requirements.txt
@@ -1,7 +1,7 @@
 fastapi[all]
 loguru
+prometheus-fastapi-instrumentator==5.9.1
 pydantic
 redis
 sse-starlette
 websockets
-prometheus-fastapi-instrumentator==5.9.1

--- a/inference/server/requirements.txt
+++ b/inference/server/requirements.txt
@@ -4,3 +4,4 @@ pydantic
 redis
 sse-starlette
 websockets
+prometheus-fastapi-instrumentator==5.9.1


### PR DESCRIPTION
Summary:
- adds /metrics endpoint to fastapi backend
- add /metrics endpoint to inference fastapi backend

This PR uses https://github.com/trallnag/prometheus-fastapi-instrumentator to add a `/metrics` endpoint to the fastapi app that can then be scraped by Prometheus, netdata or any other monitoring tools. 

Here is example of default metrics endpoint:

![image](https://user-images.githubusercontent.com/2178292/218089767-302582c3-24d4-4860-a1ed-a7fe2ce10ed4.png)

You can see it has typical enough metrics for each endpoint etc. 

If we wanted to of course we could also add custom metrics easily enough: https://github.com/trallnag/prometheus-fastapi-instrumentator#creating-new-metrics