### PR TITLE
Translate the "Looks like no tasks were found." page

### DIFF
--- a/website/public/locales/cs/common.json
+++ b/website/public/locales/cs/common.json
@@ -1,6 +1,7 @@
 {
   "about": "O nás",
   "account_settings": "Účet",
+  "back_to_dashboard": "Zpět na nástěnku",
   "connect": "Připojit",
   "conversational": "Konverzační AI pro všechny.",
   "copied": "Zkopírováno",

--- a/website/public/locales/cs/tasks.json
+++ b/website/public/locales/cs/tasks.json
@@ -49,6 +49,7 @@
     "unchanged_title": "Původní pořadí",
     "unchanged_message": "Pořadí zpráv nebylo změněno. Jste si jistí, že chcete pokračovat?"
   },
+  "no_more_tasks": "Vypadá to, že tu nejdou žádné další úlohy.",
   "label_initial_prompt": {
     "label": "Označkovat úvodní dotaz",
     "desc": "Označkujte úvodní dotaz.",

--- a/website/public/locales/en/common.json
+++ b/website/public/locales/en/common.json
@@ -2,6 +2,7 @@
   "about": "About",
   "account_settings": "Account",
   "admin_dashboard": "Admin Dashboard",
+  "back_to_dashboard": "Go back to the dashboard",
   "connect": "Connect",
   "conversational": "Conversational AI for everyone.",
   "copied": "Copied",

--- a/website/public/locales/en/tasks.json
+++ b/website/public/locales/en/tasks.json
@@ -5,6 +5,7 @@
     "unchanged_title": "No changes",
     "unchanged_message": "Are you sure you would like to continue?"
   },
+  "no_more_tasks": "Looks like no tasks were found.",
   "random": {
     "label": "I'm feeling lucky",
     "desc": "Help us improve Open Assistant by starting a random task."

--- a/website/public/locales/es/common.json
+++ b/website/public/locales/es/common.json
@@ -1,6 +1,7 @@
 {
   "about": "Acerca de",
   "account_settings": "Cuenta",
+  "back_to_dashboard": "Volver al panel principal",
   "admin_dashboard": "Panel de administración",
   "connect": "Conectar",
   "conversational": "IA conversacional para todos.",

--- a/website/public/locales/es/tasks.json
+++ b/website/public/locales/es/tasks.json
@@ -42,6 +42,7 @@
     "desc": "Proporciona etiquetas para unas instrucciones.",
     "overview": "Dada la discusión siguiente, proporciona etiquetas para la última entrada."
   },
+  "no_more_tasks": "Parece que no se ha encontrado ninguna tarea.",
   "random": {
     "label": "Voy a tener suerte",
     "desc": "Ayúdanos a mejorar Open Assistant empezando con una tarea aleatoria."

--- a/website/src/components/EmptyState.tsx
+++ b/website/src/components/EmptyState.tsx
@@ -1,6 +1,7 @@
 import { Box, Text, useColorModeValue } from "@chakra-ui/react";
 import { AlertTriangle, LucideIcon } from "lucide-react";
 import NextLink from "next/link";
+import { useTranslation } from "next-i18next";
 
 type EmptyStateProps = {
   text: string;
@@ -11,13 +12,15 @@ type EmptyStateProps = {
 export const EmptyState = (props: EmptyStateProps) => {
   const backgroundColor = useColorModeValue("white", "gray.800");
 
+  const { t } = useTranslation("common");
+
   return (
     <Box data-cy={props["data-cy"]} bg={backgroundColor} p="10" borderRadius="xl" shadow="base">
       <Box display="flex" flexDirection="column" alignItems="center" gap="8" fontSize="lg">
         <props.icon size="30" color="DarkOrange" />
         <Text data-cy="cy-no-tasks">{props.text}</Text>
         <NextLink href="/dashboard">
-          <Text color="blue.500">Go back to the dashboard</Text>
+          <Text color="blue.500">{t("back_to_dashboard")}</Text>
         </NextLink>
       </Box>
     </Box>
@@ -25,5 +28,7 @@ export const EmptyState = (props: EmptyStateProps) => {
 };
 
 export const TaskEmptyState = () => {
-  return <EmptyState text="Looks like no tasks were found." icon={AlertTriangle} data-cy="task" />;
+  const { t } = useTranslation("tasks");
+
+  return <EmptyState text={t("no_more_tasks")} icon={AlertTriangle} data-cy="task" />;
 };


### PR DESCRIPTION
- Added the code for translation of the page that appears when there are no more tasks of given type available
- Updated en, es, and cs locale files