### PR TITLE
Solves sticky navbar for the app

### DIFF
--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -33,45 +33,43 @@ export const getTransparentHeaderLayout = (page: React.ReactElement) => (
 export const getDashboardLayout = (page: React.ReactElement) => (
   <Grid templateRows="min-content 1fr" h="full" gridTemplateColumns="minmax(0, 1fr)">
     <Header />
-    <Grid templateRows="1fr min-content" h="full">
-      <ToSWrapper>
-        <SideMenuLayout
-          menuButtonOptions={[
-            {
-              labelID: "dashboard",
-              pathname: "/dashboard",
-              icon: Layout,
-            },
-            {
-              labelID: "messages",
-              pathname: "/messages",
-              icon: MessageSquare,
-            },
-            {
-              labelID: "leaderboard",
-              pathname: "/leaderboard",
-              icon: BarChart2,
-            },
-            {
-              labelID: "stats",
-              pathname: "/stats",
-              icon: TrendingUp,
-            },
-            {
-              labelID: "Guidelines",
-              pathname: "https://projects.laion.ai/Open-Assistant/docs/guides/guidelines",
-              icon: HelpCircle,
-              target: "_blank",
-            },
-          ]}
-        >
-          <Box>{page}</Box>
-          <Box mt="10">
-            <SlimFooter />
-          </Box>
-        </SideMenuLayout>
-      </ToSWrapper>
-    </Grid>
+    <ToSWrapper>
+      <SideMenuLayout
+        menuButtonOptions={[
+          {
+            labelID: "dashboard",
+            pathname: "/dashboard",
+            icon: Layout,
+          },
+          {
+            labelID: "messages",
+            pathname: "/messages",
+            icon: MessageSquare,
+          },
+          {
+            labelID: "leaderboard",
+            pathname: "/leaderboard",
+            icon: BarChart2,
+          },
+          {
+            labelID: "stats",
+            pathname: "/stats",
+            icon: TrendingUp,
+          },
+          {
+            labelID: "Guidelines",
+            pathname: "https://projects.laion.ai/Open-Assistant/docs/guides/guidelines",
+            icon: HelpCircle,
+            target: "_blank",
+          },
+        ]}
+      >
+        <Box>{page}</Box>
+        <Box mt="10">
+          <SlimFooter />
+        </Box>
+      </SideMenuLayout>
+    </ToSWrapper>
   </Grid>
 );
 


### PR DESCRIPTION
Solves #1853

It is solved in the main branch. The issue in production is that a `Grid` component is wrapping the `SideMenuLayout` unnecessarily.

Result:

![sticky-5](https://user-images.githubusercontent.com/83598208/221340538-990cec57-0a3c-4a79-8d5d-fdd1afb15f30.gif)
