### PR TITLE
Add self to documentation and notebook CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,6 @@
 /website/ @fozziethebeat @AbdBarho @notmd
 /model/ @theblackcat102 @sanagno
 /copilot/ @fozziethebeat @andreaskoepf @yk
-/docs/ @andrewm4894 @andreaskoepf @yk
+/docs/ @andrewm4894 @olliestanley @andreaskoepf @yk
 /.devcontainer/ @andrewm4894 @andreaskoepf @yk
-/notebooks/ @andrewm4894 @andreaskoepf @yk
+/notebooks/ @andrewm4894 @olliestanley @andreaskoepf @yk


### PR DESCRIPTION
We receive a lot of documentation and data gathering notebook PRs and this sometimes demands time from Yannic and Andreas who are often needed elsewhere. I would be happy to review some of these PRs to reduce workload