### PR TITLE
Fix ordering of images in leaderboard api

### DIFF
--- a/website/src/lib/leaderboard_utilities.ts
+++ b/website/src/lib/leaderboard_utilities.ts
@@ -14,8 +14,12 @@ export const updateUsersProfilePictures = async <T extends { auth_method: string
 
   const items = await prisma.user.findMany({
     where: { id: { in: frontendUserIds } },
-    select: { image: true },
+    select: { image: true, id: true },
   });
 
-  return entires.map((entry, idx) => ({ ...entry, image: items[idx].image }));
+  return entires.map((entry, idx) => ({
+    ...entry,
+    // NOTE: findMany will return the values unsorted, which is why we have to 'find' here
+    image: items.find((i) => i.id === frontendUserIds[idx]).image,
+  }));
 };

--- a/website/src/lib/users.ts
+++ b/website/src/lib/users.ts
@@ -97,13 +97,14 @@ export const getBatchFrontendUserIdFromBackendUser = async (users: { username: s
       provider: "discord",
       providerAccountId: { in: discordAccountIds },
     },
-    select: { userId: true },
+    select: { userId: true, providerAccountId: true },
   });
 
-  console.assert(discordAccountIds.length === discordAccounts.length);
-  discordAccounts.forEach(({ userId }, index) => {
-    const outputIndex = indicesOfDiscordUsers[index];
-    outputIds[outputIndex] = userId;
+  indicesOfDiscordUsers.forEach((userIdx) => {
+    // NOTE: findMany will return the values unsorted, which is why we have to 'find' here
+    const account = discordAccounts.find((a) => a.providerAccountId === users[userIdx].username);
+    outputIds[userIdx] = account.userId;
   });
+
   return outputIds;
 };


### PR DESCRIPTION
Basically, the wrong image was assigned to the user.

`prisma.finaMany` will return the items unsorted, and there is no operation to get multiple items at once in the same order you requested, you can use a transaction but it will execute sequentially.

This was a very surprising behavior for me.

https://github.com/prisma/prisma/issues/13278
