### PR TITLE
Workaround for Apple silicon hosts

### DIFF
--- a/oasst-shared/oasst_shared/schemas/inference.py
+++ b/oasst-shared/oasst_shared/schemas/inference.py
@@ -41,8 +41,11 @@ class WorkerHardwareInfo(pydantic.BaseModel):
         data["uname_processor"] = platform.uname().processor
         data["cpu_count_physical"] = psutil.cpu_count(logical=False)
         data["cpu_count_logical"] = psutil.cpu_count(logical=True)
-        data["cpu_freq_max"] = psutil.cpu_freq().max
-        data["cpu_freq_min"] = psutil.cpu_freq().min
+        # psutil.cpu_freq()is None for conatainers running on an Apple silicon host
+        # https://github.com/giampaolo/psutil/issues/1892
+        cpu_freq = psutil.cpu_freq()
+        data["cpu_freq_max"] = cpu_freq.max if cpu_freq or 0
+        data["cpu_freq_min"] = cpu_freq.min if cpu_freq or 0
         data["mem_total"] = psutil.virtual_memory().total
         data["swap_total"] = psutil.swap_memory().total
         data["gpus"] = []

--- a/oasst-shared/oasst_shared/schemas/inference.py
+++ b/oasst-shared/oasst_shared/schemas/inference.py
@@ -44,8 +44,8 @@ class WorkerHardwareInfo(pydantic.BaseModel):
         # psutil.cpu_freq()is None for conatainers running on an Apple silicon host
         # https://github.com/giampaolo/psutil/issues/1892
         cpu_freq = psutil.cpu_freq()
-        data["cpu_freq_max"] = cpu_freq.max if cpu_freq or 0
-        data["cpu_freq_min"] = cpu_freq.min if cpu_freq or 0
+        data["cpu_freq_max"] = cpu_freq.max if cpu_freq else 0
+        data["cpu_freq_min"] = cpu_freq.min if cpu_freq else 0
         data["mem_total"] = psutil.virtual_memory().total
         data["swap_total"] = psutil.swap_memory().total
         data["gpus"] = []


### PR DESCRIPTION
`psutils.cpu_freq()` doesn't currently support M1 / M2 chips. There is an open issue in psutils for this: https://github.com/giampaolo/psutil/issues/1892

`psutils.cpu_freq()` actually raises an exception when running on the Apple silicon host, and returns `None` when running in a container hosted on Apple silicon. I didn't add the exception handling since our case is the container case.