### PR TITLE
Fix call-to-action responsiveness

### DIFF
--- a/website/src/components/CallToAction.tsx
+++ b/website/src/components/CallToAction.tsx
@@ -1,4 +1,4 @@
-import { Box, HStack, Link, Text, useColorMode } from "@chakra-ui/react";
+import { Box, Link, Text, useColorMode } from "@chakra-ui/react";
 import { Github, Users } from "lucide-react";
 import { useTranslation } from "next-i18next";
 import { useId } from "react";

--- a/website/src/components/CallToAction.tsx
+++ b/website/src/components/CallToAction.tsx
@@ -1,4 +1,4 @@
-import { Box, Link, Text, useColorMode } from "@chakra-ui/react";
+import { Box, HStack, Link, Text, useColorMode } from "@chakra-ui/react";
 import { Github, Users } from "lucide-react";
 import { useTranslation } from "next-i18next";
 import { useId } from "react";
@@ -67,14 +67,14 @@ export function CallToAction() {
             {t("index:join_us_description")}
           </Text>
 
-          <Box className="mt-8 flex justify-center" gap={["3", "6"]}>
+          <Box className="mt-8 flex justify-center" gap={["2", "4"]}>
             <Link href="https://ykilcher.com/open-assistant-discord" rel="noreferrer" target="_blank">
               <button
                 type="button"
-                className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >
-                <Discord size={25} />
-                <Text as="span" className="text-lg ml-3">
+                <Discord size={20} />
+                <Text as="span" className="ml-3" fontSize={["sm", "md", "lg"]}>
                   {t("discord")}
                 </Text>
               </button>
@@ -82,10 +82,10 @@ export function CallToAction() {
             <Link href="https://github.com/LAION-AI/Open-Assistant" rel="noreferrer" target="_blank">
               <button
                 type="button"
-                className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >
-                <Github size={25} />
-                <Text as="span" className="text-lg ml-3">
+                <Github size={20} />
+                <Text as="span" className="ml-3" fontSize={["sm", "md", "lg"]}>
                   {t("github")}
                 </Text>
               </button>
@@ -93,10 +93,10 @@ export function CallToAction() {
             <Link href="/team" rel="noreferrer" target="_blank">
               <button
                 type="button"
-                className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-6 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >
-                <Users size={25} />
-                <Text as="span" className="text-lg ml-3">
+                <Users size={20} />
+                <Text as="span" className="ml-3" fontSize={["sm", "md", "lg"]}>
                   {t("team")}
                 </Text>
               </button>


### PR DESCRIPTION
Hey, following my pull request for adding the "Team" button to the call-to-action section, I made a small update to the responsiveness. 
Before             |  Now
:-------------------------:|:-------------------------:
![image](https://user-images.githubusercontent.com/25230234/229289501-3cf93539-18ff-4b45-9c91-299e677b4ace.png)  |  ![image](https://user-images.githubusercontent.com/25230234/229289660-67ab501a-e02e-432a-a6d0-c1287a1c0d72.png)

