### PR TITLE
Added RM dataset training split and add support for WebGPT and other for RLHF

### DIFF
--- a/model/model_training/custom_datasets/__init__.py
+++ b/model/model_training/custom_datasets/__init__.py
@@ -1,7 +1,7 @@
 """
     High level functions for model training
 """
-from custom_datasets.prompt_dialogue import InstructionTuning, OAPrivate, PrivateInstructionTuning
+from custom_datasets.prompt_dialogue import OAPrivate, PrivateInstructionTuning
 from custom_datasets.qa_datasets import SODA, JokeExplaination, QADataset, SODADialogue, TranslatedQA, WebGPT
 from custom_datasets.summarization import SummarizationDataset
 from custom_datasets.toxic_conversation import ProsocialDialogue, ProsocialDialogueExplaination
@@ -20,7 +20,7 @@ SUMMARIZATION_DATASETS = [
     "debate_sum",
     "tldr_news",
 ]
-OTHER = ["prosocial_dialogue", "explain_prosocial", "instruct_tuning", "private_tuning", "oa_translated", "oa_private"]
+OTHER = ["prosocial_dialogue", "explain_prosocial", "private_tuning", "oa_translated", "oa_private"]
 
 RL_DATASETS = ["oa_private"]
 
@@ -75,12 +75,11 @@ def get_one_dataset(conf, dataset_name, val_split=0.2, data_path=None, mode="sft
         dataset = SODADialogue(data_path)
     elif dataset_name == "joke":
         dataset = JokeExplaination(data_path)
-    elif dataset_name == "instruct_tuning":
-        dataset = InstructionTuning(data_path)
     elif dataset_name == "private_tuning":
         dataset = PrivateInstructionTuning(data_path)
     elif dataset_name == "oa_translated":
-        dataset = TranslatedQA(data_path)  # TODO make val_split lower..?
+        # TODO make val_split lower..? by saganos
+        dataset = TranslatedQA(data_path)
     elif dataset_name == "oa_private":
         dataset = OAPrivate(data_path, **kwargs)
     else:

--- a/model/model_training/custom_datasets/__init__.py
+++ b/model/model_training/custom_datasets/__init__.py
@@ -22,7 +22,7 @@ SUMMARIZATION_DATASETS = [
 ]
 OTHER = ["prosocial_dialogue", "explain_prosocial", "private_tuning", "oa_translated", "oa_private"]
 
-RL_DATASETS = ["oa_private"]
+RL_DATASETS = ["oa_private", "webgpt", "private_tuning"]
 
 
 def train_val_dataset(dataset, val_split=0.2):

--- a/model/model_training/custom_datasets/formatting.py
+++ b/model/model_training/custom_datasets/formatting.py
@@ -8,3 +8,8 @@ def format_pair(pairs):
         else pairs[i]
         for i in range(len(pairs))
     ]
+
+
+def format_rl_text(pairs):
+    # convert question answer pairs to only the prefix prompt for RLHF
+    return "{}{}{}".format(QA_SPECIAL_TOKENS["Question"], pairs[0], QA_SPECIAL_TOKENS["Answer"])

--- a/model/model_training/custom_datasets/prompt_dialogue.py
+++ b/model/model_training/custom_datasets/prompt_dialogue.py
@@ -4,7 +4,6 @@ import os
 import random
 from collections import OrderedDict
 from functools import reduce
-from urllib.request import urlopen
 
 import numpy as np
 from custom_datasets.formatting import QA_SPECIAL_TOKENS, format_pair
@@ -76,104 +75,6 @@ class OAPrivate(Dataset):
             return "".join(pairs)
 
 
-class PromptGeneratedDataset(Dataset):
-    """Generates from flan 11B
-    User: What are the best methods for preventing a slave trade?
-
-    Rosey: The best methods ....
-    <|endoftext|>
-
-    we are ignoring results with multiple lines for now
-    """
-
-    name = "prompt_dialogue"
-    url = "https://github.com/Rallio67/language-model-agents/raw/main/chat_dialogue_v2_c.txt"
-
-    def __init__(self, cache_dir) -> None:
-        super().__init__()
-        os.makedirs(cache_dir, exist_ok=True)
-        chat_dialogue = os.path.join(cache_dir, "chat_dialogue_v2_c.txt")
-        if not os.path.exists(chat_dialogue):
-            with urlopen(self.url) as file:
-                content = file.read().decode()
-            with open(chat_dialogue, "w") as fout:
-                fout.write(content)
-
-        question = ""
-        answer = ""
-        self.pairs = []
-        with open(chat_dialogue, "r") as f:
-            corpus = f.read().split("<|endoftext|>")
-            for dialogue in corpus:
-                dialogue = dialogue.strip()
-                if "Rosey:" in dialogue:
-                    user, bot = dialogue.split("Rosey:", maxsplit=1)
-                    question = user.split(":", maxsplit=1)[1].strip()
-                    answer = bot.strip()
-                    if len(answer) and len(question):
-                        self.pairs.append((question, answer))
-
-        if len(question) > 0 and len(answer) > 0:
-            self.pairs.append((question, answer))
-
-    def __len__(self):
-        return len(self.pairs)
-
-    def __getitem__(self, index):
-        return format_pair(self.pairs[index])
-
-
-class InstructionTuning(Dataset):
-    """
-    We have seen some promising capabilities from instruction tuning
-    with the following mix of datasets that are derived from datasets
-    available online.
-    The files for this data are in json format as a list of tuples
-    where each tuple is (source,instruction_response_pair)
-
-        - instruction_tuning_dataset_alpha_part1.json
-        - instruction_tuning_dataset_alpha_part2.json
-
-    Not to be confused with unatural instruction
-    """
-
-    name = "instruction_dataset"
-    url_part_2 = (
-        "https://github.com/Rallio67/language-model-agents/raw/main/instruction_tuning_dataset_alpha_part2.json"
-    )
-    url_part_1 = (
-        "https://github.com/Rallio67/language-model-agents/raw/main/instruction_tuning_dataset_alpha_part1.json"
-    )
-
-    def __init__(self, cache_dir) -> None:
-        super().__init__()
-        os.makedirs(cache_dir, exist_ok=True)
-
-        self.pairs = []
-        for file_link in [self.url_part_1, self.url_part_2]:
-            basename = file_link.split("/")[-1]
-            instruction_tune_file = os.path.join(cache_dir, basename)
-            if not os.path.exists(instruction_tune_file):
-                with urlopen(file_link) as file:
-                    content = file.read().decode()
-                with open(instruction_tune_file, "w", encoding="utf-8") as fout:
-                    fout.write(content)
-
-            with open(instruction_tune_file, "r", encoding="utf-8") as f:
-                datasets = json.load(f)
-                for row in datasets:
-                    _, response_pair = row
-                    question, answer = response_pair.split("\n\n", maxsplit=1)
-                    answer = answer.replace("<|endoftext|>", "").strip()
-                    self.pairs.append((question, answer))
-
-    def __len__(self):
-        return len(self.pairs)
-
-    def __getitem__(self, index):
-        return format_pair(self.pairs[index])
-
-
 class PrivateInstructionTuning(Dataset):
     """
     We have seen some promising capabilities from instruction tuning
@@ -186,14 +87,17 @@ class PrivateInstructionTuning(Dataset):
     """
 
     name = "private_tuning"
-    filename = "oa_v3_fixed_plus_safety.jsonl"
+    # how to switch it in get_one_dataset?
+    splits = OrderedDict(sft=0.25, reward_model=0.4, rl=0.35)  # fractions per task
 
-    def __init__(self, cache_dir) -> None:
+    def __init__(self, cache_dir, split="sft", filename="oa_v3_fixed_plus_safety.jsonl") -> None:
         super().__init__()
+        self.mode = split
+
         os.makedirs(cache_dir, exist_ok=True)
 
         self.pairs = []
-        for file_link in [self.filename]:
+        for file_link in [filename]:
             basename = file_link.split("/")[-1]
             instruction_tune_file = os.path.join(cache_dir, basename)
 
@@ -213,4 +117,7 @@ class PrivateInstructionTuning(Dataset):
 
     def __getitem__(self, index):
         prompt, answer = self.pairs[index]
-        return "{}{}".format(prompt, QA_SPECIAL_TOKENS["Answer"]), answer
+        if self.mode == "sft":
+            return "{}{}".format(prompt, QA_SPECIAL_TOKENS["Answer"]), answer
+        elif self.mode == "rl":
+            return "{}{}".format(prompt, QA_SPECIAL_TOKENS["Answer"])

--- a/model/model_training/custom_datasets/qa_datasets.py
+++ b/model/model_training/custom_datasets/qa_datasets.py
@@ -5,10 +5,11 @@ import glob
 import json
 import os
 import re
+from collections import OrderedDict
 from urllib.request import urlopen
 
 import numpy as np
-from custom_datasets.formatting import QA_SPECIAL_TOKENS, format_pair
+from custom_datasets.formatting import QA_SPECIAL_TOKENS, format_pair, format_rl_text
 from datasets import load_dataset
 from torch.utils.data import Dataset
 
@@ -175,10 +176,11 @@ class QADataset(Dataset):
 class WebGPT(Dataset):
 
     name = "webgpt"
+    splits = OrderedDict(sft=0.25, reward_model=0.4, rl=0.35)  # fractions per task
 
-    def __init__(self) -> None:
+    def __init__(self, split="sft") -> None:
         super().__init__()
-
+        self.mode = split
         dataset = load_dataset("openai/webgpt_comparisons")
         questions = {}
         # using prompt as our index will allows us
@@ -202,7 +204,10 @@ class WebGPT(Dataset):
     def __getitem__(self, index):
         question = self.index2question[index]
         answer = self.questions[question]
-        return format_pair((question, answer))
+        if self.mode == "sft":
+            return format_pair((question, answer))
+        elif self.mode == "rl":
+            return format_rl_text((question, answer))
 
 
 class SODA(Dataset):

--- a/model/model_training/tests/test_datasets.py
+++ b/model/model_training/tests/test_datasets.py
@@ -2,12 +2,30 @@ from argparse import Namespace
 
 from custom_datasets import QA_DATASETS, SUMMARIZATION_DATASETS, get_one_dataset
 from custom_datasets.dialogue_collator import DialogueDataCollator
+from custom_datasets.prompt_dialogue import OAPrivate, PrivateInstructionTuning
+
+
+def test_rl_sft_mode_switch():
+
+    dataset = OAPrivate(".cache", split="sft")
+    row = dataset[0]
+    assert isinstance(row, list)
+    dataset = OAPrivate(".cache", split="rl")
+    row = dataset[0]
+    assert isinstance(row, str)
+
+    dataset = PrivateInstructionTuning(".cache", split="sft")
+    row = dataset[0]
+    assert isinstance(row, tuple)
+    dataset = PrivateInstructionTuning(".cache", split="rl")
+    row = dataset[0]
+    assert isinstance(row, str)
 
 
 def test_all_datasets():
     qa_base = QA_DATASETS
     summarize_base = SUMMARIZATION_DATASETS
-    others = ["prompt_dialogue", "webgpt", "soda", "joke", "instruct_tuning", "explain_prosocial", "prosocial_dialogue"]
+    others = ["webgpt", "soda", "joke", "explain_prosocial", "prosocial_dialogue"]
     translation = ["dive_mt", "wmt2019_zh-en", "wmt2019_ru-en", "ted_trans_de-ja", "ted_trans_nl-en"]
 
     config = Namespace(cache_dir=".cache")
@@ -30,7 +48,7 @@ def test_collate_fn():
     collate_fn = DialogueDataCollator(tokenizer, max_length=620)
     qa_base = QA_DATASETS
     summarize_base = SUMMARIZATION_DATASETS
-    others = ["prompt_dialogue", "webgpt", "soda", "joke", "gsm8k"]
+    others = ["webgpt", "soda", "joke", "gsm8k"]
     trains, evals = [], []
     for dataset_name in others + qa_base + summarize_base:
         print(dataset_name)
@@ -48,6 +66,3 @@ def test_collate_fn():
     dataloader = DataLoader(ConcatDataset(evals), collate_fn=collate_fn, batch_size=128)
     for batch in dataloader:
         assert batch["targets"].shape[1] <= 620
-
-
-test_collate_fn()

--- a/model/model_training/tools/sample_rm_data.py
+++ b/model/model_training/tools/sample_rm_data.py
@@ -1,0 +1,188 @@
+"""
+    Recursive method to travese down the the conversation tree
+
+    Use fastlangid for language identification :
+    >> pip install fastlangid
+
+"""
+import glob
+import json
+import random
+import sys
+from collections import defaultdict
+from copy import deepcopy
+
+from fastlangid.langid import LID
+
+langid = LID()
+total_ranks = []
+target_file = sys.argv[1]
+
+attributes = [
+    "message_id",
+    "parent_id",
+    "text",
+    "role",
+    "lang",
+    "review_count",
+    "rank",
+    "synthetic",
+    "model_name",
+    "emojis",
+]
+
+
+def rank_replies(replies):
+    return sorted(replies, key=lambda x: x["rank"])
+
+
+def expand_nodes(tree):
+    all_convo = []
+
+    def traverse_tree(tree, root):
+        if len(tree["replies"]) == 0:
+            all_convo.append(root)
+            return
+
+        for reply in tree["replies"]:
+            new_root = deepcopy(root)
+            new_root.append({attr: reply[attr] for attr in attributes if attr in reply})
+            traverse_tree(reply, new_root)
+
+    init_root = [{attr: tree[attr] for attr in attributes if attr in tree}]
+    traverse_tree(tree, init_root)
+    return all_convo
+
+
+def extract_all_pair_rank(tree):
+    pairs = []
+
+    def traverse_tree(tree, root):
+        if len(tree["replies"]) == 0:
+            return
+
+        if tree["role"] == "prompter" and len(tree["replies"]) > 1:
+            available_reply = [{attr: r[attr] for attr in attributes if attr in r} for r in tree["replies"]]
+            pairs.append((root, available_reply))
+
+        for reply in tree["replies"]:
+            new_root = deepcopy(root)
+            new_root.append({attr: reply[attr] for attr in attributes if attr in reply})
+            traverse_tree(reply, new_root)
+
+    init_root = [{attr: tree[attr] for attr in attributes if attr in tree}]
+    traverse_tree(tree, init_root)
+    return pairs
+
+
+def viz_convo(conversation):
+    for text in conversation:
+        print(text["role"], ":", text["text"])
+
+
+def calculate_total_threads(_target_file):
+    total = 0
+    lang_stats = defaultdict(int)
+    with open(_target_file, "r") as f:
+        print(_target_file)
+        for line in f:
+            row = json.loads(line)
+            seed_prompt = row["prompt"]
+            all_convo = expand_nodes(row["prompt"])
+            for convo in all_convo:
+                for convo_ in convo:
+                    lang = langid.predict(convo_["text"])
+                    lang_stats[lang] += 1
+
+            if len(all_convo) > 1:
+                total += len(all_convo)
+            assert seed_prompt["role"] == "prompter"
+    print(total)
+    print(lang_stats)
+
+
+def process_context(convo):
+    if len(convo) == 1:
+        return {"prompt": convo[0]["text"], "history": []}
+    last_prompt = convo[-1]
+    convo.pop(-1)
+    history_pair = []
+    for idx in range(0, len(convo), 2):
+        history_pair.append((convo[idx]["text"], convo[idx + 1]["text"]))
+
+    return {"prompt": last_prompt["text"], "history": history_pair}
+
+
+if __name__ == "__main__":
+    calculate_total_threads(target_file)
+
+    usable_rank = 0
+    response_with_rank = 0
+    RM_dataset = []
+    with open(target_file, "r") as f:
+        for line in f:
+            row = json.loads(line)
+            seed_prompt = row["prompt"]
+            initial = seed_prompt["text"]
+            all_convo = extract_all_pair_rank(row["prompt"])
+            for (convo, replies) in all_convo:
+                if len(replies) > 1:
+                    prefix = process_context(convo)
+                    if "rank" not in replies[0]:
+                        continue
+                    elif replies[0]["rank"] is not None:
+                        for r in replies:
+                            if "rank" in r and r["rank"] is None:
+                                r["rank"] = 5
+                            elif "rank" not in r:
+                                r["rank"] = 5
+                        replies = sorted(replies, key=lambda x: x["rank"])
+                        pos_reply = replies[0]["text"]
+                        neg_replies = [r["text"] for r in replies[1:]]
+
+                        RM_dataset.append(
+                            {
+                                "prompt": prefix["prompt"],
+                                "history": prefix["history"],
+                                "pos": pos_reply,
+                                "neg_replies": neg_replies,
+                            }
+                        )
+
+                        response_with_rank += 1
+
+            usable_rank += len(all_convo)
+
+    print(len(RM_dataset), usable_rank)
+
+    key_sets = set()
+    for rm_jsonl in glob.glob("rm_*.jsonl"):
+        with open(rm_jsonl, "r") as f:
+            for line in f:
+                data = json.loads(line)
+                key = "{}-{}-{}".format(data["prompt"], data["pos"], "".join(data["neg_replies"]))
+                key_sets.add(key)
+
+    new_dataset = []
+    for data in RM_dataset:
+        key = "{}-{}-{}".format(data["prompt"], data["pos"], "".join(data["neg_replies"]))
+        if key not in key_sets:
+            new_dataset.append(data)
+
+    with open("rm_new.jsonl", "w") as f:
+        for row in new_dataset:
+            f.write(json.dumps(row) + "\n")
+
+    random.shuffle(RM_dataset)
+    train_flag = int(len(RM_dataset) * 0.8)
+    test_flag = int(len(RM_dataset) * 0.9)
+    train, test, val = RM_dataset[:train_flag], RM_dataset[train_flag:test_flag], RM_dataset[test_flag:]
+    with open("rm_train.jsonl", "w") as f:
+        for row in train:
+            f.write(json.dumps(row) + "\n")
+    with open("rm_test.jsonl", "w") as f:
+        for row in test:
+            f.write(json.dumps(row) + "\n")
+    with open("rm_val.jsonl", "w") as f:
+        for row in val:
+            f.write(json.dumps(row) + "\n")

--- a/oasst-shared/oasst_shared/schemas/inference.py
+++ b/oasst-shared/oasst_shared/schemas/inference.py
@@ -64,9 +64,7 @@ class WorkerHardwareInfo(pydantic.BaseModel):
 
 class WorkerConfig(pydantic.BaseModel):
     model_name: str = DEFAULT_MODEL_NAME
-    hardware_info: WorkerHardwareInfo = pydantic.Field(
-        default_factory=WorkerHardwareInfo
-    )
+    hardware_info: WorkerHardwareInfo = pydantic.Field(default_factory=WorkerHardwareInfo)
 
     @property
     def compat_hash(self) -> str:
@@ -81,9 +79,7 @@ class WorkParameters(pydantic.BaseModel):
     top_p: float = 0.9
     temperature: float = 1.0
     repetition_penalty: float | None = None
-    seed: int = pydantic.Field(
-        default_factory=lambda: random.randint(0, 0xFFFF_FFFF_FFFF_FFFF - 1)
-    )
+    seed: int = pydantic.Field(default_factory=lambda: random.randint(0, 0xFFFF_FFFF_FFFF_FFFF - 1))
 
 
 class MessageState(str, enum.Enum):
@@ -111,9 +107,7 @@ class Thread(pydantic.BaseModel):
 
 class WorkRequest(pydantic.BaseModel):
     thread: Thread = pydantic.Field(..., repr=False)
-    created_at: datetime.datetime = pydantic.Field(
-        default_factory=datetime.datetime.utcnow
-    )
+    created_at: datetime.datetime = pydantic.Field(default_factory=datetime.datetime.utcnow)
     parameters: WorkParameters = pydantic.Field(default_factory=WorkParameters)
 
 


### PR DESCRIPTION
1. Added the code I use for splitting RM dataset : tools/sample_rm_data.py

```
python -m tools.sample_rm_data 2023-02-12_oasst_prod.jsonl
```

This generates 3 splits of rm_test.jsonl, rm_train.jsonl, rm_val.jsonl 

2. Added webgpt and private_tuning for RLHF dataset


```
    - oa_private:
        data_path: .cache
        split: rl
        val_split: 0.0
        fraction: 1
        file: 2023-02-12_oasst_prod.jsonl
    - webgpt:
        val_split: 0.0
        fraction: 1
    - private_tuning:
        val_split: 0.0
        fraction: 1
```

make sure `oa_v3_fixed_plus_safety.jsonl` used in private_tuning is placed under .cache
