### PR TITLE
Scoring Adjustment

### DIFF
--- a/backend/oasst_backend/models/user_stats.py
+++ b/backend/oasst_backend/models/user_stats.py
@@ -63,7 +63,7 @@ class UserStats(SQLModel, table=True):
             + int(self.accepted_prompts * 0.05)
             + self.accepted_replies_assistant * 4
             + self.accepted_replies_prompter
-            + int(self.reply_ranked_1 * 9 * 1.2)
-            + int(self.reply_ranked_2 * 3 * 1.2)
-            + int(self.reply_ranked_3 * 1.2)
+            + self.reply_ranked_1 * 11
+            + self.reply_ranked_2 * 3
+            + self.reply_ranked_3
         )

--- a/backend/oasst_backend/models/user_stats.py
+++ b/backend/oasst_backend/models/user_stats.py
@@ -53,17 +53,17 @@ class UserStats(SQLModel, table=True):
 
     def compute_leader_score(self) -> int:
         return (
-            int(self.prompts * 0.08)
-            + int(self.replies_assistant * 4.8)
+            int(self.prompts * 0.05
+            + self.replies_assistant * 4
             + self.replies_prompter
             + self.labels_simple
             + self.labels_full * 2
             + self.rankings_total
             + self.rankings_good
-            + int(self.accepted_prompts * 0.08)
-            + int(self.accepted_replies_assistant * 4.8)
+            + self.accepted_prompts * 0.05
+            + self.accepted_replies_assistant * 4
             + self.accepted_replies_prompter
-            + self.reply_ranked_1 * 9
-            + self.reply_ranked_2 * 3
-            + self.reply_ranked_3
+            + self.reply_ranked_1 * 9 * 1.2
+            + self.reply_ranked_2 * 3 * 1.2
+            + self.reply_ranked_3 * 1.2)
         )

--- a/backend/oasst_backend/models/user_stats.py
+++ b/backend/oasst_backend/models/user_stats.py
@@ -52,18 +52,18 @@ class UserStats(SQLModel, table=True):
     reply_ranked_3: int = 0
 
     def compute_leader_score(self) -> int:
-        return int(
-            self.prompts * 0.05
+        return (
+            int(self.prompts * 0.05)
             + self.replies_assistant * 4
             + self.replies_prompter
             + self.labels_simple
             + self.labels_full * 2
             + self.rankings_total
             + self.rankings_good
-            + self.accepted_prompts * 0.05
+            + int(self.accepted_prompts * 0.05)
             + self.accepted_replies_assistant * 4
             + self.accepted_replies_prompter
-            + self.reply_ranked_1 * 9 * 1.2
-            + self.reply_ranked_2 * 3 * 1.2
-            + self.reply_ranked_3 * 1.2)
+            + int(self.reply_ranked_1 * 9 * 1.2)
+            + int(self.reply_ranked_2 * 3 * 1.2)
+            + int(self.reply_ranked_3 * 1.2)
         )

--- a/backend/oasst_backend/models/user_stats.py
+++ b/backend/oasst_backend/models/user_stats.py
@@ -52,8 +52,8 @@ class UserStats(SQLModel, table=True):
     reply_ranked_3: int = 0
 
     def compute_leader_score(self) -> int:
-        return (
-            int(self.prompts * 0.05
+        return int
+            self.prompts * 0.05
             + self.replies_assistant * 4
             + self.replies_prompter
             + self.labels_simple

--- a/backend/oasst_backend/models/user_stats.py
+++ b/backend/oasst_backend/models/user_stats.py
@@ -53,15 +53,15 @@ class UserStats(SQLModel, table=True):
 
     def compute_leader_score(self) -> int:
         return (
-            int(self.prompts * 0.1)
-            + self.replies_assistant * 4
+            int(self.prompts * 0.08)
+            + int(self.replies_assistant * 4.8)
             + self.replies_prompter
             + self.labels_simple
             + self.labels_full * 2
             + self.rankings_total
             + self.rankings_good
-            + int(self.accepted_prompts * 0.1)
-            + self.accepted_replies_assistant * 4
+            + int(self.accepted_prompts * 0.08)
+            + int(self.accepted_replies_assistant * 4.8)
             + self.accepted_replies_prompter
             + self.reply_ranked_1 * 9
             + self.reply_ranked_2 * 3

--- a/backend/oasst_backend/models/user_stats.py
+++ b/backend/oasst_backend/models/user_stats.py
@@ -52,7 +52,7 @@ class UserStats(SQLModel, table=True):
     reply_ranked_3: int = 0
 
     def compute_leader_score(self) -> int:
-        return int
+        return int(
             self.prompts * 0.05
             + self.replies_assistant * 4
             + self.replies_prompter


### PR DESCRIPTION
To help clear the prompt backlog, as per https://github.com/LAION-AI/Open-Assistant/issues/1659, this cuts the score weighting for creating a prompt in half. It also increases the score weighting for penning a good reply (it getting ranked first) by about 20%.