### PR TITLE
Get available auth providers from inference server

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -66,6 +66,25 @@ You can use the debug credentials provider to log in without fancy emails or OAu
 1. Use the `Login` button in the top right to go to the login page.
 1. You should see a section for debug credentials. Enter any username you wish, you will be logged in as that user.
 
+### Testing Oauth login to the inference server
+
+Create a `docker-compose.override.yml` in the root of the repo, and add the following to it
+
+```yml
+services:
+  inference-server:
+    environment:
+      # fill out these variables, you would need to create an app from the corresponding provider(s)
+      # you can fill only one of them if you want to
+      AUTH_DISCORD_CLIENT_ID:
+      AUTH_DISCORD_CLIENT_SECRET:
+
+      AUTH_GITHUB_CLIENT_ID:
+      AUTH_GITHUB_CLIENT_SECRET:
+```
+
+And now when you start all containers, the possibility to login to inference through these providers will be available.
+
 ### Using Storybook
 
 To develop components using [Storybook](https://storybook.js.org/) run `npm run storybook`. Then navigate to in your

--- a/website/src/components/Chat/ChatAuth.tsx
+++ b/website/src/components/Chat/ChatAuth.tsx
@@ -3,37 +3,55 @@ import { Github } from "lucide-react";
 import Link from "next/link";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
-import { useMemo } from "react";
+import { memo } from "react";
 import { Discord } from "src/components/Icons/Discord";
+import { get } from "src/lib/api";
+import useSWRImmutable from "swr/immutable";
 
-export const ChatAuth = ({ inferenceHost }: { inferenceHost: string }) => {
+const icons = {
+  github: <Github size={128} />,
+  discord: <Discord size={128} />,
+};
+
+export const ChatAuth = memo(function ChatAuth({ inferenceHost }: { inferenceHost: string }) {
   const { t } = useTranslation(["chat", "common"]);
+  const { data: authProviders } = useSWRImmutable<string[]>(`${inferenceHost}/auth/providers`, get, {
+    fallbackData: [],
+  });
+
   const { data: session } = useSession();
   const isAuth = session?.inference.isAuthenticated;
+  const username = session?.user.name;
 
-  const content = useMemo(() => {
-    if (isAuth) {
-      return (
+  if (isAuth) {
+    return (
+      <Card mt={4}>
         <CardBody display="flex" flexDirection="row" justifyContent="space-between" alignItems="center" gap={4}>
           <Text>{t("you_are_logged_in")}</Text>
           <Button>{t("common:sign_out")}</Button>
         </CardBody>
-      );
-    }
-    return (
+      </Card>
+    );
+  }
+  return (
+    <Card mt={4}>
       <CardBody display="flex" flexDirection="column" gap={4}>
         <Text>{t("login_message")}</Text>
-        <Grid justifyItems="center" gridTemplateColumns="repeat(2, minmax(150px, 1fr))" gap={12}>
-          <Link href={`${inferenceHost}/auth/login/github`}>
-            <Github size={128} />
-          </Link>
-          <Link href={`${inferenceHost}/auth/login/discord`}>
-            <Discord size={128} />
-          </Link>
+        <Grid
+          justifyItems="center"
+          gridTemplateColumns={`repeat(${authProviders.length}, minmax(150px, 1fr))`}
+          gap={12}
+        >
+          {authProviders.map((provider) => (
+            <Link
+              key={provider}
+              href={`${inferenceHost}/auth/login/${provider}` + (provider === "debug" ? `?username=${username}` : "")}
+            >
+              {icons[provider] ?? provider}
+            </Link>
+          ))}
         </Grid>
       </CardBody>
-    );
-  }, [isAuth, t, inferenceHost]);
-
-  return <Card mt={4}>{content}</Card>;
-};
+    </Card>
+  );
+});

--- a/website/src/pages/api/auth/[...nextauth].ts
+++ b/website/src/pages/api/auth/[...nextauth].ts
@@ -1,6 +1,5 @@
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { boolean } from "boolean";
-import Cookies from "cookies";
 import { generateUsername } from "friendly-username-generator";
 import { NextApiRequest, NextApiResponse } from "next";
 import type { AuthOptions } from "next-auth";


### PR DESCRIPTION
Instead of hard-coding the providers list in the frontend, we now fetch this list from the inference server.

Also, update the debug login so it matches oauth process / callback structure, now it can be used from the website just like any other provider