### PR TITLE
Add re-rank cli utility

### DIFF
--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -910,6 +910,50 @@ class TreeManager:
         self.update_message_ranks(message_tree_id, rankings_by_message)
         return True
 
+    def ranked_pairs_update(self, rankings: list[MessageReaction]) -> int:
+        num_updated = 0
+        ordered_ids_list: list[list[UUID]] = [
+            msg_reaction.payload.payload.ranked_message_ids for msg_reaction in rankings
+        ]
+
+        common_set: set[UUID] = set.intersection(*map(set, ordered_ids_list))
+        if len(common_set) < 2:
+            logger.warning("The intersection of ranking results ID sets has less than two elements. Skipping.")
+            return
+
+        # keep only elements in common set
+        ordered_ids_list = [list(filter(lambda x: x in common_set, ids)) for ids in ordered_ids_list]
+        assert all(len(x) == len(common_set) for x in ordered_ids_list)
+
+        logger.debug(f"SORTED MESSAGE IDS {ordered_ids_list}")
+        consensus = ranked_pairs(ordered_ids_list)
+        assert len(consensus) == len(common_set)
+        logger.debug(f"CONSENSUS: {consensus}\n\n")
+
+        # fetch all siblings and index by id
+        siblings = self.pr.fetch_message_siblings(consensus[0], review_result=None, deleted=None)
+        siblings = {m.id: m for m in siblings}
+
+        # set rank for each message that was part of the common set
+        for rank, message_id in enumerate(consensus):
+            message = siblings.get(message_id)
+            if message:
+                if message.rank != rank:
+                    message.rank = rank
+                    self.db.add(message)
+                    num_updated += 1
+            else:
+                logger.warning(f"Message {message_id=} not found among siblings.")
+
+        # clear rank of sibling messages not in consensus
+        for message in siblings.values():
+            if message.id not in consensus and message.rank is not None:
+                message.rank = None
+                self.db.add(message)
+                num_updated += 1
+
+        return num_updated
+
     def update_message_ranks(
         self, message_tree_id: UUID, rankings_by_message: dict[UUID, list[MessageReaction]]
     ) -> bool:
@@ -925,41 +969,7 @@ class TreeManager:
 
         try:
             for rankings in rankings_by_message.values():
-                ordered_ids_list: list[list[UUID]] = [
-                    msg_reaction.payload.payload.ranked_message_ids for msg_reaction in rankings
-                ]
-
-                common_set: set[UUID] = set.intersection(*map(set, ordered_ids_list))
-                if len(common_set) < 2:
-                    logger.warning("The intersection of ranking results ID sets has less than two elements. Skipping.")
-                    continue
-
-                # keep only elements in common set
-                ordered_ids_list = [list(filter(lambda x: x in common_set, ids)) for ids in ordered_ids_list]
-                assert all(len(x) == len(common_set) for x in ordered_ids_list)
-
-                logger.debug(f"SORTED MESSAGE IDS {ordered_ids_list}")
-                consensus = ranked_pairs(ordered_ids_list)
-                assert len(consensus) == len(common_set)
-                logger.debug(f"CONSENSUS: {consensus}\n\n")
-
-                # fetch all siblings and clear ranks
-                siblings = self.pr.fetch_message_siblings(consensus[0], review_result=None, deleted=None)
-                for m in siblings:
-                    m.rank = None
-                    self.db.add(m)
-
-                # index by id
-                siblings = {m.id: m for m in siblings}
-
-                # set rank for each message that was part of the common set
-                for rank, message_id in enumerate(consensus):
-                    msg = siblings.get(message_id)
-                    if msg:
-                        msg.rank = rank
-                        self.db.add(msg)
-                    else:
-                        logger.warning(f"Message {message_id=} not found among siblings.")
+                self.ranked_pairs_update(rankings)
 
         except Exception:
             logger.exception(f"update_message_ranks({message_tree_id=}) failed")

--- a/backend/rerank.py
+++ b/backend/rerank.py
@@ -1,0 +1,71 @@
+import argparse
+from uuid import UUID
+
+import oasst_backend.utils.database_utils as db_utils
+from export import fetch_tree_ids
+from loguru import logger
+from oasst_backend.api.deps import create_api_client
+from oasst_backend.models.api_client import ApiClient
+from oasst_backend.models.message_tree_state import State as TreeState
+from oasst_backend.prompt_repository import PromptRepository
+from oasst_backend.tree_manager import TreeManager
+from sqlmodel import Session
+
+IMPORT_API_CLIENT_ID = UUID("bd8fde8b-1d8e-4e9a-9966-e96d000f8363")
+
+
+def update_tree_ranking(tm: TreeManager, message_tree_id: UUID) -> int:
+    ranking_role_filter = None if tm.cfg.rank_prompter_replies else "assistant"
+    rankings_by_message = tm.query_tree_ranking_results(message_tree_id, role_filter=ranking_role_filter)
+    updated = 0
+    for rankings in rankings_by_message.values():
+        updated += tm.ranked_pairs_update(rankings)
+    return updated
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Update message ranks with feedback received after tree-completion.")
+    parser.add_argument("--commit", action="store_true", default=False, help="Dry run with rollback if not specified")
+    args = parser.parse_args()
+    return args
+
+
+def main():
+    args = parse_args()
+
+    dry_run = not args.commit
+
+    @db_utils.managed_tx_function(auto_commit=db_utils.CommitMode.ROLLBACK if dry_run else db_utils.CommitMode.COMMIT)
+    def update_rankings_tx(db: Session) -> int:
+        # create tree manager
+        # get import api client
+        api_client = db.query(ApiClient).filter(ApiClient.id == IMPORT_API_CLIENT_ID).first()
+        if not api_client:
+            api_client = create_api_client(
+                session=db,
+                description="API client used for importing data",
+                frontend_type="import",
+                force_id=IMPORT_API_CLIENT_ID,
+            )
+
+        tm = TreeManager(db, PromptRepository(db, api_client=api_client))
+
+        # find all ready for export trees
+        tree_ids = fetch_tree_ids(db, state_filter=TreeState.READY_FOR_EXPORT)
+        updated = 0
+        for message_tree_id, _ in tree_ids:
+            try:
+                updated += update_tree_ranking(tm, message_tree_id)
+            except Exception:
+                logger.exception(f"Update ranking of message tree {message_tree_id} failed")
+        return updated
+
+    updated = update_rankings_tx()
+    logger.info(f"Rank of {updated} messages updated.")
+
+    if dry_run:
+        logger.info("DRY RUN with rollback (run with --commit to modify db)")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a cli command called `rerank.py` (in `backend/` directory) which can be used to re-calculate the rank of all trees in `ready_for_export` state. Its main function is to incorporate user feedback received after a tree already was completed (e.g. late submission). Especially for long messages with texts this can happen when the job became active again after hide-timeout.