### PR TITLE
add CC BY-SA 4.0 to terms of use

### DIFF
--- a/website/src/components/ToS.tsx
+++ b/website/src/components/ToS.tsx
@@ -72,6 +72,11 @@ const TermsData = [
         title: "",
         desc: "The use, distribution, storage, forwarding, editing and/or other use of images that violate these terms of use is prohibited.",
       },
+      {
+        number: "3.5",
+        title: "",
+        desc: "When you submit or modify text to which you hold the copyright, you agree to license it under: Creative Commons Attribution-ShareAlike 4.0 (“CC BY-SA 4.0”)"
+      }
     ],
   },
   {


### PR DESCRIPTION
You can see a similar statement is used in [Wikipedia terms of use](https://foundation.wikimedia.org/wiki/Terms_of_Use/en) and it makes sure that the user contributed data is clear to be released under a CC with no disputes.