### PR TITLE
Reduce probability of initial prompt tasks

### DIFF
--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -193,7 +193,7 @@ class TreeManager:
             task_weights[TaskType.REPLY.value] = 2
 
         if num_missing_prompts > 0:
-            task_weights[TaskType.PROMPT.value] = 1
+            task_weights[TaskType.PROMPT.value] = 0.01
 
         task_weights = np.array(task_weights)
         weight_sum = task_weights.sum()


### PR DESCRIPTION
The weight of initial prompt tasks for random task selection is reduced to 0.01 which makes it very unlikely to be selected as long as other tasks such as reply or ranking are available.

Closes: #1758 