### PR TITLE
Fix 'Open In Colab' link in gutenberg notebook

### DIFF
--- a/notebooks/gutenberg/project_gutenberg_crawler.ipynb
+++ b/notebooks/gutenberg/project_gutenberg_crawler.ipynb
@@ -13,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LAION-AI/Open-Assistant/blob/notebooks/gutenberg/project_gutenberg_crawler.ipynb)"
+    "[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/LAION-AI/Open-Assistant/blob/main/notebooks/gutenberg/project_gutenberg_crawler.ipynb)"
    ]
   },
   {


### PR DESCRIPTION
I'm not sure if this type of PR is welcome, but I just wanted to correct the link. 😅