### PR TITLE
Correlation metrics for Reward Model

### DIFF
--- a/model/model_training/configs/config_rm.yaml
+++ b/model/model_training/configs/config_rm.yaml
@@ -38,6 +38,7 @@ defaults_rm:
   sort_by_length: false
   per_digit_tokens: false
   datasets_extra: []
+  metrics: ["accuracy", "kendall_tau"]
 
 oasst-rm-1-pythia-6B:
   is_reward_model: true

--- a/model/model_training/configs/config_rm.yaml
+++ b/model/model_training/configs/config_rm.yaml
@@ -38,7 +38,7 @@ defaults_rm:
   sort_by_length: false
   per_digit_tokens: false
   datasets_extra: []
-  metrics: ["accuracy", "kendall_tau"]
+  metrics: ["accuracy", "kendalltau"]
 
 oasst-rm-1-pythia-6B:
   is_reward_model: true

--- a/model/model_training/metrics.py
+++ b/model/model_training/metrics.py
@@ -1,5 +1,5 @@
 import numpy as np
-from scipy.stats import kendalltau
+from scipy import stats as st
 
 
 def reward_accuracy(eval_pred):
@@ -32,10 +32,23 @@ def kendall_tau(eval_pred):
         logits_batch = logits[labels==i]
         pred_rank = np.argsort(logits_batch)
         true_rank = np.arange(logits_batch.size-1,-1,-1)
-        print(pred_rank,true_rank)
-        tau += kendalltau(pred_rank, true_rank)[0]
+        tau += st.kendalltau(pred_rank, true_rank)[0]
 
-    return {"kendall_tau":tau/np.unique(labels).size}
+    return {"kendalltau":tau/np.unique(labels).size}
+
+
+def spearmanr(eval_pred):
+    
+    logits = eval_pred.predictions
+    labels = eval_pred.label_ids
+    score = 0.0
+    for i in np.unique(labels):
+        logits_batch = logits[labels==i]
+        pred_rank = np.argsort(logits_batch)
+        true_rank = np.arange(logits_batch.size-1,-1,-1)
+        score += st.spearmanr(pred_rank, true_rank).statistic
+
+    return {"spearmanr":score/np.unique(labels).size}
 
 
 class RewardMetrics:
@@ -49,8 +62,10 @@ class RewardMetrics:
         for name in metrics:
             if name == "accuracy":
                 self.metrics.append(reward_accuracy)
-            elif name == "kendall_tau":
+            elif name == "kendalltau":
                 self.metrics.append(kendall_tau)
+            elif name == "spearmanr":
+                self.metrics.append(spearmanr)
                 
     def __call__(self,eval_pred):
         results = {}

--- a/model/model_training/metrics.py
+++ b/model/model_training/metrics.py
@@ -1,0 +1,60 @@
+import numpy as np
+from scipy.stats import kendalltau
+
+
+def reward_accuracy(eval_pred):
+    logits = eval_pred.predictions
+    labels = eval_pred.label_ids
+
+    pos_scores,neg_scores = [],[]
+    for i in np.unique(labels):
+        logits_batch = logits[labels==i]
+        pos_scores.append(logits_batch[0])
+        neg_scores.append(logits_batch[-1])
+    pos_scores = np.array(pos_scores).reshape(-1,1)
+    neg_scores = np.array(neg_scores).reshape(-1,1)
+
+    metrics = {
+        "pos_score": np.mean(pos_scores),
+        "neg_score": np.mean(neg_scores),
+        "score_diff": np.mean(pos_scores - neg_scores),
+        "accuracy": np.mean(pos_scores > neg_scores),
+    }
+    return metrics
+
+
+def kendall_tau(eval_pred):
+    
+    logits = eval_pred.predictions
+    labels = eval_pred.label_ids
+    tau = 0.0
+    for i in np.unique(labels):
+        logits_batch = logits[labels==i]
+        pred_rank = np.argsort(logits_batch)
+        true_rank = np.arange(logits_batch.size-1,-1,-1)
+        print(pred_rank,true_rank)
+        tau += kendalltau(pred_rank, true_rank)[0]
+
+    return {"kendall_tau":tau/np.unique(labels).size}
+
+
+class RewardMetrics:
+    
+    def __init__(self,metrics):
+        
+        if isinstance(metrics,str):
+            metrics = [metrics]
+
+        self.metrics = []
+        for name in metrics:
+            if name == "accuracy":
+                self.metrics.append(reward_accuracy)
+            elif name == "kendall_tau":
+                self.metrics.append(kendall_tau)
+                
+    def __call__(self,eval_pred):
+        results = {}
+        for metrics in self.metrics:
+            results.update(metrics(eval_pred))
+        
+        return results

--- a/model/model_training/metrics.py
+++ b/model/model_training/metrics.py
@@ -1,18 +1,20 @@
 import numpy as np
 from scipy import stats as st
 
+RM_METRICS = ["accuracy", "kendalltau", "spearmanr"]
+
 
 def reward_accuracy(eval_pred):
     logits = eval_pred.predictions
     labels = eval_pred.label_ids
 
-    pos_scores,neg_scores = [],[]
+    pos_scores, neg_scores = [], []
     for i in np.unique(labels):
-        logits_batch = logits[labels==i]
+        logits_batch = logits[labels == i]
         pos_scores.append(logits_batch[0])
         neg_scores.append(logits_batch[-1])
-    pos_scores = np.array(pos_scores).reshape(-1,1)
-    neg_scores = np.array(neg_scores).reshape(-1,1)
+    pos_scores = np.array(pos_scores).reshape(-1, 1)
+    neg_scores = np.array(neg_scores).reshape(-1, 1)
 
     metrics = {
         "pos_score": np.mean(pos_scores),
@@ -24,38 +26,34 @@ def reward_accuracy(eval_pred):
 
 
 def kendall_tau(eval_pred):
-    
     logits = eval_pred.predictions
     labels = eval_pred.label_ids
     tau = 0.0
     for i in np.unique(labels):
-        logits_batch = logits[labels==i]
+        logits_batch = logits[labels == i]
         pred_rank = np.argsort(logits_batch)
-        true_rank = np.arange(logits_batch.size-1,-1,-1)
+        true_rank = np.arange(logits_batch.size - 1, -1, -1)
         tau += st.kendalltau(pred_rank, true_rank)[0]
 
-    return {"kendalltau":tau/np.unique(labels).size}
+    return {"kendalltau": tau / np.unique(labels).size}
 
 
 def spearmanr(eval_pred):
-    
     logits = eval_pred.predictions
     labels = eval_pred.label_ids
     score = 0.0
     for i in np.unique(labels):
-        logits_batch = logits[labels==i]
+        logits_batch = logits[labels == i]
         pred_rank = np.argsort(logits_batch)
-        true_rank = np.arange(logits_batch.size-1,-1,-1)
+        true_rank = np.arange(logits_batch.size - 1, -1, -1)
         score += st.spearmanr(pred_rank, true_rank).statistic
 
-    return {"spearmanr":score/np.unique(labels).size}
+    return {"spearmanr": score / np.unique(labels).size}
 
 
 class RewardMetrics:
-    
-    def __init__(self,metrics):
-        
-        if isinstance(metrics,str):
+    def __init__(self, metrics):
+        if isinstance(metrics, str):
             metrics = [metrics]
 
         self.metrics = []
@@ -66,10 +64,12 @@ class RewardMetrics:
                 self.metrics.append(kendall_tau)
             elif name == "spearmanr":
                 self.metrics.append(spearmanr)
-                
-    def __call__(self,eval_pred):
+            else:
+                raise ValueError(f"Invalid metrics {name}. Available {RM_METRICS}")
+
+    def __call__(self, eval_pred):
         results = {}
         for metrics in self.metrics:
             results.update(metrics(eval_pred))
-        
+
         return results

--- a/model/model_training/trainer_rm.py
+++ b/model/model_training/trainer_rm.py
@@ -5,10 +5,10 @@ from typing import Callable, Dict, List, Literal, Optional, Tuple, Union
 
 import bitsandbytes
 import datasets
-import numpy as np
 import torch
 from model_training.custom_datasets.ranking_collator import RankingDataCollator
 from model_training.efficiency_utils import fuse_gelu
+from model_training.metrics import RewardMetrics
 from model_training.utils import (
     PerDatasetSampler,
     _strtobool,
@@ -18,7 +18,6 @@ from model_training.utils import (
     get_tokenizer,
     read_yamls,
 )
-from model_training.metrics import RewardMetrics
 from torch import nn
 from torch.utils.data import DataLoader
 from tqdm import tqdm
@@ -71,10 +70,10 @@ class RMTrainer(Trainer):
 
         loss = loss.mean().detach()
 
-        labels=[]
-        for i, (s,e) in enumerate(zip(cu_lens[:-1], cu_lens[1:])):
-                labels.extend([i]*(e-s))
-        labels = torch.tensor(labels).view(-1,1)
+        labels = []
+        for i, (s, e) in enumerate(zip(cu_lens[:-1], cu_lens[1:])):
+            labels.extend([i] * (e - s))
+        labels = torch.tensor(labels).view(-1, 1)
 
         return (loss, logits, labels)
 

--- a/model/model_training/trainer_rm.py
+++ b/model/model_training/trainer_rm.py
@@ -76,7 +76,7 @@ class RMTrainer(Trainer):
                 labels.extend([i]*(e-s))
         labels = torch.tensor(labels).view(-1,1)
 
-        return (loss, out_logits, labels)
+        return (loss, logits, labels)
 
     def get_train_dataloader(self):
         """


### PR DESCRIPTION
Added support for tracking multiple metrics while RM training.
Supported metrics
- Kendalls tau
- Spearman corr
- Accuracy

An extra argument `metrics` should be specified in config_rm.yaml

fixes : #2122 