### PR TITLE
Add SFT params random_offset_probability, label_masking

### DIFF
--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -71,11 +71,11 @@ This works with `torch.distributed`.
 To experiment with the Open Assistant data simply run:
 
 ```bash
-python trainer_sft.py --configs defaults oa_dataset_only galactica-125m
+python trainer_sft.py --configs defaults oasst_export_eu galactica-125m
 ```
 
-Change the `data_path` in the `oa_dataset_only` from the `configs/config.yaml`
-file to the correct path.
+Change the `input_file_path` in the `oasst_export_eu` from the
+`configs/config.yaml` file to the correct path.
 
 ## Training with RL
 

--- a/model/model_training/configs/config.yaml
+++ b/model/model_training/configs/config.yaml
@@ -55,6 +55,8 @@ defaults:
   verbose: false
   output_dir: saved_model
   use_custom_sampler: false
+  random_offset_probability: 0.5 # probability for random message offsets
+  label_masking: true
 
 oa_dataset_only:
   datasets:
@@ -69,7 +71,7 @@ oasst_export_eu:
     - oasst_export:
         lang: "en,es,de,fr"
         #top_k: 2
-        input_file_path: 2023-02-26_oasst_default.jsonl.gz
+        input_file_path: 2023-03-07_oasst_default_with_labels.jsonl.gz
 
 pythia:
   learning_rate: 8e-6

--- a/model/model_training/custom_datasets/formatting.py
+++ b/model/model_training/custom_datasets/formatting.py
@@ -1,4 +1,10 @@
-QA_SPECIAL_TOKENS = {"Question": "<human>", "Answer": "<bot>", "StartPrefix": "<prefix>", "EndPrefix": "</prefix>"}
+QA_SPECIAL_TOKENS = {
+    "Question": "<|prompter|>",
+    "Answer": "<|assistant|>",
+    "System": "<|system|>",
+    "StartPrefix": "<|prefix_begin|>",
+    "EndPrefix": "<|prefix_end|>",
+}
 
 
 def format_pair(pairs):

--- a/model/model_training/trainer_sft.py
+++ b/model/model_training/trainer_sft.py
@@ -214,10 +214,18 @@ if __name__ == "__main__":
     train_collate_fn = DialogueDataCollator(
         tokenizer,
         max_length=training_conf.max_length,
+        random_offset_probability=training_conf.random_offset_probability,
+        label_masking=training_conf.label_masking,
         samples_mixing=training_conf.samples_mixing,
         pad_to_multiple_of=16,
     )
-    eval_collate_fn = DialogueDataCollator(tokenizer, max_length=training_conf.max_length, samples_mixing=False)
+    eval_collate_fn = DialogueDataCollator(
+        tokenizer,
+        max_length=training_conf.max_length,
+        random_offset_probability=training_conf.random_offset_probability,
+        label_masking=training_conf.label_masking,
+        samples_mixing=False,
+    )
 
     if training_conf.use_custom_sampler:
         sampler = PerDatasetSampler.build_sampler_from_config(


### PR DESCRIPTION
Added SFT training parameters:
- `random_offset_probability` (float, default: 0.5): probability of random offset into conversations when conversation > max_length 
- `label_masking` (bool, default: true): if true only loss for tokens of assistant replies is calculated else for all tokens (including prompter)