### PR TITLE
Feature/remove reward instructor

### DIFF
--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -98,6 +98,16 @@ python trainer_sft.py --configs oasst_export_eu galactica-125m
 Change the `input_file_path` in the `oasst_export_eu` from the
 `configs/config.yaml` file to the correct path.
 
+## Training the Reward Model
+
+To experiment with the reward model run:
+```bash
+python trainer_rm.py --configs defaults_rm oasst-rm-1-pythia-1b
+```
+
+Since the model configs are kept quite minimal it is important to overwrite the other default options (as given by `defaults_rm`)
+with the model specific ones.
+
 ## Training with RL
 
 To train using trlx try:

--- a/model/model_training/configs/config_rm.yaml
+++ b/model/model_training/configs/config_rm.yaml
@@ -39,6 +39,12 @@ defaults_rm:
   per_digit_tokens: false
   datasets_extra: []
 
+oast_export_only:
+  datasets:
+    - oasst_export:
+        lang: "en,es,de,fr"
+        input_file_path: 2023-03-21_oasst_ready_synth_labels.jsonl.gz
+
 oasst-rm-1-pythia-6B:
   is_reward_model: true
   pooling: last
@@ -83,3 +89,145 @@ oasst-rm-1-pythia-1b:
   num_train_epochs: 1
   eval_steps: 100
   save_steps: 500
+
+rm-bloomz-560m:
+  model_name: bigscience/bloomz-560m
+  learning_rate: 3e-5
+  gradient_accumulation_steps: 16
+  per_device_train_batch_size: 2
+  max_length: 600
+  freeze_layer: 12
+  num_train_epochs: 2
+
+rm-deberta-v2-xlarge:
+  model_name: microsoft/deberta-v2-xlarge
+  learning_rate: 1e-5
+  freeze_layer: 15
+  scheduler: cosine
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 16
+  per_device_train_batch_size: 1
+  warmup_steps: 600
+  eval_steps: 200
+  save_steps: 500
+  max_length: 512
+  num_train_epochs: 2
+
+rm-deberta-v2-xxlarge-a100:
+  model_name: microsoft/deberta-v2-xxlarge
+  learning_rate: 2e-6
+  scheduler: cosine
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 12
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 4
+  warmup_steps: 600
+  eval_steps: 1000000
+  save_steps: 1000
+  max_length: 512
+  num_train_epochs: 2
+
+rm-deberta-v3-base:
+  # needs protobuf==3.20.x or lower, which conflicts with venv of this folder!
+  model_name: microsoft/deberta-v3-base
+  learning_rate: 1e-5
+  scheduler: cosine
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 32
+  per_device_train_batch_size: 3
+  warmup_steps: 200
+  eval_steps: 200
+  save_steps: 1000
+  max_length: 512
+  num_train_epochs: 5
+
+rm-deberta-v3-large-squad2:
+  model_name: deepset/deberta-v3-large-squad2
+  learning_rate: 1e-5
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 32
+  per_device_train_batch_size: 1
+  warmup_steps: 600
+  eval_steps: 200
+  save_steps: 500
+  max_length: 512
+  num_train_epochs: 2
+
+
+rm-deberta-v3-large:
+  model_name: microsoft/deberta-v3-large
+  learning_rate: 1e-5
+  scheduler: cosine
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 32
+  per_device_train_batch_size: 1
+  warmup_steps: 600
+  eval_steps: 200
+  save_steps: 500
+  max_length: 512
+  num_train_epochs: 2
+
+rm-electra-large-discriminator:
+  model_name: google/electra-large-discriminator
+  learning_rate: 3e-5
+  max_length: 300
+
+rm-galactica-1.3b:
+  model_name: facebook/galactica-1.3b
+  learning_rate: 6e-6
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 16
+  per_device_train_batch_size: 2
+  warmup_steps: 600
+  freeze_layer: 20
+  eval_steps: 200
+  save_steps: 500
+  max_length: 400
+  num_train_epochs: 2
+  drop_token_type: true
+
+rm-galactica-125m:
+  model_name: facebook/galactica-125m
+  learning_rate: 1e-5
+  gradient_checkpointing: false
+  gradient_accumulation_steps: 32
+  per_device_train_batch_size: 2
+  warmup_steps: 600
+  eval_steps: 200
+  save_steps: 500
+  max_length: 512
+  num_train_epochs: 2
+  drop_token_type: true
+
+rm-rankgen-t5-base-all:
+  model_name: kalpeshk2011/rankgen-t5-base-all
+  tokenizer_name: google/t5-v1_1-base
+  learning_rate: 6e-6
+  gradient_checkpointing: false
+  fp16: true
+  gradient_accumulation_steps: 16
+  per_device_train_batch_size: 2
+  warmup_steps: 600
+  freeze_layer: 20
+  eval_steps: 200
+  save_steps: 500
+  max_length: 400
+  num_train_epochs: 2
+
+rm-rankgen-t5-base-xl-all:
+  model_name: kalpeshk2011/rankgen-t5-xl-all
+  # todo: decide on what to do with these models? extra config? or leave it as is?
+  # model_name: kalpeshk2011/rankgen-t5-xl-pg19
+  # model_name: kalpeshk2011/rankgen-t5-large-all
+  tokenizer_name: google/t5-v1_1-base
+  learning_rate: 6e-6
+  gradient_checkpointing: false
+  fp16: false
+  gradient_accumulation_steps: 16
+  per_device_train_batch_size: 2
+  warmup_steps: 600
+  freeze_layer: 20
+  eval_steps: 200
+  save_steps: 500
+  max_length: 400
+  num_train_epochs: 2

--- a/model/model_training/custom_datasets/__init__.py
+++ b/model/model_training/custom_datasets/__init__.py
@@ -34,7 +34,7 @@ OTHER = ["prosocial_dialogue", "explain_prosocial", "private_tuning", "oa_transl
 
 RL_DATASETS = ["webgpt", "private_tuning", "alpaca"]
 
-RM_DATASETS = ["oasst_export"]
+RM_DATASETS = ["oasst_export", "webgpt"]
 
 
 def train_val_dataset(dataset, val_split=0.2):


### PR DESCRIPTION
closes 2049

I updated the model_training/utils.py with all the functionality I could find diverging from reward/instructor.

I still have a few questions:
 - do we need the all of the dataset processing functionality form `reward/instructor`, e.g. in `experimental_dataset.py` and `cls_dataset.py` and alsow the `webgpt_return_format` function in utils?
 - will we use `webgpt` and `hfsummary` as reward model training data? Currently only the `oasst_export` data is defined as training data for the RM model