### PR TITLE
Minor training speed improvements

### DIFF
--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -139,8 +139,13 @@ python trainer_sft.py --configs defaults your-model-name --deepspeed
 ```
 
 ### Troubleshooting
-- If training on a VM, you might need to install OpenMPI. Check out [this blog post](https://lambdalabs.com/blog/horovod-keras-for-multi-gpu-training#open-mpi-optional) by Lambda on how to install OpenMPI on their machines.
-- Installing `mpi4py` requires `python-dev`, which can be installed via `sudo apt install libpython3.10-dev` (replace `3.10` with whatever Python version you're running).
+
+- If training on a VM, you might need to install OpenMPI. Check out
+  [this blog post](https://lambdalabs.com/blog/horovod-keras-for-multi-gpu-training#open-mpi-optional)
+  by Lambda on how to install OpenMPI on their machines.
+- Installing `mpi4py` requires `python-dev`, which can be installed via
+  `sudo apt install libpython3.10-dev` (replace `3.10` with whatever Python
+  version you're running).
 
 ## Results
 

--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -138,6 +138,10 @@ the end to trigger deepspeed
 python trainer_sft.py --configs defaults your-model-name --deepspeed
 ```
 
+### Troubleshooting
+- If training on a VM, you might need to install OpenMPI. Check out [this blog post](https://lambdalabs.com/blog/horovod-keras-for-multi-gpu-training#open-mpi-optional) by Lambda on how to install OpenMPI on their machines.
+- Installing `mpi4py` requires `python-dev`, which can be installed via `sudo apt install libpython3.10-dev` (replace `3.10` with whatever Python version you're running).
+
 ## Results
 
 Experimental results in wandb

--- a/model/model_training/configs/config.yaml
+++ b/model/model_training/configs/config.yaml
@@ -87,6 +87,17 @@ pythia-1B:
   per_device_train_batch_size: 16
   per_device_eval_batch_size: 32
 
+pythia-6.9B:
+  learning_rate: 8e-6
+  model_name: EleutherAI/pythia-6.9b-deduped
+  weight_decay: 0.0
+  max_length: 512
+  warmup_steps: 500
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 2
+  per_device_train_batch_size: 2
+  per_device_eval_batch_size: 2
+
 galactica-125m:
   learning_rate: 5e-5
   model_name: facebook/galactica-125m

--- a/model/model_training/configs/zero_config.json
+++ b/model/model_training/configs/zero_config.json
@@ -5,12 +5,14 @@
     "loss_scale_window": 1000,
     "initial_scale_power": 16,
     "hysteresis": 2,
-    "min_loss_scale": 0.1
+    "min_loss_scale": 1
   },
   "optimizer": {
     "type": "AdamW",
     "params": {
       "lr": "auto",
+      "betas": "auto",
+      "eps": "auto",
       "weight_decay": "auto"
     }
   },
@@ -24,27 +26,17 @@
     }
   },
   "zero_optimization": {
-    "stage": 3,
-    "offload_optimizer": {
-      "device": "cpu",
-      "pin_memory": true
-    },
-    "offload_param": {
-      "device": "cpu",
-      "pin_memory": true
-    },
+    "stage": 1,
+    "allgather_partitions": true,
+    "allgather_bucket_size": 2e8,
     "overlap_comm": true,
+    "reduce_scatter": true,
+    "reduce_bucket_size": 2e8,
     "contiguous_gradients": true,
-    "reduce_bucket_size": "auto",
-    "stage3_prefetch_bucket_size": "auto",
-    "stage3_param_persistence_threshold": "auto",
-    "sub_group_size": 1e9,
-    "stage3_max_live_parameters": 1e9,
-    "stage3_max_reuse_distance": 1e9,
-    "stage3_gather_16bit_weights_on_model_save": true
+    "cpu_offload": true
   },
   "gradient_accumulation_steps": "auto",
-  "gradient_clipping": 2.0,
+  "gradient_clipping": "auto",
   "steps_per_print": 2000,
   "train_batch_size": "auto",
   "train_micro_batch_size_per_gpu": "auto",

--- a/model/model_training/trainer_sft.py
+++ b/model/model_training/trainer_sft.py
@@ -215,7 +215,7 @@ if __name__ == "__main__":
         tokenizer,
         max_length=training_conf.max_length,
         samples_mixing=training_conf.samples_mixing,
-        pad_to_multiple_of=32,
+        pad_to_multiple_of=16,
     )
     eval_collate_fn = DialogueDataCollator(tokenizer, max_length=training_conf.max_length, samples_mixing=False)
 

--- a/model/model_training/trainer_sft.py
+++ b/model/model_training/trainer_sft.py
@@ -212,7 +212,10 @@ if __name__ == "__main__":
 
     train, evals = get_dataset(training_conf)
     train_collate_fn = DialogueDataCollator(
-        tokenizer, max_length=training_conf.max_length, samples_mixing=training_conf.samples_mixing
+        tokenizer,
+        max_length=training_conf.max_length,
+        samples_mixing=training_conf.samples_mixing,
+        pad_to_multiple_of=32,
     )
     eval_collate_fn = DialogueDataCollator(tokenizer, max_length=training_conf.max_length, samples_mixing=False)
 


### PR DESCRIPTION
The following two changes are added for a slight speed improvement (~10% on `pythia-6.9b`, ~11s/it -> ~10s/it):
- round the vocab size to the nearest multiple of 16
- pad sequences to multiples of 16

The exact numbers are pretty arbitrary, primarily based on [this tweet](https://twitter.com/karpathy/status/1621578354024677377) and [this thread](https://twitter.com/cHHillee/status/1630274804795445248).

I also include a config for fine-tuning `pythia-6.9b` and a bit of README for setting up DeepSpeed on a cloud VM.