### PR TITLE
Set validation max length to a different value.

### DIFF
--- a/model/model_training/configs/config.yaml
+++ b/model/model_training/configs/config.yaml
@@ -13,6 +13,7 @@ defaults:
   eval_steps: 200
   save_steps: 1000
   max_length: 512
+  val_max_length:
   num_train_epochs: 3
   logging_steps: 10
   max_grad_norm: 2.0

--- a/model/model_training/trainer_sft.py
+++ b/model/model_training/trainer_sft.py
@@ -329,9 +329,15 @@ def main():
         use_system_prefix=training_conf.use_system_prefix,
         system_prefix=training_conf.system_prefix,
     )
+
+    if training_conf.val_max_length is not None:
+        val_max_len = training_conf.val_max_length
+    else:
+        val_max_len = training_conf.max_length
+
     eval_collate_fn = DialogueDataCollator(
         tokenizer,
-        max_length=training_conf.max_length,
+        max_length=val_max_len,
         random_offset_probability=training_conf.random_offset_probability,
         label_masking=training_conf.label_masking,
         samples_mixing=False,
@@ -410,6 +416,7 @@ def main():
             config=training_conf,
         )
         wandb.config["_max_length"] = training_conf.max_length
+        wandb.config["val_max_length"] = val_max_len
 
     trainer = SFTTrainer(
         model=model,


### PR DESCRIPTION
Option to set the validation max_length to be different from the training max_length.

As the validation max length influences accuracy/loss results. 
It would be good to keep it fixed at say, 2048, and vary the train max length. This might also mean configuring the per_device_eval_batch_size to be lower/running less frequent validation.