### PR TITLE
Adding Home Page Unit Test

### DIFF
--- a/website/src/test_pages/index.test.tsx
+++ b/website/src/test_pages/index.test.tsx
@@ -1,0 +1,10 @@
+import { render, screen } from "@testing-library/react";
+import Home from "src/pages/index";
+
+describe("Home page", () => {
+  it("should render correctly", () => {
+    render(<Home />);
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Open Assistant");
+  });
+});
+

--- a/website/src/test_pages/index.test.tsx
+++ b/website/src/test_pages/index.test.tsx
@@ -7,4 +7,3 @@ describe("Home page", () => {
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Open Assistant");
   });
 });
-


### PR DESCRIPTION
Noticed there wasn't a jest test for the home/index page. Decided to add one in case something caused that to not work and came up as a breaking change.

Also, I'm planning to add some more website unit tests over the next week or two. It wouldn't hurt for us to have those.