### PR TITLE
Add enabled flag + query param to trollboards REST endpoint

### DIFF
--- a/backend/oasst_backend/api/v1/trollboards.py
+++ b/backend/oasst_backend/api/v1/trollboards.py
@@ -14,8 +14,9 @@ router = APIRouter()
 def get_trollboard(
     time_frame: UserStatsTimeFrame,
     max_count: Optional[int] = Query(100, gt=0, le=10000),
+    enabled: Optional[bool] = None,
     api_client: ApiClient = Depends(deps.get_trusted_api_client),
     db: Session = Depends(deps.get_db),
 ) -> TrollboardStats:
     usr = UserStatsRepository(db)
-    return usr.get_trollboard(time_frame, limit=max_count)
+    return usr.get_trollboard(time_frame, limit=max_count, enabled=enabled)

--- a/oasst-shared/oasst_shared/schemas/protocol.py
+++ b/oasst-shared/oasst_shared/schemas/protocol.py
@@ -495,6 +495,9 @@ class TrollScore(BaseModel):
     auth_method: str
     display_name: str
     last_activity_date: Optional[datetime]
+    enabled: bool
+    deleted: bool
+    show_on_leaderboard: bool
 
     troll_score: int = 0
 


### PR DESCRIPTION
- three additional user properties are now included in trollboard stats `enabled`, `deleted`, `show_on_leaderboard`
- an optional enabled param can be specified for the trollboards rest queries, to only show enabled send `enabled=true`