### PR TITLE
Fixing docs syntax/grammar errors

### DIFF
--- a/docs/docs/data/datasets.md
+++ b/docs/docs/data/datasets.md
@@ -45,7 +45,7 @@ signed into Github.
 After you fork, clone the repository locally. You can do so as follows:
 
 ```bash
-git clone git@github.com:<your_github_username>/OpenAssistant.git
+git clone git@github.com:<your_github_username>/Open-Assistant.git
 cd Open-Assistant  # enter the directory
 ```
 

--- a/docs/docs/data/datasets.md
+++ b/docs/docs/data/datasets.md
@@ -37,9 +37,8 @@ for stability**.
 
 ### 1. **Fork the OpenAssistant repository**
 
-Fork the
-[OpenAssistant repository](https://github.com/LAION-AI/Open-Assistant). To do
-this, click the link to the repository and click "Fork" in the upper-right
+Fork the [OpenAssistant repository](https://github.com/LAION-AI/Open-Assistant).
+To do this, click the link to the repository and click "Fork" in the upper-right
 corner. You should get an option to fork to your account, provided you are
 signed into Github.
 

--- a/docs/docs/data/datasets.md
+++ b/docs/docs/data/datasets.md
@@ -38,7 +38,7 @@ for stability**.
 ### 1. **Fork the OpenAssistant repository**
 
 Fork the
-`OpenAssistant`[repository](https://github.com/LAION-AI/Open-Assistant). To do
+[OpenAssistant repository](https://github.com/LAION-AI/Open-Assistant). To do
 this, click the link to the repository and click "Fork" in the upper-right
 corner. You should get an option to fork to your account, provided you are
 signed into Github.
@@ -47,7 +47,7 @@ After you fork, clone the repository locally. You can do so as follows:
 
 ```bash
 git clone git@github.com:<your_github_username>/OpenAssistant.git
-cd OpenAssistant  # enter the directory
+cd Open-Assistant  # enter the directory
 ```
 
 Next, you want to set your `upstream` location to enable you to push/pull (add
@@ -76,7 +76,7 @@ upstream        git@github.com:LAION-AI/Open-Assistant.git (push)
 If you do NOT have an `origin` for whatever reason, then run:
 
 ```bash
-git remote add origin git@github.com:<your_github_username>/OpenAssistant.git
+git remote add origin git@github.com:<your_github_username>/Open-Assistant.git
 ```
 
 The goal of `upstream` is to keep your repository up-to-date to any changes that
@@ -100,7 +100,7 @@ git checkout -b <dataset_name>
 
 :::caution
 
-Please do not make changes on the master branch!
+Please do not make changes on the main branch!
 
 :::
 
@@ -114,7 +114,7 @@ The correct branch will have a asterisk \* in front of it.
 
 ### 2. **Create a development environment**
 
-You can make an environment in any way you choose to. We highlight two possible
+You can make an environment in any way you choose. We highlight two possible
 options:
 
 #### 2a) Create a conda environment

--- a/docs/docs/data/supervised-datasets.md
+++ b/docs/docs/data/supervised-datasets.md
@@ -6,7 +6,7 @@ For discussion about usage of supervised data see issue
 ## Motivation
 
 An important part of making the assistant useful is to teach it to understand
-and follow instructions, and to perform large set of tasks well.
+and follow instructions, and to perform a large set of tasks well.
 
 While RLHF seems like the main ingredient, using existing supervised data might
 help.

--- a/docs/docs/faq/faq.md
+++ b/docs/docs/faq/faq.md
@@ -61,7 +61,7 @@ website [https://open-assistant.io/](https://open-assistant.io/). If you want to
 contribute code, take a look at the
 [tasks in GitHub](https://github.com/orgs/LAION-AI/projects/3) and grab one.
 Take a look at this
-[contributing guide](https://github.com/GuilleHoardings/Open-Assistant/blob/main/CONTRIBUTING.md).
+[contributing guide](https://github.com/LAION-AI/Open-Assistant/blob/main/CONTRIBUTING.md).
 
 ## Questions about the model training website
 


### PR DESCRIPTION
Noticed a few issues with syntax and grammar errors in the docs md files as well as inconsistencies with branch and repo names (the cd is to Open-Assistant, not OpenAssistant, our prod branch is main not master, etc.) 

Also, there was a link to the CONTRIBUTION.md of a fork instead of the main repo. 

Furthermore, I am unable to add labels and I would prefer to set squash and merge on GitHub, but I am currently unable to do so.

Closes #1456