### PR TITLE
Update chat API calls

### DIFF
--- a/website/src/lib/oasst_inference_client.ts
+++ b/website/src/lib/oasst_inference_client.ts
@@ -3,7 +3,13 @@ import axios, { AxiosRequestConfig } from "axios";
 import Cookies from "cookies";
 import type { NextApiRequest, NextApiResponse } from "next";
 import { JWT } from "next-auth/jwt";
-import { InferenceCreateChatResponse, InferenceDebugTokenResponse } from "src/types/Chat";
+import {
+  ChatResponse,
+  InferenceCreateChatResponse,
+  InferenceDebugTokenResponse,
+  InferenceMessage,
+  InferencePostMessageResponse,
+} from "src/types/Chat";
 
 // TODO: this class could be structured better
 export class OasstInferenceClient {
@@ -50,26 +56,42 @@ export class OasstInferenceClient {
     return this.inferenceToken;
   }
 
-  create_chat(): Promise<InferenceCreateChatResponse> {
-    return this.request("POST", "/chat", { data: "" });
+  get_my_chats() {
+    return this.request("GET", "/chats");
   }
 
-  post_prompt({ chat_id, parent_id, content }: { chat_id: string; parent_id: string | null; content: string }) {
-    return this.request("POST", `/chat/${chat_id}/message`, {
+  create_chat(): Promise<InferenceCreateChatResponse> {
+    return this.request("POST", "/chats", { data: "" });
+  }
+
+  get_chat(chat_id: string): Promise<ChatResponse> {
+    return this.request("GET", `/chats/${chat_id}`);
+  }
+
+  post_prompt({
+    chat_id,
+    parent_id,
+    content,
+  }: {
+    chat_id: string;
+    parent_id: string | null;
+    content: string;
+  }): Promise<InferencePostMessageResponse> {
+    return this.request("POST", `/chats/${chat_id}/messages`, {
       data: { parent_id, content },
+    });
+  }
+
+  stream_events({ chat_id, message_id }: { chat_id: string; message_id: string }) {
+    return this.request("GET", `/chats/${chat_id}/messages/${message_id}/events`, {
+      headers: {
+        Accept: "text/event-stream",
+      },
       responseType: "stream",
     });
   }
 
   vote({ chat_id, message_id, score }: { chat_id: string; message_id: string; score: number }) {
-    return this.request("POST", `/chat/${chat_id}/message/${message_id}/vote`, {
-      data: {
-        score,
-      },
-    });
-  }
-
-  get_my_chats() {
-    return this.request("GET", "/chat");
+    return this.request("POST", `/chats/${chat_id}/messages/${message_id}/votes`, { data: { score } });
   }
 }

--- a/website/src/lib/routes.ts
+++ b/website/src/lib/routes.ts
@@ -45,5 +45,9 @@ export const API_ROUTES = {
   AVAILABLE_TASK: withLang("/api/available_tasks"),
   RECENT_MESSAGES: withLang("/api/messages"),
   ADMIN_DELETE_MESSAGE: (messageId: string) => createRoute(`/api/admin/delete_message/${messageId}`),
+  GET_CHAT_MESSAGES: (chat_id: string) => `/api/chat/message?${new URLSearchParams({ chat_id })}`,
+  CREATE_CHAT_MESSAGE: `/api/chat/message`,
   CHAT_MESSAGE_VOTE: `/api/chat/vote`,
+  STREAM_CHAT_MESSAGE: (chat_id: string, message_id: string) =>
+    `/api/chat/events?${new URLSearchParams({ chat_id, message_id })}`,
 };

--- a/website/src/pages/api/chat/events.ts
+++ b/website/src/pages/api/chat/events.ts
@@ -1,0 +1,13 @@
+import { withoutRole } from "src/lib/auth";
+import { OasstInferenceClient } from "src/lib/oasst_inference_client";
+
+const handler = withoutRole("banned", async (req, res, token) => {
+  const { chat_id, message_id } = req.query;
+
+  const client = new OasstInferenceClient(req, res, token);
+  const stream = await client.stream_events({ chat_id: chat_id as string, message_id: message_id as string });
+  res.status(200);
+  stream.pipe(res);
+});
+
+export default handler;

--- a/website/src/pages/api/chat/message.ts
+++ b/website/src/pages/api/chat/message.ts
@@ -2,11 +2,20 @@ import { withoutRole } from "src/lib/auth";
 import { OasstInferenceClient } from "src/lib/oasst_inference_client";
 
 const handler = withoutRole("banned", async (req, res, token) => {
-  const { chat_id, parent_id, content } = req.body;
   const client = new OasstInferenceClient(req, res, token);
-  const responseStream = await client.post_prompt({ chat_id, parent_id, content });
-  res.status(200);
-  responseStream.pipe(res);
+  let data;
+  if (req.method === "GET") {
+    const chat = await client.get_chat(req.query.chat_id as string);
+    data = chat.messages;
+  } else if (req.method === "POST") {
+    const { chat_id, parent_id, content } = req.body;
+    data = await client.post_prompt({ chat_id, parent_id, content });
+  }
+
+  if (data) {
+    return res.status(200).json(data);
+  }
+  res.status(400).end();
 });
 
 export default handler;

--- a/website/src/types/Chat.ts
+++ b/website/src/types/Chat.ts
@@ -7,7 +7,7 @@ export interface InferenceCreateChatResponse {
   id: string;
 }
 
-export interface InferenceResponse {
+export interface InferencePostMessageResponse {
   assistant_message: InferenceMessage;
   prompter_message: InferenceMessage;
 }
@@ -22,4 +22,9 @@ export interface InferenceMessage {
 
 export interface GetChatsResponse {
   chats: InferenceCreateChatResponse[];
+}
+
+export interface ChatResponse {
+  id: string;
+  messages: InferenceMessage[];
 }


### PR DESCRIPTION
The inference API has changed, see `#breaking-changes`, this PR update the API to the new spec.

Also, here we fetch old messages when opening a chat, so the conversation can continue.

Known issues: the chat screen scrolls to the top when submitting a message, this is likely due to the fact the we update and render the entire messages array every time.