### PR TITLE
Add language badge to messages

### DIFF
--- a/website/src/components/Messages/MessageTableEntry.tsx
+++ b/website/src/components/Messages/MessageTableEntry.tsx
@@ -133,6 +133,9 @@ export function MessageTableEntry({ message, enabled, highlight, showAuthorBadge
           style={{ float: "right", position: "relative", right: "-0.3em", bottom: "-0em", marginLeft: "1em" }}
           onClick={(e) => e.stopPropagation()}
         >
+          <Badge variant="subtle" colorScheme="gray" fontSize="xx-small">
+            {message.lang}
+          </Badge>
           {Object.entries(emojiState.emojis)
             .filter(([emoji]) => isKnownEmoji(emoji))
             .sort(([emoji]) => -emoji)


### PR DESCRIPTION
Should make it easier to identify the language of the message.

![image](https://user-images.githubusercontent.com/24505302/219687164-e1cfa3ac-eecd-4b49-bc94-221d6027d416.png)
