### PR TITLE
Update inference installation

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -92,7 +92,7 @@ Run the inference server:
 ```bash
 cd server
 pip install -r requirements.txt
-uvicorn main:app --reload
+DEBUG_API_KEYS='["0000"]' uvicorn main:app --reload
 ```
 
 Run one (or more) workers:
@@ -110,7 +110,7 @@ running:
 docker run --rm -it -p 8001:80 -e MODEL_ID=distilgpt2 ghcr.io/huggingface/text-generation-inference
 ```
 
-Run the client:
+Run the text client:
 
 ```bash
 cd text-client

--- a/inference/README.md
+++ b/inference/README.md
@@ -52,7 +52,7 @@ docker attach open-assistant-inference-text-client-1
 > **Note:** Please wait for the `inference-text-generation-server` service to
 > output `{"message":"Connected"}` before starting to chat.
 
-## Development Variant 2 (you'll need tmux)
+## Development Variant 2 (tmux terminal multiplexing)
 
 Ensure you have `tmux` installed on you machine and the following packages
 installed into the Python environment;

--- a/inference/README.md
+++ b/inference/README.md
@@ -54,9 +54,24 @@ docker attach open-assistant-inference-text-client-1
 
 ## Development Variant 2 (you'll need tmux)
 
-Run `./full-dev-setup.sh` to start the full development setup. Make sure to wait
-until the 2nd terminal is ready and says `{"message":"Connected"}` before
-entering input into the last terminal.
+Ensure you have `tmux` installed on you machine and the following packages
+installed into the Python environment;
+
+- `uvicorn`
+- `worker/requirements.txt`
+- `server/requirements.txt`
+- `text-client/requirements.txt`
+- `oasst_shared`
+
+You can run development setup to start the full development setup.
+
+```bash
+cd inference
+./full-dev-setup.sh
+```
+
+> Make sure to wait until the 2nd terminal is ready and says
+> `{"message":"Connected"}` before entering input into the last terminal.
 
 ## Development Variant 3 (you'll need multiple terminals)
 

--- a/inference/README.md
+++ b/inference/README.md
@@ -75,6 +75,12 @@ cd inference
 
 ## Development Variant 3 (you'll need multiple terminals)
 
+Run a postgres container:
+
+```bash
+docker run --rm -it -p 5432:5432 -e POSTGRES_PASSWORD=postgres --name postgres postgres
+```
+
 Run a redis container (or use the one of the general docker compose file):
 
 ```bash

--- a/inference/server/requirements.txt
+++ b/inference/server/requirements.txt
@@ -1,5 +1,5 @@
 alembic
-fastapi[all]
+fastapi[all]==0.88.0
 loguru
 prometheus-fastapi-instrumentator
 psycopg2-binary


### PR DESCRIPTION
fixes #1549. 

I've verified that I can setup the inference-server locally using each method with a fresh Python environment. 

* Updates installation option 2. with necessary requirements.
* Pins `fastapi` version so that we can don't have a `RuntimeError` similar to [this](https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/7714).
* Adds missing `postgres` container to installation option 3.
* Adds missing API key to manual installation option 3