### PR TITLE
Fix passing parallelism var to worker in Ansible playbook

### DIFF
--- a/ansible/inference/deploy-worker.yaml
+++ b/ansible/inference/deploy-worker.yaml
@@ -36,3 +36,4 @@
         env:
           BACKEND_URL: "{{ backend_url }}"
           API_KEY: "{{ api_key }}"
+          PARALLELISM: "{{ parallelism }}"


### PR DESCRIPTION
Corrects an error in #2078. The variable was added to the playbook but not passed as an environment variable to the worker container