### PR TITLE
Data analysis suite

### DIFF
--- a/scripts/postprocessing/importance_selection.py
+++ b/scripts/postprocessing/importance_selection.py
@@ -1,0 +1,261 @@
+import logging
+import warnings
+
+import numpy as np
+import pandas as pd
+import psycopg2
+import shap
+from scipy.special import softmax
+from scipy.stats import dirichlet
+from tqdm import trange
+from tqdm.contrib.logging import logging_redirect_tqdm
+from xgboost import XGBRegressor
+
+
+def get_df(study_label):
+    conn = psycopg2.connect("host=0.0.0.0 port=5432 user=postgres password=postgres dbname=postgres")
+    # Define the SQL query
+    query = "SELECT message_id, labels, message.user_id FROM text_labels JOIN message ON message_id = message.id;"
+
+    # Read the query results into a Pandas dataframe
+    df = pd.read_sql(query, con=conn)
+    print(df.head())
+    # Close the database connection
+    conn.close()
+    users = set()
+    for row in df.itertuples(index=False):
+        row = row._asdict()
+        users.add(str(row["user_id"]))
+    users = list(users)
+    messages = set()
+    for row in df.itertuples(index=False):
+        row = row._asdict()
+        messages.add(str(row["message_id"]))
+    messages = list(messages)
+
+    arr = np.full((len(messages), len(users)), np.NaN, dtype=np.half)
+
+    for row in df.itertuples(index=False):
+        row = row._asdict()
+        labels = row["labels"]
+        value = labels.get(study_label, None)
+        if value is not None:
+            # tmp=out[str(row["message_id"])]
+            # tmp = np.array(tmp)
+            # tmp[users.index(row["user_id"])] = value
+            # out[str(row["message_id"])] = np.array(tmp)
+            # print(out[str(row["message_id"])].density)
+            mid = messages.index(str(row["message_id"]))
+            uid = users.index(str(row["user_id"]))
+            arr[mid, uid] = value
+    print("results", len(users), arr.shape)
+    # df = pd.DataFrame.from_dict(out,orient="index")
+    print("generated dataframe")
+    return arr, messages
+
+
+def compute_feature_importance(features, target, index):
+    """
+    Computes feature importance weights using the Extra Trees algorithm.
+
+    Args:
+        df (pandas.DataFrame): An DataFrame of input features.
+        target (string): Column which contains the labels.
+
+    Returns:
+        dict: A dictionary mapping feature names to importance weights.
+    """
+    # get rid of target
+    X = (features - np.nanmean(features, 0)) / np.nanstd(features, 0)
+    # print("feature",X.shape)
+    # get target
+    y = target
+    # Use simple imputer for mean to not change the importance of tree split
+    # Create an instance of the ExtraTreesRegressor algorithm
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    et = XGBRegressor(tree_method="gpu_hist", n_estimators=200, verbosity=0)
+    # et =
+    # now get wether the coefficient is negative or positive:
+    # lin = Pipeline([("scaler", StandardScaler()),("imputer", SimpleImputer(missing_values=np.nan, strategy='constant',fill_value=0)), ("lin", LinearRegression())])
+
+    # Fit the algorithm to the input data
+    et.fit(X, y)
+    # lin.fit(X, y)
+
+    # Get the feature importances from the fitted algorithm
+    # importances = np.array(list(et.named_steps["extra trees"].get_booster().get_score(importance_type="gain").values()))
+
+    explainer = shap.Explainer(et, verbosity=0)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    shap_values = explainer.shap_values(X)
+    # Normalize based on _non NAN_ features:
+    mask = ~np.isnan(X)
+    to_combine = mask.sum(0) + 1
+    importances = np.sum(shap_values, 0) / to_combine
+
+    # print(len(importances),len(coefficient),X.columns.tolist())
+    # Create a dictionary mapping feature names to importance weights
+    # print("index",len(index))
+    # print("length importance", importances)
+    # print("length coefficient", len(coefficient))
+
+    importance_series = pd.DataFrame({"importance": importances}, index=index)
+    return importance_series
+
+
+def reweight_features(features, weights):
+    # X = df.drop(target_col, axis=1)
+    # print("info",features.shape,weights.shape)
+    X = (features - np.nanmean(features, 0, keepdims=True)) / np.nanstd(features, 0, keepdims=True)
+    # print(X.shape, weights.shape)
+    # normalizer = (X.notna().astype(float) * weights).sum(skipna=True, axis=1)
+    values = np.nansum(X * weights.reshape(1, -1), axis=1)
+    # values = values / normalizer
+    return values
+
+
+def get_subframe(arr, columns_to_filter):
+    return np.delete(arr, columns_to_filter, axis=1)
+
+
+def sample_importance_weights(importance_weights, temperature=1.0):
+    weights = softmax(
+        abs(importance_weights) / temperature,
+    )
+    column = np.random.choice(len(importance_weights), p=weights)
+    return column
+
+
+def make_random_testframe(num_rows, num_cols, frac_missing):
+    data = np.random.rand(num_rows, num_cols).astype(np.float16)
+    mask = np.random.rand(num_rows, num_cols) < frac_missing
+    data[mask] = np.nan
+    return data
+
+
+def combine_underrepresented_columns(arr, num_instances):
+    # 1. get the mask
+    mask = ~np.isnan(arr)
+    to_combine = mask.sum(0) < num_instances
+    print("to combine", mask.sum(0))
+    print("combining", to_combine.astype(int).sum().tolist(), "many columns")
+    if not any(to_combine):
+        return arr
+    # mean = np.zeros(arr.shape[0])
+    # for i in to_combine.tolist():
+    #    mean = np.nansum(np.stack(arr[:,i],mean),0)
+    # mean = mean/len(to_combine)
+    mean = np.nanmean(arr[:, to_combine], 1, keepdims=True)
+    print(mean.shape)
+    dp = np.arange(len(to_combine))[to_combine]
+    print("removing unused columns")
+    arr = get_subframe(arr, dp)
+    arr = np.concatenate([arr, mean], 1)
+    print("out arr", arr.shape)
+    print(np.isnan(mean).astype(int).sum())
+    return arr
+
+
+def importance_votes(arr, alpha=100.0, to_fit=50, init_weight=None):
+    # arr = combine_underrepresented_columns(matrix,underrepresentation_thresh)
+    filtered_columns = []
+    weighter = None
+    if init_weight is None:
+        weighter = np.ones(arr.shape[1])  # pd.Series(1.0, index=df.drop(columns=target).columns)
+    else:
+        weighter = init_weight
+    index = list(range(arr.shape[1]))
+    # subtract 1: the last one will always have maximal reduction!
+    bar = trange(to_fit)
+    for _ in bar:
+        index = list(filter(lambda x: x not in filtered_columns, index))
+        # 0. produce target column:
+        # print("step 0")
+        target = reweight_features(arr, weighter)
+        # 1. get a subframe of interesting features
+        # print("step 1")
+        # subframe = get_subframe(arr, filtered_columns)
+        # 2. compute feature importance
+        # print("step 2")
+        importance_weights = compute_feature_importance(arr, target, index)
+        # 3. sample column
+        # print("step 3")
+        # new_column = sample_importance_weights(importance_weights["importance"], temperature)
+        # new_column=index[new_column]
+        # value = importance_weights["importance"][new_column]
+        # print(weighter.shape, importance_weights["importance"].shape)
+        weighter += alpha * importance_weights["importance"].to_numpy()
+        # normalize to maintain the "1-voter one vote" total number of votes!
+        stepsize = np.mean(abs(importance_weights["importance"].to_numpy()))
+        bar.set_description(f"expected stepsize: {stepsize}", refresh=True)
+        weighter = weighter / sum(abs(weighter)) * len(weighter)
+        # filtered_columns.append(new_column)
+    # print("new weight values", weighter)
+    return reweight_features(arr, weighter), weighter
+
+
+def select_ids(arr, pick_frac, alph_range=(100, 100), folds=20, frac=0.5):
+    # votes = []
+    votes = np.zeros((folds, len(arr)))
+    alphas = np.geomspace(alph_range[0], alph_range[1], folds)
+    num_per_iter = int(len(arr) * pick_frac)
+    for i in trange(folds):
+        tofit = np.copy(arr)
+        # print("arr shape", arr.shape)
+        init_weight = dirichlet.rvs(np.ones(arr.shape[1]))[0]
+        out, weight = importance_votes(tofit, alpha=alphas[i], init_weight=init_weight)
+        print(i, "final weight")
+        print(weight)
+        # mask =(out>thresh)
+        # out = np.arange(arr.shape[0])[mask]
+        indices = np.argpartition(out, -num_per_iter)[-num_per_iter:]
+        votes[i, indices] = 1
+        # votes.append(indices.tolist())
+    out = []
+    votes = np.mean(votes, 0)
+    for idx, f in enumerate(votes):
+        if f > frac:
+            out.append((idx, f))
+    return out
+
+
+LOG = logging.getLogger(__name__)
+
+if __name__ == "__main__":
+    warnings.filterwarnings("ignore", category=FutureWarning)
+    warnings.filterwarnings("ignore", category=DeprecationWarning)
+    warnings.simplefilter("ignore")
+    logging.captureWarnings(True)
+    logging.basicConfig(level=logging.ERROR)
+    # Generate some example data
+    # df = make_random_testframe(100_000,5000,0.99)
+    df, message_ids = get_df("spam")
+    print("combining columns:")
+    df = combine_underrepresented_columns(df, 250)
+
+    print("after preprocessing")
+    # print(df)
+    # preproc input
+
+    # Compute feature importances
+    # y = reweight_features(df,np.ones(df.shape[1]))
+    # importance_weights = compute_feature_importance(df, y, list(range(df.shape[1])))
+    # Print the importance weights for each feature
+    # print(importance_weights)
+
+    print("STARTING RUN")
+
+    # sampled_columns = sample_importance_weights(
+    #    importance_weights["importance"],
+    # )
+    # print("sampled column", sampled_columns)
+    # print("compute importance votes:")
+    # weighted_votes, weightings = importance_votes(df)
+    # print(weighted_votes)
+    # print(weightings)
+    with logging_redirect_tqdm():
+        print("selected ids")
+    ids = select_ids(df, 0.1)
+    for i, frac in ids:
+        res = message_ids[i]
+        print(res, frac)

--- a/scripts/postprocessing/importance_selection.py
+++ b/scripts/postprocessing/importance_selection.py
@@ -4,18 +4,46 @@ import warnings
 import numpy as np
 import pandas as pd
 import psycopg2
-import shap
+from scipy.optimize import LinearConstraint, minimize
+from scipy.sparse import coo_array, csr_array, csr_matrix, hstack
 from scipy.special import softmax
-from scipy.stats import dirichlet
 from tqdm import trange
 from tqdm.contrib.logging import logging_redirect_tqdm
-from xgboost import XGBRegressor
+
+
+def least_squares_fit(features, target, scaling=1):
+    X = features  # (features - np.mean(features, 0)) / np.std(features, 0)
+    # print("feature",X.shape)
+    # get target
+    y = target.reshape(-1)
+    # Use simple imputer for mean to not change the importance of tree split
+    # Create an instance of the ExtraTreesRegressor algorithm
+    zX = X.toarray()
+    summed_target = y  # (y+zX[:,-1])/2
+    vote_matrix = csr_matrix(zX[:, :-1])
+    constraint = LinearConstraint(np.ones(X.shape[-1] - 1), 1 * scaling, 1 * scaling)
+    init = np.ones(X.shape[-1] - 1)  # lsqr(vote_matrix,summed_target)[0]
+    init = init / np.linalg.norm(init)
+    result = minimize(
+        lambda x: np.sum((vote_matrix @ x - summed_target) ** 2),
+        init,
+        jac=lambda x: 2 * vote_matrix.T @ (vote_matrix @ x - summed_target),
+        constraints=constraint,
+        hess=lambda _: 2 * vote_matrix.T @ vote_matrix,
+        method="trust-constr",
+    )
+    # result = least_squares(residual, np.ones(X.shape[-1]-1))
+    # result = least_squares(zX[:,:-1], (y+zX[:,-1])/2,
+    # print(result)
+    return np.concatenate([result.x, np.ones(1)])
 
 
 def get_df(study_label):
     conn = psycopg2.connect("host=0.0.0.0 port=5432 user=postgres password=postgres dbname=postgres")
     # Define the SQL query
-    query = "SELECT message_id, labels, message.user_id FROM text_labels JOIN message ON message_id = message.id;"
+    query = (
+        "SELECT DISTINCT message_id, labels, message.user_id FROM text_labels JOIN message ON message_id = message.id;"
+    )
 
     # Read the query results into a Pandas dataframe
     df = pd.read_sql(query, con=conn)
@@ -23,19 +51,39 @@ def get_df(study_label):
     # Close the database connection
     conn.close()
     users = set()
-    for row in df.itertuples(index=False):
-        row = row._asdict()
-        users.add(str(row["user_id"]))
-    users = list(users)
     messages = set()
     for row in df.itertuples(index=False):
         row = row._asdict()
+        users.add(str(row["user_id"]))
+        # for row in df.itertuples(index=False):
+        # row = row._asdict()
         messages.add(str(row["message_id"]))
+    users = list(users)
     messages = list(messages)
+    print("num users:", len(users), "num messages:", len(messages), "num in df", len(df))
 
-    arr = np.full((len(messages), len(users)), np.NaN, dtype=np.half)
+    # arr = np.full((len(messages), len(users)), np.NaN, dtype=np.half)
+    row_idx = []
+    col_idx = []
+    data = []
 
-    for row in df.itertuples(index=False):
+    def swap(x):
+        return (x[1], x[0])
+
+    dct = dict(map(swap, enumerate(messages)))
+    print("converting messages...")
+    df["message_id"] = df["message_id"].map(dct)
+    print("converting users...")
+    df["user_id"] = df["user_id"].map(dict(map(swap, enumerate(users))))
+    print("converting labels...")
+    df["labels"] = df["labels"].map(lambda x: float(x.get(study_label, 0)))
+    row_idx = df["message_id"].to_numpy()
+    col_idx = df["user_id"].to_numpy()
+    data = df["labels"].to_numpy()
+    print(data)
+    print(row_idx)
+    print(col_idx)
+    """ for row in df.itertuples(index=False):
         row = row._asdict()
         labels = row["labels"]
         value = labels.get(study_label, None)
@@ -45,77 +93,40 @@ def get_df(study_label):
             # tmp[users.index(row["user_id"])] = value
             # out[str(row["message_id"])] = np.array(tmp)
             # print(out[str(row["message_id"])].density)
-            mid = messages.index(str(row["message_id"]))
-            uid = users.index(str(row["user_id"]))
-            arr[mid, uid] = value
+            row_idx.append(messages.index(str(row["message_id"])))
+            col_idx.append(users.index(str(row["user_id"])))
+            data.append(value)
+            #arr[mid, uid] = value """
+    arr = csr_array(coo_array((data, (row_idx, col_idx))))
     print("results", len(users), arr.shape)
     # df = pd.DataFrame.from_dict(out,orient="index")
     print("generated dataframe")
-    return arr, messages
+    return arr, messages, users
 
 
-def compute_feature_importance(features, target, index):
-    """
-    Computes feature importance weights using the Extra Trees algorithm.
-
-    Args:
-        df (pandas.DataFrame): An DataFrame of input features.
-        target (string): Column which contains the labels.
-
-    Returns:
-        dict: A dictionary mapping feature names to importance weights.
-    """
-    # get rid of target
-    X = (features - np.nanmean(features, 0)) / np.nanstd(features, 0)
-    # print("feature",X.shape)
-    # get target
-    y = target
-    # Use simple imputer for mean to not change the importance of tree split
-    # Create an instance of the ExtraTreesRegressor algorithm
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    et = XGBRegressor(tree_method="gpu_hist", n_estimators=200, verbosity=0)
-    # et =
-    # now get wether the coefficient is negative or positive:
-    # lin = Pipeline([("scaler", StandardScaler()),("imputer", SimpleImputer(missing_values=np.nan, strategy='constant',fill_value=0)), ("lin", LinearRegression())])
-
-    # Fit the algorithm to the input data
-    et.fit(X, y)
-    # lin.fit(X, y)
-
-    # Get the feature importances from the fitted algorithm
-    # importances = np.array(list(et.named_steps["extra trees"].get_booster().get_score(importance_type="gain").values()))
-
-    explainer = shap.Explainer(et, verbosity=0)
-    warnings.filterwarnings("ignore", category=DeprecationWarning)
-    shap_values = explainer.shap_values(X)
-    # Normalize based on _non NAN_ features:
-    mask = ~np.isnan(X)
-    to_combine = mask.sum(0) + 1
-    importances = np.sum(shap_values, 0) / to_combine
-
-    # print(len(importances),len(coefficient),X.columns.tolist())
-    # Create a dictionary mapping feature names to importance weights
-    # print("index",len(index))
-    # print("length importance", importances)
-    # print("length coefficient", len(coefficient))
-
-    importance_series = pd.DataFrame({"importance": importances}, index=index)
-    return importance_series
-
-
-def reweight_features(features, weights):
+def reweight_features(features, weights, noise_scale=0.0):
     # X = df.drop(target_col, axis=1)
     # print("info",features.shape,weights.shape)
-    X = (features - np.nanmean(features, 0, keepdims=True)) / np.nanstd(features, 0, keepdims=True)
-    # print(X.shape, weights.shape)
+    # X = (features - np.mean(features, 0).reshape(1,-1)) / np.std(features, 0).reshape(1,-1)
+    noise = np.random.randn(weights.shape[0]) * noise_scale
+    weights = weights + noise
     # normalizer = (X.notna().astype(float) * weights).sum(skipna=True, axis=1)
-    values = np.nansum(X * weights.reshape(1, -1), axis=1)
+    values = features @ weights
     # values = values / normalizer
     return values
 
 
 def get_subframe(arr, columns_to_filter):
-    return np.delete(arr, columns_to_filter, axis=1)
+    # return np.delete(arr, columns_to_filter, axis=1)
+    """
+    Remove the rows denoted by ``indices`` form the CSR sparse matrix ``mat``.
+    """
+    if not isinstance(arr, csr_array):
+        raise ValueError("works only for CSR format -- use .tocsr() first")
+    indices = list(columns_to_filter)
+    mask = np.ones(arr.shape[1], dtype=bool)
+    mask[indices] = False
+    return arr[:, mask]
 
 
 def sample_importance_weights(importance_weights, temperature=1.0):
@@ -135,83 +146,109 @@ def make_random_testframe(num_rows, num_cols, frac_missing):
 
 def combine_underrepresented_columns(arr, num_instances):
     # 1. get the mask
-    mask = ~np.isnan(arr)
+    mask = arr != 0
     to_combine = mask.sum(0) < num_instances
-    print("to combine", mask.sum(0))
-    print("combining", to_combine.astype(int).sum().tolist(), "many columns")
+    # print("to combine", mask.sum(0))
+    # print("combining", to_combine.astype(int).sum().tolist(), "many columns")
     if not any(to_combine):
         return arr
     # mean = np.zeros(arr.shape[0])
     # for i in to_combine.tolist():
     #    mean = np.nansum(np.stack(arr[:,i],mean),0)
     # mean = mean/len(to_combine)
-    mean = np.nanmean(arr[:, to_combine], 1, keepdims=True)
-    print(mean.shape)
+    mean = np.mean(arr[:, to_combine], 1).reshape(-1, 1)
+    # print("mean shape",mean.shape)
     dp = np.arange(len(to_combine))[to_combine]
-    print("removing unused columns")
+    # print("removing unused columns")
     arr = get_subframe(arr, dp)
-    arr = np.concatenate([arr, mean], 1)
-    print("out arr", arr.shape)
-    print(np.isnan(mean).astype(int).sum())
+    # print("subframe shape",arr.shape)
+    arr = hstack([arr, mean])
+    # print("out arr", arr.shape)
+    # print((mean==0).astype(int).sum())
     return arr
 
 
-def importance_votes(arr, alpha=100.0, to_fit=50, init_weight=None):
+def importance_votes(arr, to_fit=10, init_weight=None):
     # arr = combine_underrepresented_columns(matrix,underrepresentation_thresh)
     filtered_columns = []
     weighter = None
     if init_weight is None:
-        weighter = np.ones(arr.shape[1])  # pd.Series(1.0, index=df.drop(columns=target).columns)
+        weighter = np.ones(arr.shape[1]) / arr.shape[1]  # pd.Series(1.0, index=df.drop(columns=target).columns)
     else:
         weighter = init_weight
-    index = list(range(arr.shape[1]))
+    # print(arr.shape)
+    index = np.arange(arr.shape[1])
     # subtract 1: the last one will always have maximal reduction!
     bar = trange(to_fit)
-    for _ in bar:
+    target = np.ones(arr.shape[0])
+    for i in bar:
         index = list(filter(lambda x: x not in filtered_columns, index))
         # 0. produce target column:
         # print("step 0")
+        target_old = target
         target = reweight_features(arr, weighter)
+        error = np.mean((target - target_old) ** 2)
+        bar.set_description(f"expected error: {error}", refresh=True)
+        if error < 1e-10:
+            break
         # 1. get a subframe of interesting features
         # print("step 1")
         # subframe = get_subframe(arr, filtered_columns)
         # 2. compute feature importance
         # print("step 2")
-        importance_weights = compute_feature_importance(arr, target, index)
+        # importance_weights=None
+        # importance_weights = compute_feature_importance(arr, target, index)
+        weighter = least_squares_fit(arr, target)
         # 3. sample column
         # print("step 3")
         # new_column = sample_importance_weights(importance_weights["importance"], temperature)
         # new_column=index[new_column]
         # value = importance_weights["importance"][new_column]
         # print(weighter.shape, importance_weights["importance"].shape)
-        weighter += alpha * importance_weights["importance"].to_numpy()
+        # weighter += alpha[i] * importance_weights["importance"].to_numpy()
         # normalize to maintain the "1-voter one vote" total number of votes!
-        stepsize = np.mean(abs(importance_weights["importance"].to_numpy()))
-        bar.set_description(f"expected stepsize: {stepsize}", refresh=True)
-        weighter = weighter / sum(abs(weighter)) * len(weighter)
+        # weighter = weighter / sum(abs(weighter))
+        # stepsize = np.mean(abs(importance_weights["importance"].to_numpy()))
+        # bar.set_description(f"expected stepsize: {stepsize}", refresh=True)
         # filtered_columns.append(new_column)
     # print("new weight values", weighter)
     return reweight_features(arr, weighter), weighter
 
 
-def select_ids(arr, pick_frac, alph_range=(100, 100), folds=20, frac=0.5):
-    # votes = []
-    votes = np.zeros((folds, len(arr)))
-    alphas = np.geomspace(alph_range[0], alph_range[1], folds)
-    num_per_iter = int(len(arr) * pick_frac)
+def select_ids(arr, pick_frac, minima=(50, 500), folds=50, to_fit=200, frac=0.6):
+    """
+    selects the top-"pick_frac"% of messages from "arr" after merging all
+    users with less than "minima" votes (minima increases linearly with each iteration from min to max).
+    The method returns all messages that are within `frac` many "minima" selection
+    """
+    votes = []
+    minima = np.linspace(*minima, num=folds, dtype=int)
+    num_per_iter = int(arr.shape[0] * pick_frac)
+    writer_num = 0
+    tmp = None
     for i in trange(folds):
-        tofit = np.copy(arr)
+        tofit = combine_underrepresented_columns(arr, minima[i])
+        if tofit.shape[1] == writer_num:
+            print("already tested these writer counts, skipping and using cached value.....")
+            votes.append(tmp)
+            continue
+        writer_num = tofit.shape[1]
         # print("arr shape", arr.shape)
-        init_weight = dirichlet.rvs(np.ones(arr.shape[1]))[0]
-        out, weight = importance_votes(tofit, alpha=alphas[i], init_weight=init_weight)
-        print(i, "final weight")
-        print(weight)
+        init_weight = np.ones(tofit.shape[1]) / tofit.shape[1]
+        out, weight = importance_votes(tofit, init_weight=init_weight, to_fit=to_fit)
+        # print(i, "final weight")
+        # print(weight)
         # mask =(out>thresh)
         # out = np.arange(arr.shape[0])[mask]
         indices = np.argpartition(out, -num_per_iter)[-num_per_iter:]
-        votes[i, indices] = 1
+        tmp = np.zeros((arr.shape[0]))
+        tmp[indices] = 1
+        votes.append(tmp)
         # votes.append(indices.tolist())
+    # print(*[f"user_id: {users[idx]} {m}±{s}" for m, s, idx in zip(weights_mean, weights_std, range(len(weights_mean)))], sep="\n")
     out = []
+    votes = np.stack(votes, axis=0)
+    print("votespace", votes.shape)
     votes = np.mean(votes, 0)
     for idx, f in enumerate(votes):
         if f > frac:
@@ -229,9 +266,13 @@ if __name__ == "__main__":
     logging.basicConfig(level=logging.ERROR)
     # Generate some example data
     # df = make_random_testframe(100_000,5000,0.99)
-    df, message_ids = get_df("spam")
+    df, message_ids, users = get_df("quality")
     print("combining columns:")
-    df = combine_underrepresented_columns(df, 250)
+    # df = combine_underrepresented_columns(df, 100)
+    weights = np.ones(df.shape[-1])
+    y = reweight_features(df, weights)
+    num_per_iter = int(df.shape[0] * 0.5)
+    naive = np.argpartition(y, -num_per_iter)[-num_per_iter:]
 
     print("after preprocessing")
     # print(df)
@@ -255,7 +296,28 @@ if __name__ == "__main__":
     # print(weightings)
     with logging_redirect_tqdm():
         print("selected ids")
-    ids = select_ids(df, 0.1)
+        ids = select_ids(df, 0.5, folds=500)
+
+    #    print(res, frac)
+    conn = psycopg2.connect("host=0.0.0.0 port=5432 user=postgres password=postgres dbname=postgres")
+    # Define the SQL query
+    # , payload#>'{payload, text}' as text
+    query = "SELECT DISTINCT id as message_id, message_tree_id FROM message;"
+    print("selected", len(ids), "messages")
+    # Read the query results into a Pandas dataframe
+    df = pd.read_sql(query, con=conn)
+    out = []
+    fracs = []
+    in_naive = []
     for i, frac in ids:
         res = message_ids[i]
-        print(res, frac)
+        out.append((df.loc[df["message_id"] == res]))
+        fracs.append(frac)
+        in_naive.append(i in naive)
+    df = pd.concat(out)
+    df["fracs"] = fracs
+    df["in_naive"] = in_naive
+    print(df.shape)
+    print("differences from naive", len(in_naive) - sum(in_naive))
+    print(df)
+    df.to_csv("output.csv")

--- a/scripts/postprocessing/ranking_disagreement.py
+++ b/scripts/postprocessing/ranking_disagreement.py
@@ -1,0 +1,123 @@
+from collections import defaultdict
+
+import numpy as np
+import pandas as pd
+import psycopg2
+from rankings import ranked_pairs
+from scipy.stats import kendalltau
+
+
+# source: wikipedia ;)
+# but here without the normalization
+def normalised_kendall_tau_distance(values1, values2):
+    """Compute the Kendall tau distance."""
+    n = len(values1)
+    assert len(values2) == n, "Both lists have to be of equal length"
+    i, j = np.meshgrid(np.arange(n), np.arange(n))
+    a = np.argsort(values1)
+    b = np.argsort(values2)
+    ndisordered = np.logical_or(
+        np.logical_and(a[i] < a[j], b[i] > b[j]), np.logical_and(a[i] > a[j], b[i] < b[j])
+    ).sum()
+    return ndisordered / (n * (n - 1))
+
+
+def get_df():
+    """
+    Simple method that computes merged rankings and compares them to each user.
+    Most interesting output for end-user is presumably the last that lists each user with their
+    correlation to the mean ranking.
+    Lower means less well aligned to the mean, higher means more well aligned.
+    Note that rankings with fewer options are more likely to be wrong, so this could
+    yield to misleading results:
+    **You cannot use this for automatic flagging!**
+    """
+    conn = psycopg2.connect("host=0.0.0.0 port=5432 user=postgres password=postgres dbname=postgres")
+    # Define the SQL query
+    # query = """SELECT DISTINCT t.parent_message_id, r.user_id, r.payload->'payload'->>'ranked_message_ids' as ranked_ids
+    #    FROM message_reaction r JOIN task t ON r.task_id = t.id
+    #      WHERE r.payload->'payload'->>'type' = 'message_ranking';"""
+    role = "'assistant'"
+    message_tree_id = None  # "'ef458036-ae8e-4ff5-98f2-0f9dfedcb206'"
+    query = f"""
+        -- get all ranking results of completed tasks for all parents with >= 2 children
+        SELECT DISTINCT p.parent_id, p.message_tree_id, mr.* FROM
+        (
+            -- find parents with > 1 children
+            SELECT m.parent_id, m.message_tree_id, COUNT(m.id) children_count
+            FROM message_tree_state mts
+            INNER JOIN message m ON mts.message_tree_id = m.message_tree_id
+            WHERE m.review_result                  -- must be reviewed
+            AND NOT m.deleted                   -- not deleted
+            AND m.parent_id IS NOT NULL         -- ignore initial prompts
+            AND ({role} IS NULL OR m.role = {role}) -- children with matching role
+            -- AND mts.message_tree_id = {message_tree_id}
+            GROUP BY m.parent_id, m.message_tree_id
+            HAVING COUNT(m.id) > 1
+        ) as p
+        LEFT JOIN task t ON p.parent_id = t.parent_message_id AND t.done AND (t.payload_type = 'RankPrompterRepliesPayload' OR t.payload_type = 'RankAssistantRepliesPayload')
+        LEFT JOIN message_reaction mr ON mr.task_id = t.id AND mr.payload_type = 'RankingReactionPayload'
+        """
+
+    # Read the query results into a Pandas dataframe
+    df = pd.read_sql(query, con=conn)
+    print(df[["message_tree_id", "parent_id", "payload"]])
+    # Close the database connection
+    conn.close()
+    users = set()
+    messages = set()
+    rankings = defaultdict(list)
+    rankings_with_user = defaultdict(list)
+    for row in df.itertuples(index=False):
+        row = row._asdict()
+        users.add(str(row["user_id"]))
+        messages.add(str(row["message_tree_id"]))
+        #
+        if row["payload"] is None:
+            continue
+        ranking = row["payload"]["payload"]["ranked_message_ids"]
+        rankings_with_user[str(row["parent_id"])].append((ranking, str(row["user_id"])))
+        rankings[str(row["parent_id"])].append(ranking)
+    print(*[f"{k} : {v}" for k, v in rankings.items()], sep="\n")
+    users = list(users)
+    messages = list(messages)
+    consensus = dict()
+    total_correlation = list()
+    for k, v in rankings.items():
+        # print("v",[len(i) for i in v])
+        common_set = set.intersection(*map(set, v))
+        # clean up the rankings and remove stuff not in all of them
+        v = [list(filter(lambda x: x in common_set, ids)) for ids in v]
+        merged_rankings = ranked_pairs(v)
+        consensus[k] = merged_rankings
+        ls = []
+        for (vote, id) in rankings_with_user[k]:
+            # clean up the rankings and remove stuff not in all of them
+            vote = list(filter(lambda x: x in common_set, vote))
+            ls.append((kendalltau(merged_rankings, vote), id))
+        rankings_with_user[k] = ls
+        total_correlation.extend(ls)
+    correlation_by_user = defaultdict(list)
+    for u in users:
+        for (c, m) in total_correlation:
+            if m == u:
+                correlation_by_user[u].append(c)
+
+    return consensus, users, messages, rankings_with_user, correlation_by_user
+
+
+if __name__ == "__main__":
+    cons, user, messages, rankings, correlation_by_user = get_df()
+    # print(user)
+    # print(messages)
+    # print(rankings)
+    # print("consensus:", cons)
+    print("correlation_by_user:", correlation_by_user)
+    for k, v in correlation_by_user.items():
+        if len(v) < 50:
+            res = "not enough data"
+        else:
+            i = list(map(lambda x: x, v))
+            res = np.mean(i)
+            res_std = np.std(i)
+            print("result:", k, f" with value {res:.2f}", f"± {res_std:.2f}")

--- a/scripts/postprocessing/ranking_disagreement.py
+++ b/scripts/postprocessing/ranking_disagreement.py
@@ -91,7 +91,7 @@ def get_df():
         merged_rankings = ranked_pairs(v)
         consensus[k] = merged_rankings
         ls = []
-        for (vote, id) in rankings_with_user[k]:
+        for vote, id in rankings_with_user[k]:
             # clean up the rankings and remove stuff not in all of them
             vote = list(filter(lambda x: x in common_set, vote))
             ls.append((kendalltau(merged_rankings, vote), id))
@@ -99,7 +99,7 @@ def get_df():
         total_correlation.extend(ls)
     correlation_by_user = defaultdict(list)
     for u in users:
-        for (c, m) in total_correlation:
+        for c, m in total_correlation:
             if m == u:
                 correlation_by_user[u].append(c)
 

--- a/scripts/postprocessing/rankings.py
+++ b/scripts/postprocessing/rankings.py
@@ -96,13 +96,15 @@ def ranked_pairs(ranks: List[List[int]]):
     """
     tallies, names = head_to_head_votes(ranks)
     tallies = tallies - tallies.T
-    # print(tallies)
     # note: the resulting tally matrix should be skew-symmetric
     # order by strength of victory (using tideman's original method, don't think it would make a difference for us)
     sorted_majorities = []
     for i in range(len(ranks[0])):
         for j in range(len(ranks[0])):
-            if tallies[i, j] > 0:
+            # you can never prefer yourself over yourself
+            # we also have to pick one of the two choices,
+            # if the preference is exactly zero...
+            if tallies[i, j] >= 0 and i != j:
                 sorted_majorities.append((i, j, tallies[i, j]))
     # we don't explicitly deal with tied majorities here
     sorted_majorities = np.array(sorted(sorted_majorities, key=lambda x: x[2], reverse=True))
@@ -128,13 +130,36 @@ def ranked_pairs(ranks: List[List[int]]):
 
 
 if __name__ == "__main__":
-    ranks = (
+
+    ranks = """ (
         [("w", "x", "z", "y") for _ in range(1)]
         + [("w", "y", "x", "z") for _ in range(2)]
         # + [("x","y","z","w") for _ in range(4)]
-        # + [("x", "z", "w", "y") for _ in range(5)]
-        # + [("y", "w", "x", "z") for _ in range(1)]
+        + [("x", "z", "w", "y") for _ in range(5)]
+        + [("y", "w", "x", "z") for _ in range(1)]
         # [("y","z","w","x") for _ in range(1000)]
-    )
+    )"""
+    ranks = [
+        [
+            ("c5181083-d3e9-41e7-a935-83fb9fa01488"),
+            ("dcf3d179-0f34-4c15-ae21-b8feb15e422d"),
+            ("d11705af-5575-43e5-b22e-08d155fbaa62"),
+        ],
+        [
+            ("d11705af-5575-43e5-b22e-08d155fbaa62"),
+            ("c5181083-d3e9-41e7-a935-83fb9fa01488"),
+            ("dcf3d179-0f34-4c15-ae21-b8feb15e422d"),
+        ],
+        [
+            ("dcf3d179-0f34-4c15-ae21-b8feb15e422d"),
+            ("c5181083-d3e9-41e7-a935-83fb9fa01488"),
+            ("d11705af-5575-43e5-b22e-08d155fbaa62"),
+        ],
+        [
+            ("d11705af-5575-43e5-b22e-08d155fbaa62"),
+            ("c5181083-d3e9-41e7-a935-83fb9fa01488"),
+            ("dcf3d179-0f34-4c15-ae21-b8feb15e422d"),
+        ],
+    ]
     rp = ranked_pairs(ranks)
     print(rp)

--- a/scripts/postprocessing/rankings.py
+++ b/scripts/postprocessing/rankings.py
@@ -130,7 +130,6 @@ def ranked_pairs(ranks: List[List[int]]):
 
 
 if __name__ == "__main__":
-
     ranks = """ (
         [("w", "x", "z", "y") for _ in range(1)]
         + [("w", "y", "x", "z") for _ in range(2)]


### PR DESCRIPTION
This adds in two scripts to compare rankings and votes.
The rankings is relatively simple and computes the expected kendall-tau correlation of a user to the consensus vote.
This is mostly for spotting bad actors. Currently it does not find statistically significant outliers that are also bad actors

This doesn't mean that individual bad actors don't exist, but it does mean that either
1. there are so many of them, the ranking results are so far beyond repair that the merged rankings themselves make no sense
2. there are so few of them, that they overall don't affect the results sufficiently negatively to be noticable

The truth is probably somewhere in the middle: since we only have ~3 rankers per message, if we had one that is consistently screwing with things, he would be hard to detect since by sheer luck he would agree enough with another ranker to overall vanish in the correlations.


The vote aggregation script is much more sophisticated and computes optimal weightings for each power-user based on aggregations of non-power users:
I now have an initial "smart" selection of messages based on a hierarchical consensus finding scheme:
The idea is to split the voters into an "aggregation" and a "re-rating" group:
The "aggregation" group is comprised of the set of users with less than X number of ratings.
These users get aggregated into one mean (i.e. weighting 1:1) and act as the anchor.
Users with more than X ratings are used to compute weightings, specifically we attempt to reweight them such that
min ∑ (A u - (y + agg)/2)²
subject to 
∑ u = 1

with "A" being the matrix of votes done by people in the "re-rating" group and "agg" being the aggregated voter vector.
y is simply the current weighting result y = A u_prev.
I.e. "y" is the current target, assuming that the current  u weightings are correct.
After finding "better" uweightings in the least-squares optimization, I recompute the new target y and compute the next u until a fixed point is reached.

The end result is a weighting of the "re-rating" group in u and a priority we can read from y.

However, the choice between what people we put into the "aggregation" and "re-rating" group is pretty arbitrary based on a split with who has more than X ratings:
- if we have low X then we have much much more people which can get re-weighted, but our "agg" anchor might be a lot more inaccurate
- if we have high X we have a much more statistically stable "agg" anchor, but less weighting potential.

The way I decided to solve this is by simply running many iterations 50≤X≤500 which gives us all (reasonable) configurations, and then giving a confidence score based on how often a message is in the top P% of messages.

The method outputs a CSV file with 
- "message_id"
- "message_tree_id"
- "fracs" (what fraction of the ensemble the message_id is in)
- "in_naive" (whether it would be in the naive "1 user; 1 vote" model)


