### PR TITLE
Fix GitHub auth flow on inference server

### DIFF
--- a/inference/server/oasst_inference_server/routes/auth.py
+++ b/inference/server/oasst_inference_server/routes/auth.py
@@ -116,7 +116,7 @@ async def callback_github(
             user_response_json = await user_response.json()
 
     try:
-        github_id = user_response_json["id"]
+        github_id = str(user_response_json["id"])
         github_username = user_response_json["login"]
     except KeyError:
         raise HTTPException(status_code=400, detail="Invalid user info response from GitHub")


### PR DESCRIPTION
Close #2119. Unlike Discord, GitHub returns user IDs as integers in JSON, not strings. We therefore need to convert to string for the ID to be compatible with our database.