### PR TITLE
website: Add missing translation keys for stats page

### DIFF
--- a/website/public/locales/en/stats.json
+++ b/website/public/locales/en/stats.json
@@ -1,11 +1,15 @@
 {
+  "aborted_low_grade": "Aborted low grade",
+  "backlog_ranking": "Backlog ranking",
   "count": "Count",
   "growing": "Growing",
   "halted_by_moderator": "Halted by moderator",
   "human_messages_by_lang": "Human messages by language",
   "human_messages_by_role": "Human messages by role",
+  "initial_prompt_review": "Initial prompt review",
   "message_trees_by_state": "Message trees by state",
   "message_trees_states_by_lang": "Message trees states by language",
+  "ranking": "Ranking",
   "ready_for_export": "Ready for export",
   "stats": "Stats",
   "users_accepted_tos": "Users accepted terms"


### PR DESCRIPTION
This PR is self explanatory, there was some missing translations based on the keys returned from the server.