### PR TITLE
Copy message text button

### DIFF
--- a/website/public/locales/en/message.json
+++ b/website/public/locales/en/message.json
@@ -2,7 +2,7 @@
   "confirm_open_link_body": "Do you want to open this link?",
   "confirm_open_link_header": "Confirm open link",
   "copy_message_id": "Copy message ID",
-  "copy_message_text": "Copy message text",
+  "copy_message_text": "Copy raw message",
   "copy_message_link": "Copy message link",
   "label_action": "Label",
   "label_title": "Label",

--- a/website/public/locales/en/message.json
+++ b/website/public/locales/en/message.json
@@ -2,6 +2,7 @@
   "confirm_open_link_body": "Do you want to open this link?",
   "confirm_open_link_header": "Confirm open link",
   "copy_message_id": "Copy message ID",
+  "copy_message_text": "Copy message text",
   "copy_message_link": "Copy message link",
   "label_action": "Label",
   "label_title": "Label",

--- a/website/src/components/Messages/MessageTableEntry.tsx
+++ b/website/src/components/Messages/MessageTableEntry.tsx
@@ -309,6 +309,9 @@ const MessageActions = ({
           >
             {t("copy_message_link")}
           </MenuItem>
+          <MenuItem onClick={() => handleCopy(message.text)} icon={<Copy />}>
+            {t("copy_message_text")}
+          </MenuItem>
           {!!isAdminOrMod && (
             <>
               <MenuDivider />


### PR DESCRIPTION
Adds a simple "Copy message text" button in the dropdown menu for messages. 

Issue: #1815 