### PR TITLE
Fix CodeT data notebooks to run out the box and display a sample output

### DIFF
--- a/notebooks/data-augmentation/codet-data/Augment_CodeT_codegen.ipynb
+++ b/notebooks/data-augmentation/codet-data/Augment_CodeT_codegen.ipynb
@@ -27,7 +27,7 @@
     "import json\n",
     "from pathlib import Path\n",
     "import requests\n",
-    "from typing import Dict, List, Tuple"
+    "from typing import List, Tuple"
    ]
   },
   {
@@ -45,6 +45,8 @@
     "    \"HumanEval_codegen.jsonl\",\n",
     "    \"mbpp_codegen.jsonl\",\n",
     "]\n",
+    "\n",
+    "Path(\"data/augmented\").mkdir(parents=True, exist_ok=True)\n",
     "\n",
     "FILE_PATHS: List[Path] = [Path(f\"data/{data_file}\") for data_file in DATA_FILES]\n",
     "\n",
@@ -166,11 +168,93 @@
     "for file_path, out_path in zip(FILE_PATHS, OUT_PATHS):\n",
     "    process_file(file_path, out_path)"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display a sample output from HumanEval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prompt\n",
+      "Write a Python function corresponding to the docstring: Check if in given list of numbers, are any two numbers closer to each other than given threshold.\n",
+      "\n",
+      "Solution\n",
+      "from typing import List\n",
+      "\n",
+      "def has_close_elements(numbers: List[float], threshold: float) -> bool:\n",
+      "    for idx, elem in enumerate(numbers):\n",
+      "        for idx2, elem2 in enumerate(numbers):\n",
+      "            if idx != idx2:\n",
+      "                distance = abs(elem - elem2)\n",
+      "                if distance < threshold:\n",
+      "                    return True\n",
+      "\n",
+      "    return False\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample = json.loads(Path(\"data/augmented/HumanEval_codegen.jsonl\").read_text().splitlines()[0])\n",
+    "\n",
+    "print(\"Prompt\")\n",
+    "print(sample[\"prompt\"])\n",
+    "print()\n",
+    "print(\"Solution\")\n",
+    "print(sample[\"solution\"])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display a sample output from MBPP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prompt\n",
+      "Write a Python function corresponding to the docstring: ''' Write a function to find the shared elements from the given two lists.\n",
+      "\n",
+      "Solution\n",
+      "def similar_elements(test_tup1, test_tup2):\n",
+      "  res = tuple(set(test_tup1) & set(test_tup2))\n",
+      "  return (res) \n"
+     ]
+    }
+   ],
+   "source": [
+    "sample = json.loads(Path(\"data/augmented/mbpp_codegen.jsonl\").read_text().splitlines()[0])\n",
+    "\n",
+    "print(\"Prompt\")\n",
+    "print(sample[\"prompt\"])\n",
+    "print()\n",
+    "print(\"Solution\")\n",
+    "print(sample[\"solution\"])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('venv': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -184,12 +268,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.6"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "1f9a0efd3e4a33b8f30a65df6ca5a95cc3f93ce2f11519ee8c13fe711de61465"
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
    }
   }
  },

--- a/notebooks/data-augmentation/codet-data/Augment_CodeT_testgen.ipynb
+++ b/notebooks/data-augmentation/codet-data/Augment_CodeT_testgen.ipynb
@@ -46,6 +46,8 @@
     "    \"mbpp_testgen.jsonl\",\n",
     "]\n",
     "\n",
+    "Path(\"data/augmented\").mkdir(parents=True, exist_ok=True)\n",
+    "\n",
     "FILE_PATHS: List[Path] = [Path(f\"data/{data_file}\") for data_file in DATA_FILES]\n",
     "\n",
     "OUT_PATHS: List[Path] = [Path(f\"data/augmented/{out_file}\") for out_file in OUT_FILES]"
@@ -159,11 +161,92 @@
     "for file_path, out_path in zip(FILE_PATHS, OUT_PATHS):\n",
     "    process_file(file_path, out_path)"
    ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display a sample output from HumanEval"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prompt\n",
+      "Write a test for a Python function with the following docstring: Check if in given list of numbers, are any two numbers closer to each other than given threshold.\n",
+      "\n",
+      "Solution\n",
+      "def check(candidate):\n",
+      "    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.3) == True\n",
+      "    assert candidate([1.0, 2.0, 3.9, 4.0, 5.0, 2.2], 0.05) == False\n",
+      "    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.95) == True\n",
+      "    assert candidate([1.0, 2.0, 5.9, 4.0, 5.0], 0.8) == False\n",
+      "    assert candidate([1.0, 2.0, 3.0, 4.0, 5.0, 2.0], 0.1) == True\n",
+      "    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 1.0) == True\n",
+      "    assert candidate([1.1, 2.2, 3.1, 4.1, 5.1], 0.5) == False\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample = json.loads(Path(\"data/augmented/HumanEval_testgen.jsonl\").read_text().splitlines()[0])\n",
+    "\n",
+    "print(\"Prompt\")\n",
+    "print(sample[\"prompt\"])\n",
+    "print()\n",
+    "print(\"Solution\")\n",
+    "print(sample[\"solution\"])"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Display a sample output from MBPP"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Prompt\n",
+      "Write a test for a Python function with the following docstring: ''' Write a function to find the shared elements from the given two lists.\n",
+      "\n",
+      "Solution\n",
+      "def check(candidate):\n",
+      "    assert set(similar_elements((3, 4, 5, 6),(5, 7, 4, 10))) == set((4, 5))\n",
+      "    assert set(similar_elements((1, 2, 3, 4),(5, 4, 3, 7))) == set((3, 4))\n",
+      "    assert set(similar_elements((11, 12, 14, 13),(17, 15, 14, 13))) == set((13, 14))\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample = json.loads(Path(\"data/augmented/mbpp_testgen.jsonl\").read_text().splitlines()[0])\n",
+    "\n",
+    "print(\"Prompt\")\n",
+    "print(sample[\"prompt\"])\n",
+    "print()\n",
+    "print(\"Solution\")\n",
+    "print(sample[\"solution\"])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.5 ('venv': venv)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -177,12 +260,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.9.6"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "1f9a0efd3e4a33b8f30a65df6ca5a95cc3f93ce2f11519ee8c13fe711de61465"
+    "hash": "31f2aee4e71d21fbe5cf8b01ff0e069b9275f58929596ceb00d14d90e3e16cd6"
    }
   }
  },


### PR DESCRIPTION
These notebooks previously required the "data" and "data/augmentation" directories to be manually created to run. This fixes that problem and introduces a cell to output a sample so that anyone browsing GitHub can see an example of the content of the data.