### PR TITLE
Show correct user avatars on leaderboard

### DIFF
--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -67,7 +67,7 @@ export const LeaderboardTable = ({
           const display_name = getValue();
           return (
             <div className="flex flex-row items-center gap-2">
-              <UserAvatar key={display_name} displayName={display_name} avatarUrl={row.original.image} />
+              <UserAvatar displayName={display_name} avatarUrl={row.original.image} />
               {isAdminOrMod ? (
                 <Link as={NextLink} href={`/admin/manage_user/${row.original.user_id}`}>
                   {display_name}

--- a/website/src/components/LeaderboardTable/LeaderboardTable.tsx
+++ b/website/src/components/LeaderboardTable/LeaderboardTable.tsx
@@ -63,18 +63,21 @@ export const LeaderboardTable = ({
       },
       columnHelper.accessor("display_name", {
         header: t("user"),
-        cell: ({ getValue, row }) => (
-          <div className="flex flex-row items-center gap-2">
-            <UserAvatar displayName={getValue()} avatarUrl={row.original.image} />
-            {isAdminOrMod ? (
-              <Link as={NextLink} href={`/admin/manage_user/${row.original.user_id}`}>
-                {getValue()}
-              </Link>
-            ) : (
-              getValue()
-            )}
-          </div>
-        ),
+        cell: ({ getValue, row }) => {
+          const display_name = getValue();
+          return (
+            <div className="flex flex-row items-center gap-2">
+              <UserAvatar key={display_name} displayName={display_name} avatarUrl={row.original.image} />
+              {isAdminOrMod ? (
+                <Link as={NextLink} href={`/admin/manage_user/${row.original.user_id}`}>
+                  {display_name}
+                </Link>
+              ) : (
+                display_name
+              )}
+            </div>
+          );
+        },
       }),
       columnHelper.accessor("leader_score", {
         header: t("score"),
@@ -117,7 +120,7 @@ export const LeaderboardTable = ({
   const rowProps = useBoardRowProps<WindowLeaderboardEntity>();
 
   if (isLoading) {
-    return <CircularProgress isIndeterminate></CircularProgress>;
+    return <CircularProgress isIndeterminate />;
   }
 
   if (error) {
@@ -132,7 +135,7 @@ export const LeaderboardTable = ({
       rowProps={rowProps}
       getSubRows={jsonExpandRowModel.getSubRows}
       {...pagnationProps}
-    ></DataTable>
+    />
   );
 };
 
@@ -140,7 +143,7 @@ const SpaceRow = () => {
   const color = useColorModeValue("gray.600", "gray.400");
   return (
     <Flex justify="center">
-      <Box as={MoreHorizontal} color={color}></Box>
+      <Box as={MoreHorizontal} color={color} />
     </Flex>
   );
 };

--- a/website/src/components/UserAvatar.tsx
+++ b/website/src/components/UserAvatar.tsx
@@ -1,26 +1,21 @@
 import Image from "next/image";
-import { useState } from "react";
-export function UserAvatar(options: { displayName: string; avatarUrl?: string }) {
-  const { displayName, avatarUrl } = options;
-  const [src, setSrc] = useState(
-    avatarUrl
-      ? avatarUrl
-      : `https://api.dicebear.com/5.x/initials/png?seed=${displayName}&radius=50&backgroundType=gradientLinear`
-  );
+import { useEffect, useState } from "react";
+export function UserAvatar({ displayName, avatarUrl }: { displayName: string; avatarUrl?: string }) {
+  const diceBearURL = `https://api.dicebear.com/5.x/initials/png?seed=${displayName}&radius=50&backgroundType=gradientLinear`;
+
+  const [src, setSrc] = useState(avatarUrl ?? diceBearURL);
+  useEffect(() => {
+    setSrc(avatarUrl ?? diceBearURL);
+  }, [avatarUrl, diceBearURL]);
+
   return (
-    <>
-      <Image
-        src={src}
-        onError={() =>
-          setSrc(
-            `https://api.dicebear.com/5.x/initials/png?seed=${displayName}&radius=50&backgroundType=gradientLinear`
-          )
-        }
-        alt={`${displayName}'s avatar`}
-        width={30}
-        height={30}
-        className="rounded-full"
-      />
-    </>
+    <Image
+      src={src}
+      onError={() => setSrc(diceBearURL)}
+      alt={`${displayName}'s avatar`}
+      width={30}
+      height={30}
+      className="rounded-full"
+    />
   );
 }


### PR DESCRIPTION
Fixes a bug introduced in #1986 where going forwards or backwards in the in the users list on the leaderboard would not update the avatar.