### PR TITLE
fix: typos in spanish (es) version of landing page

### DIFF
--- a/website/public/locales/es/index.json
+++ b/website/public/locales/es/index.json
@@ -1,6 +1,6 @@
 {
   "blurb": "Creemos que podemos crear una revolución.",
-  "blurb1": "De la misma manera que Stable Diffusion ayudó al mundo a crear arte e imágenes de maneras nuevas, queremos mejorar el mundo proporcionando una IA conversacional asombrosa",
+  "blurb1": "De la misma forma que Stable Diffusion ayudó al mundo a crear arte e imágenes de nuevas maneras, queremos mejorar el mundo proporcionando una IA conversacional asombrosa.",
   "description": "IA conversacional para todos. Un proyecto de código abierto para crear un GPT LLM preparado para chatear administrado por LAION y colaboradores de todo el mundo.",
   "faq_items": {
     "q0": "¿Cómo de avanzado está el proyecto?",
@@ -16,7 +16,7 @@
     "q5": "¿Qué hardware será necesario para ejecutar los modelos?",
     "a5": "Habrá versiones que se podrán ejecutar en hardware de consumo."
   },
-  "faq_title": "Preguntas frequentes",
+  "faq_title": "Preguntas frecuentes",
   "join_us_description": "Todos los proyectos de código abierto comienzan con personas como tú. El código abierto es la creencia de que si colaboramos juntos, podemos regalar nuestro conocimiento y tecnología al mundo en beneficio de la humanidad. ¿Te apuntas? Encuéntranos aquí:",
   "join_us_title": "Únete a nosotros",
   "subtitle": "IA conversacional para todos."


### PR DESCRIPTION
In the spanish version of `index.json` the following changes were made:

- "blurb1": rephrased to avoid repetition, word order fixed and missing punctuation added

- "faq_title": typo fix