### PR TITLE
Fix to rank_datasets.py

### DIFF
--- a/model/reward/instructor/rank_datasets.py
+++ b/model/reward/instructor/rank_datasets.py
@@ -101,7 +101,7 @@ class WebGPT(Dataset):
         self.index2question = {}
         for row in dataset["train"]:
             question = row["question"]["full_text"]
-            if question not in self.index2question:
+            if question not in self.index2question.values():
                 self.index2question[len(self.index2question)] = question
 
             if question not in questions:


### PR DESCRIPTION
As far as I know the `reward/` dir will not be used in favour of `model_training/reward_model` now but I guess there is no harm in fixing this anyway. Closes #2210.