### PR TITLE
Fixed typo in tasks.json (english)

### DIFF
--- a/website/public/locales/en/tasks.json
+++ b/website/public/locales/en/tasks.json
@@ -20,7 +20,7 @@
   },
   "reply_as_user": {
     "label": "Reply as User",
-    "desc": "Chat with Open Assistant and help improve it's responses as you interact with it.",
+    "desc": "Chat with Open Assistant and help improve its responses as you interact with it.",
     "overview": "Given the following conversation, provide an adequate reply",
     "instruction": "Provide the user's reply",
     "response_placeholder": "Write your reply here..."


### PR DESCRIPTION
Fixed a typo in tasks.json from "it's" to "its".