### PR TITLE
Flash attention support for Llama

### DIFF
--- a/model/model_training/models/patching.py
+++ b/model/model_training/models/patching.py
@@ -6,10 +6,11 @@ from typing import Callable, Optional
 
 import torch
 import torch.nn as nn
-import torch.nn.functional as F
-from torch.nn.utils.rnn import pad_sequence
+import transformers
 from transformers import GPTNeoXForCausalLM, GPTNeoXModel, LlamaForCausalLM, LlamaModel
 
+from .patching_llama import llama_forward_with_flash_attn
+from .patching_utils import compute_flash_attention
 from .reward_model import GPTNeoXRewardModel
 
 SUPPORTED_MODELS = [
@@ -36,39 +37,18 @@ def _patched_attn_forward(post_module: nn.Module, module: nn.Module, *args, **kw
 
 
 def _patched_gpt_neox_attn(
-    module: nn.Module,
+    self: transformers.models.gpt_neox.modeling_gpt_neox.GPTNeoXAttention,
     flash_attn: FlashSelfAttention,
     query: torch.Tensor,
     key: torch.Tensor,
     value: torch.Tensor,
     attention_mask=None,
-    head_mask=None,
 ):
     # query, key, value: [bs, num_attention_heads, seq_len, attn_head_size]
-    flash_attn.train(module.training)
+    flash_attn.train(self.training)
     out_dtype = value.dtype
-    batch_size, max_len = query.size(0), query.size(2)
-
     q, k, v = query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2)
-    qkv = torch.stack([q, k, v], dim=2).to(torch.float16)  # need to truncate here since rotary embeddings are fp32
-    cu_seqlens, max_seqlen = None, None
-
-    if attention_mask is not None:
-        # Limitation: attention mask can have "holes", which is currently not handled correctly
-        # model will be able to pay attention up to the last non-masked token, even if previous tokens are masked.
-        seqlens = (attention_mask[:, 0, 0, :] == 0).cumsum(dim=1).argmax(dim=1) + 1
-        qkv = torch.cat([qkv[i, : seqlens[i]] for i in range(batch_size)], dim=0)
-        cu_seqlens = torch.cat([torch.zeros_like(seqlens[:1]), seqlens.cumsum(dim=0)], dim=0).to(torch.int32)
-        max_seqlen = seqlens.max().item()
-
-    out = flash_attn(qkv, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
-    # out: [bs, seq_len, num_attention_heads, attn_head_size]
-
-    if attention_mask is not None:
-        seqs = [out[start:end] for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])]
-        out = pad_sequence(seqs, batch_first=True)
-        # restore original sequence length
-        out = F.pad(out, (0, 0) * (out.dim() - 2) + (0, max_len - out.size(1)), value=0.0)
+    out = compute_flash_attention(flash_attn, q, k, v, attention_mask)
     out = out.transpose(1, 2).to(out_dtype)
     return out, None
 
@@ -91,10 +71,16 @@ def add_flash_attn(module: nn.Module, causal: bool = True):
     [1] https://github.com/HazyResearch/flash-attention
     """
 
-    if not hasattr(module, "_attn"):
-        warnings.warn("Provided module doesn't have a _attn() function to be patched.")
     flash_attn = FlashSelfAttention(causal=causal)
-    module._attn = partial(_patched_gpt_neox_attn, module, flash_attn)
+    if isinstance(module, transformers.models.llama.modeling_llama.LlamaAttention):
+        module.old_forward = module.forward
+        module.forward = partial(llama_forward_with_flash_attn, module, flash_attn)
+    elif isinstance(module, transformers.models.gpt_neox.modeling_gpt_neox.GPTNeoXAttention):
+        if not hasattr(module, "_attn"):
+            warnings.warn("Provided module doesn't have a _attn() function to be patched.")
+        module._attn = partial(_patched_gpt_neox_attn, module, flash_attn)
+    else:
+        raise NotImplementedError(f"Flash attention is not implemented for {module.__class__.__name__}.")
 
 
 def patch_model(
@@ -164,12 +150,12 @@ or run with:
     mlp_key = mlp_key_lookup.get(model.__class__, "mlp")
 
     for layer in model.layers:
-        if resid_pdrop is not None:
-            add_dropout(getattr(layer, attention_key), _patched_attn_forward, resid_pdrop)
-            add_dropout(getattr(layer, mlp_key), _patched_mlp_forward, resid_pdrop)
-
         if flash_attention:
             if isinstance(model, LlamaModel):
                 warnings.warn("Flash attention is not supported for LLaMA models.")
             else:
                 add_flash_attn(layer.attention, causal=True)
+
+        if resid_pdrop is not None:
+            add_dropout(getattr(layer, attention_key), _patched_attn_forward, resid_pdrop)
+            add_dropout(getattr(layer, mlp_key), _patched_mlp_forward, resid_pdrop)

--- a/model/model_training/models/patching_llama.py
+++ b/model/model_training/models/patching_llama.py
@@ -1,0 +1,95 @@
+from typing import Optional, Tuple
+
+import torch
+import torch.nn as nn
+import transformers
+
+from .patching_utils import compute_flash_attention
+
+
+def rotate_half(x):
+    """Rotates half the hidden dims of the input."""
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return torch.cat((-x2, x1), dim=-1)
+
+
+def apply_rotary_pos_emb(q, k, cos, sin, position_ids):
+    gather_indices = position_ids[:, None, :, None]  # [bs, 1, seq_len, 1]
+    gather_indices = gather_indices.repeat(1, cos.shape[1], 1, cos.shape[3])
+    cos = torch.gather(cos.repeat(gather_indices.shape[0], 1, 1, 1), 2, gather_indices)
+    sin = torch.gather(sin.repeat(gather_indices.shape[0], 1, 1, 1), 2, gather_indices)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    return q_embed, k_embed
+
+
+def llama_forward_with_flash_attn(
+    self: transformers.models.llama.modeling_llama.LlamaAttention,
+    flash_attn: nn.Module,  # flash_attn.modules.mha.FlashSelfAttention
+    hidden_states: torch.Tensor,
+    attention_mask: Optional[torch.Tensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    past_key_value: Optional[Tuple[torch.Tensor]] = None,
+    output_attentions: bool = False,
+    use_cache: bool = False,
+) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
+    # self: transformers.models.llama.modeling_llama.LlamaAttention
+    bsz, q_len, _ = hidden_states.size()
+
+    query_states = self.q_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    key_states = self.k_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    value_states = self.v_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+
+    kv_seq_len = key_states.shape[-2]
+    if past_key_value is not None:
+        kv_seq_len += past_key_value[0].shape[-2]
+    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+    query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
+    # [bsz, nh, t, hd]
+
+    if past_key_value is not None:
+        # reuse k, v, self_attention
+        key_states = torch.cat([past_key_value[0], key_states], dim=2)
+        value_states = torch.cat([past_key_value[1], value_states], dim=2)
+
+    past_key_value = (key_states, value_states) if use_cache else None
+
+    # attn_weights = torch.matmul(query_states, key_states.transpose(2, 3)) / math.sqrt(self.head_dim)
+
+    # if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
+    #     raise ValueError(
+    #         f"Attention weights should be of size {(bsz * self.num_heads, q_len, kv_seq_len)}, but is"
+    #         f" {attn_weights.size()}"
+    #     )
+
+    # if attention_mask is not None:
+    #     if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+    #         raise ValueError(
+    #             f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+    #         )
+    #     attn_weights = attn_weights + attention_mask
+    #     attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
+
+    # # upcast attention to fp32
+    # attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
+    # attn_output = torch.matmul(attn_weights, value_states)
+
+    flash_attn.train(self.training)
+    out_dtype = value_states.dtype
+    q, k, v = query_states.transpose(1, 2), key_states.transpose(1, 2), value_states.transpose(1, 2)
+    attn_output = compute_flash_attention(flash_attn, q, k, v, attention_mask)
+    attn_output = attn_output.transpose(1, 2).to(out_dtype)
+
+    if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+        raise ValueError(
+            f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+            f" {attn_output.size()}"
+        )
+
+    attn_output = attn_output.transpose(1, 2)
+    attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
+
+    attn_output = self.o_proj(attn_output)
+
+    return attn_output, None, past_key_value

--- a/model/model_training/models/patching_utils.py
+++ b/model/model_training/models/patching_utils.py
@@ -1,0 +1,29 @@
+import torch
+import torch.nn.functional as F
+from torch.nn.utils.rnn import pad_sequence
+
+
+def compute_flash_attention(flash_attn, q, k, v, attention_mask=None, head_mask=None):
+    # q, k, v: [bs, seq_len, num_attention_heads, attn_head_size]
+    batch_size, max_len = q.size(0), q.size(1)
+    qkv = torch.stack([q, k, v], dim=2).to(torch.float16)  # need to truncate in case input is fp32
+    cu_seqlens, max_seqlen = None, None
+
+    if attention_mask is not None:
+        # Limitation: attention mask can have "holes", which is currently not handled correctly
+        # model will be able to pay attention up to the last non-masked token, even if previous tokens are masked.
+        seqlens = (attention_mask[:, 0, 0, :] == 0).cumsum(dim=1).argmax(dim=1) + 1
+        qkv = torch.cat([qkv[i, : seqlens[i]] for i in range(batch_size)], dim=0)
+        cu_seqlens = torch.cat([torch.zeros_like(seqlens[:1]), seqlens.cumsum(dim=0)], dim=0).to(torch.int32)
+        max_seqlen = seqlens.max().item()
+
+    out = flash_attn(qkv, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+    # out: [bs, seq_len, num_attention_heads, attn_head_size]
+
+    if attention_mask is not None:
+        seqs = [out[start:end] for start, end in zip(cu_seqlens[:-1], cu_seqlens[1:])]
+        # stack and pad sequences together
+        out = pad_sequence(seqs, batch_first=True)
+        # restore original sequence length in case there was padding on all sequences initially
+        out = F.pad(out, (0, 0) * (out.dim() - 2) + (0, max_len - out.size(1)), value=0.0)
+    return out


### PR DESCRIPTION
Adds support for patching flash attention into Llama models. This is done by replacing the `forward` method of `LlamaAttention` and using `flash_attention` for the attention computation part.