### PR TITLE
Fix jest unit test

### DIFF
--- a/website/jest.setup.js
+++ b/website/jest.setup.js
@@ -1,2 +1,36 @@
 // jest.setup.js
 import "@testing-library/jest-dom/extend-expect";
+
+const CONSOLE_FAIL_TYPES = ["error", "warn"];
+
+// Throw errors when a `console.error` or `console.warn` happens
+// by overriding the functions.
+// If the warning/error is intentional, then catch it and expect for it, like:
+//
+//  jest.spyOn(console, 'warn').mockImplementation();
+//  ...
+//  expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Empty titles are deprecated.'));
+CONSOLE_FAIL_TYPES.forEach((type) => {
+  const orig_f = console[type];
+  console[type] = (...message) => {
+    orig_f(...message);
+    throw new Error(`Failing due to console.${type} while running test!\n\n${message.join(" ")}`);
+  };
+});
+
+// Mock out useTranslation hook as per https://react.i18next.com/misc/testing
+jest.mock("react-i18next", () => ({
+  // this mock makes sure any components using the translate hook can use it without a warning being shown
+  useTranslation: () => {
+    return {
+      t: (str) => str,
+      i18n: {
+        changeLanguage: () => new Promise(() => {}),
+      },
+    };
+  },
+  initReactI18next: {
+    type: "3rdParty",
+    init: () => {},
+  },
+}));

--- a/website/src/setupTests.js
+++ b/website/src/setupTests.js
@@ -1,5 +1,0 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import "@testing-library/jest-dom";


### PR DESCRIPTION
It was broken because it required i18n to be stubbed, but because it was indicating this with a console warning, it wasn't noticed.

I've stubbed i18n and also made warn's and error's fatal (unless overridden otherwise)