### PR TITLE
fix: added platform support for ghcr.io images to be run on Apple Sil…

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -52,6 +52,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v3.2.0
         with:
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           file: ${{ inputs.dockerfile }}
           context: ${{ inputs.context }}
           build-args: ${{ inputs.build-args }}


### PR DESCRIPTION
Added support for multiple platforms for ghcr.io images. 

When running this image on an x86_64 / amd64 machine, the amd64 variant is pulled and run.

Reference:
https://docs.docker.com/engine/reference/commandline/buildx_build/#platform
https://docs.docker.com/build/building/multi-platform/
