### PR TITLE
Bugs in Markdown, 3. Big numbers in lists are corrupted resolved

### DIFF
--- a/website/src/components/Messages/RenderedMarkdown.tsx
+++ b/website/src/components/Messages/RenderedMarkdown.tsx
@@ -77,8 +77,13 @@ const sx: SystemStyleObject = {
       borderBottomColor: "gray.700",
     },
   },
-  "ol li::marker": {
-    content: "counter(list-item) '.'",
+  "ol": {
+    counterReset: "list-item",
+    listStyleType: "none",
+  },
+  "ol li::before": {
+    counterIncrement: "list-item",
+    content: "counter(list-item) '.' ' '",
   },
 };
 


### PR DESCRIPTION
"li" element has the value of display property set to "list-item" by default and it is not a common element and does not respect the margin/padding . I have used counter() & ::before so that way the whole element doesn't get out of the margin/padding and it's scalable and can be inserted big numbers