### PR TITLE
Fix leaderboard not loading

### DIFF
--- a/website/src/lib/leaderboard_utilities.ts
+++ b/website/src/lib/leaderboard_utilities.ts
@@ -1,4 +1,5 @@
 import { getValidDisplayName } from "src/lib/display_name_validation";
+import prisma from "src/lib/prismadb";
 import { getBatchFrontendUserIdFromBackendUser } from "src/lib/users";
 
 export const updateUsersDisplayNames = <T extends { display_name: string; username: string }>(entries: T[]) => {


### PR DESCRIPTION
The problem that happened here is that because we declare prisma as global
https://github.com/LAION-AI/Open-Assistant/blob/f2b1112038a44603da750c7200de787af9566606/website/src/lib/prismadb.ts#L2-L5

Vscode, typescript, and nextjs did not complain about it missing, even though it was.

We need to seriously consider prioritizing  #879

We might need to enable some of typescript strict mode configurations one be one and do PRs
https://www.typescriptlang.org/tsconfig#strict

I will start working on it
