### PR TITLE
update warning and improve readme in model training

### DIFF
--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -4,9 +4,24 @@
 
 `pip install -e ..` (pyproject.toml resides in the parent directory)
 
+Make sure the oasst_data module is installed
+
+```bash
+python -m pip install ../../oasst-data/
+```
+
 Run tests: `pytest .`
 
+You might run into a `SystemExit` here for the test `tests/test_patched_gpt_neox.py::test_flash_attention_patch`.
+If so just follow the warning and install `flash_attn`:
+
+```bash
+python -m pip install flash_attn
+```
+
+
 Start training SFT model
+
 
 ```bash
 python trainer_sft.py --configs galactica-125m

--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -12,16 +12,15 @@ python -m pip install ../../oasst-data/
 
 Run tests: `pytest .`
 
-You might run into a `SystemExit` here for the test `tests/test_patched_gpt_neox.py::test_flash_attention_patch`.
-If so just follow the warning and install `flash_attn`:
+You might run into a `SystemExit` here for the test
+`tests/test_patched_gpt_neox.py::test_flash_attention_patch`. If so just follow
+the warning and install `flash_attn`:
 
 ```bash
 python -m pip install flash_attn
 ```
 
-
 Start training SFT model
-
 
 ```bash
 python trainer_sft.py --configs galactica-125m

--- a/model/model_training/models/patching.py
+++ b/model/model_training/models/patching.py
@@ -116,7 +116,7 @@ def patch_model(
         except ModuleNotFoundError:
             warnings.warn(
                 """\nmodule flash_attn not found - either install:
-  pip3 install flash_atten
+  pip3 install flash_attn
 or run with:
   --use_flash_attention=false """
             )


### PR DESCRIPTION
closes #2148 
- Add installation instruction for oasst_data
- Fix warning to point to the correct module
- Add additional information in model/model_training/README.md for guidance