### PR TITLE
Bugs in Markdown. 3. Big numbers in lists are corrupted resolved

### DIFF
--- a/website/src/components/Messages/RenderedMarkdown.tsx
+++ b/website/src/components/Messages/RenderedMarkdown.tsx
@@ -77,8 +77,11 @@ const sx: SystemStyleObject = {
       borderBottomColor: "gray.700",
     },
   },
-  "ol li::marker": {
-    content: "counter(list-item) '.'",
+  ol: {
+    listStyleType: "none",
+  },
+  "ol li::before": {
+    content: "counter(list-item) '.' ' '",
   },
 };
 


### PR DESCRIPTION
Issue to resolve: https://github.com/LAION-AI/Open-Assistant/issues/1847

I deactivated the default value for listStyleType property and instead, I added '::before' so that way it feels responsive along with the rest of the 'li' element.

![1](https://user-images.githubusercontent.com/111088099/222522404-b4ac38d5-3637-4b3b-b95a-5023eacfb35f.PNG)
![2](https://user-images.githubusercontent.com/111088099/222522424-6ffe61f8-eec8-4818-b8cc-ed7cd6e23fc4.PNG)