### PR TITLE
Add initial load tests

### DIFF
--- a/inference/README.md
+++ b/inference/README.md
@@ -117,3 +117,16 @@ cd text-client
 pip install -r requirements.txt
 python __main__.py
 ```
+
+## Distributed Testing
+
+We run distributed load tests using the
+[`locust`](https://github.com/locustio/locust) Python package.
+
+```bash
+pip install locust
+cd tests/locust
+locust
+```
+
+Navigate to http://0.0.0.0:8089/ to view the locust UI.

--- a/inference/server/main.py
+++ b/inference/server/main.py
@@ -236,9 +236,11 @@ async def create_message(
 
                 _, response_packet_str = item
                 response_packet = inference.WorkResponsePacket.parse_raw(response_packet_str)
+                logger.info(f"Received response packet for {chat_id} of {response_packet}")
                 result_data.append(response_packet)
 
                 if response_packet.is_end:
+                    logger.info(f"Reached end of response packet for {chat_id}")
                     break
 
                 yield {

--- a/inference/tests/locust/locustfile.py
+++ b/inference/tests/locust/locustfile.py
@@ -1,0 +1,9 @@
+from locust import HttpUser, between
+
+
+class ChatUser(HttpUser):
+    wait_time = between(1, 2)
+
+    def on_start(self):
+        response = self.client.post("/chat", json={}).json()
+        self.chat_id = response["id"]

--- a/inference/tests/locust/locustfile.py
+++ b/inference/tests/locust/locustfile.py
@@ -1,4 +1,6 @@
 import json
+import random
+import time
 
 import sseclient
 from locust import HttpUser, between, task
@@ -6,21 +8,24 @@ from locust import HttpUser, between, task
 
 class ChatUser(HttpUser):
     wait_time = between(1, 2)
-
-    def on_start(self):
-        response = self.client.post("/chat", json={}).json()
-        self.chat_id = response["id"]
+    conversation_length = random.randint(3, 20)
+    time_to_respond = random.randint(3, 5)  # for the user
 
     @task
-    def send_msg(self):
-        response = self.client.post(
-            f"/chat/{self.chat_id}/message",
-            json={"message": "yo"},
-            stream=True,
-            headers={"Accept": "text/event-stream"},
-        )
-        response.raise_for_status()
+    def chat(self):
+        chat_id = self.client.post("/chat", json={}).json()["id"]
 
-        client = sseclient.SSEClient(response)
-        for event in client.events():
-            _ = json.loads(event.data)
+        for _ in range(self.conversation_length):
+            response = self.client.post(
+                f"/chat/{chat_id}/message",
+                json={"message": "yo"},
+                stream=True,
+                headers={"Accept": "text/event-stream"},
+            )
+            response.raise_for_status()
+
+            client = sseclient.SSEClient(response)
+            for event in client.events():
+                _ = json.loads(event.data)
+
+            time.sleep(self.time_to_respond)

--- a/inference/tests/locust/locustfile.py
+++ b/inference/tests/locust/locustfile.py
@@ -1,4 +1,7 @@
-from locust import HttpUser, between
+import json
+
+import sseclient
+from locust import HttpUser, between, task
 
 
 class ChatUser(HttpUser):
@@ -7,3 +10,17 @@ class ChatUser(HttpUser):
     def on_start(self):
         response = self.client.post("/chat", json={}).json()
         self.chat_id = response["id"]
+
+    @task
+    def send_msg(self):
+        response = self.client.post(
+            f"/chat/{self.chat_id}/message",
+            json={"message": "yo"},
+            stream=True,
+            headers={"Accept": "text/event-stream"},
+        )
+        response.raise_for_status()
+
+        client = sseclient.SSEClient(response)
+        for event in client.events():
+            _ = json.loads(event.data)


### PR DESCRIPTION
* closes #1622 

I've used locust to write a basic load test which will hit two endpoints sequentially that mimic the `text-client` in the inference server.

1. `/chat` to start a new conversation with `chat_id`
2. `/chat/{chat_id}/message` to send a message to the Assistant

An isolated load test user workflow is summarised by first spawning $X$ users every $T$ seconds to a maximum amount of $N$ concurrent users

1. A user starts a conversation with the Assistant
2. Then they enter a conversation loop
    1. Send a chat message to the Assistant
    2. Wait until Assistant responds
    3. Wait $S$ further seconds
    4. Repeat

Initial results showed the Bot failing (potentially due to a race condition) and I'm currently investigating the source of that error. The main error happens inside of `add_prompter_message()`  and is is caused by the `chat.pending_message_request` status being non `None` giving rise to a `HTTPError` of “Already pending”.