### PR TITLE
Fix failing pre-commit on WikiData notebook

### DIFF
--- a/notebooks/data-augmentation/wikidata-qa/wikidata.ipynb
+++ b/notebooks/data-augmentation/wikidata-qa/wikidata.ipynb
@@ -54,7 +54,6 @@
    "outputs": [],
    "source": [
     "class WikiGraph:\n",
-    "\n",
     "    HEADER = {\n",
     "        \"User-Agent\": \"Mozilla/5.0 (compatible; WikiDataGraphCrawler/0.1)\",\n",
     "    }\n",


### PR DESCRIPTION
4f8b8906acab5634d3c0b139cad6e3a6f7221dab unfortunately broke pre-commit on `main`, as pre-commit passed on the PR but we since changed the `black` version which no longer agrees with a line in the PR. This fixes the CI failure.