### PR TITLE
Code state of wandb run bqiatai0 (2023-03-25_oasst_cyrillic_alpaca_reference_good)

### DIFF
--- a/model/model_training/.gitignore
+++ b/model/model_training/.gitignore
@@ -4,5 +4,6 @@ saved_model
 saved_model*
 .saved_model*
 .save_model*
+.saved
 llama_model
 models-*

--- a/model/model_training/configs/config.yaml
+++ b/model/model_training/configs/config.yaml
@@ -120,8 +120,8 @@ pretrain:
 reference-data:
   datasets:
     - oasst_export:
-        lang: "en,es,de,fr"
-        input_file_path: 2023-03-27_oasst_research_ready_synth.jsonl.gz
+        lang: "bg,ca,cs,da,de,en,es,fr,hr,hu,it,nl,pl,pt,ro,ru,sl,sr,sv,uk"
+        input_file_path: 2023-03-25_oasst_research_ready_synth_labels.jsonl.gz
         val_split: 0.05
     - alpaca
   sort_by_length: false
@@ -172,15 +172,15 @@ reference-pythia-12b:
   model_name: EleutherAI/pythia-12b-deduped
   output_dir: pythia_model_12b
   weight_decay: 0.0
-  max_length: 620
+  max_length: 2048
   warmup_steps: 100
   gradient_checkpointing: true
-  gradient_accumulation_steps: 1
-  per_device_train_batch_size: 8
-  per_device_eval_batch_size: 8
+  gradient_accumulation_steps: 2
+  per_device_train_batch_size: 4
+  per_device_eval_batch_size: 4
   eval_steps: 100
-  save_steps: 500
-  num_train_epochs: 16
+  save_steps: 2000
+  num_train_epochs: 8
   save_total_limit: 4
 
 llama-7b:

--- a/model/model_training/configs/config.yaml
+++ b/model/model_training/configs/config.yaml
@@ -117,6 +117,16 @@ pretrain:
     - explain_prosocial:
         fraction: 0.05
 
+reference-data:
+  datasets:
+    - oasst_export:
+        lang: "en,es,de,fr"
+        input_file_path: 2023-03-27_oasst_research_ready_synth.jsonl.gz
+        val_split: 0.05
+    - alpaca
+  sort_by_length: false
+  use_custom_sampler: false
+
 oasst_export_eu:
   datasets:
     - oasst_export:
@@ -155,19 +165,19 @@ oasst_export_latin_cyrillic:
   sort_by_length: false
   use_custom_sampler: false
 
-pythia-12b:
+reference-pythia-12b:
   dtype: fp16
   log_dir: "pythia_log_12b"
-  learning_rate: 8e-6
+  learning_rate: 6e-6
   model_name: EleutherAI/pythia-12b-deduped
   output_dir: pythia_model_12b
   weight_decay: 0.0
   max_length: 620
   warmup_steps: 100
-  gradient_checkpointing: false
-  gradient_accumulation_steps: 8
-  per_device_train_batch_size: 2
-  per_device_eval_batch_size: 5
+  gradient_checkpointing: true
+  gradient_accumulation_steps: 1
+  per_device_train_batch_size: 8
+  per_device_eval_batch_size: 8
   eval_steps: 100
   save_steps: 500
   num_train_epochs: 16
@@ -184,8 +194,8 @@ llama-7b:
   warmup_steps: 100
   gradient_checkpointing: false
   gradient_accumulation_steps: 4
-  per_device_train_batch_size: 4
-  per_device_eval_batch_size: 10
+  per_device_train_batch_size: 2
+  per_device_eval_batch_size: 5
   eval_steps: 100
   save_steps: 500
   num_train_epochs: 16
@@ -265,12 +275,17 @@ pythia-12B:
   learning_rate: 6e-6
   model_name: EleutherAI/pythia-12b-deduped
   weight_decay: 0.0
-  max_length: 2048
-  warmup_steps: 20
+  max_length: 620
+  use_flash_attention: true
+  warmup_steps: 100
   gradient_checkpointing: false
   gradient_accumulation_steps: 4
   per_device_train_batch_size: 2
-  per_device_eval_batch_size: 2
+  per_device_eval_batch_size: 5
+  eval_steps: 200
+  save_steps: 500
+  num_train_epochs: 16
+  save_total_limit: 4
 
 gpt-neox:
   model_name: EleutherAI/gpt-neox-20b

--- a/model/model_training/configs/zero_config.json
+++ b/model/model_training/configs/zero_config.json
@@ -7,6 +7,9 @@
     "hysteresis": 2,
     "min_loss_scale": 1
   },
+  "bf16": {
+    "enabled": "auto"
+  },
   "optimizer": {
     "type": "AdamW",
     "params": {
@@ -28,15 +31,11 @@
   "zero_optimization": {
     "stage": 2,
     "allgather_partitions": true,
-    "allgather_bucket_size": 2e8,
-    "overlap_comm": true,
+    "allgather_bucket_size": 1e9,
+    "overlap_comm": false,
     "reduce_scatter": true,
-    "reduce_bucket_size": 2e8,
-    "contiguous_gradients": true,
-    "offload_optimizer": {
-      "device": "cpu",
-      "pin_memory": true
-    }
+    "reduce_bucket_size": 1e9,
+    "contiguous_gradients": true
   },
   "gradient_accumulation_steps": "auto",
   "gradient_clipping": "auto",


### PR DESCRIPTION
Wandb run: [2023-03-25_oasst_cyrillic_alpaca_reference_good](https://wandb.ai/open-assistant/supervised-finetuning/runs/bqiatai0)

Training run verified with the following dependency versions:
deepspeed==0.8.3
transformers @ git+https://github.com/huggingface/transformers.git@6fc44656b43f1de939a1e62dd59c45d1fec9f1aa


Full output of pip freeze environment:
```
accelerate==0.15.0
aiodns==3.0.0
aiohttp==3.8.3
aiosignal==1.3.1
appdirs==1.4.4
async-timeout==4.0.2
attrs==22.2.0
beautifulsoup4==4.12.0
bitsandbytes==0.36.0.post2
Brotli==1.0.9
certifi==2022.12.7
cffi==1.15.1
cfgv==3.3.1
charset-normalizer==2.1.1
click==8.1.3
datasets==2.8.0
deepspeed==0.8.3
dill==0.3.6
distlib==0.3.6
docker-pycreds==0.4.0
einops==0.6.0
evaluate==0.4.0
filelock==3.10.7
flash-attn==0.2.8
frozenlist==1.3.3
fsspec==2023.3.0
gdown==4.7.1
gitdb==4.0.10
GitPython==3.1.31
grpcio==1.53.0
hjson==3.1.0
huggingface-hub==0.13.3
identify==2.5.22
idna==3.4
inflate64==0.3.1
joblib==1.2.0
jsonschema==4.17.3
loguru==0.6.0
markdown-it-py==2.2.0
mdurl==0.1.2
-e git+https://github.com/LAION-AI/Open-Assistant.git@f0e1c60296833d58e54e8f8841752a8e73e19c1e#egg=model_training&subdirectory=model
msgpack==1.0.5
multidict==6.0.4
multiprocess==0.70.14
multivolumefile==0.2.3
networkx==3.0
ninja==1.11.1
nltk==3.8.1
nodeenv==1.7.0
numpy==1.24.2
nvidia-cublas-cu11==11.10.3.66
nvidia-cuda-nvrtc-cu11==11.7.99
nvidia-cuda-runtime-cu11==11.7.99
nvidia-cudnn-cu11==8.5.0.96
-e git+https://github.com/LAION-AI/Open-Assistant.git@f0e1c60296833d58e54e8f8841752a8e73e19c1e#egg=oasst_data&subdirectory=oasst-data
-e git+https://github.com/LAION-AI/Open-Assistant.git@f0e1c60296833d58e54e8f8841752a8e73e19c1e#egg=oasst_shared&subdirectory=oasst-shared
packaging==23.0
pandas==1.5.3
pathtools==0.1.2
platformdirs==3.2.0
pre-commit==3.2.1
protobuf==4.22.1
psutil==5.9.4
py-cpuinfo==9.0.0
py7zr==0.20.4
pyarrow==11.0.0
pybcj==1.0.1
pycares==4.3.0
pycparser==2.21
pycryptodomex==3.17
pydantic==1.10.4
Pygments==2.14.0
pynvml==11.5.0
pyppmd==1.0.0
pyrsistent==0.19.3
PySocks==1.7.1
python-dateutil==2.8.2
pytz==2023.2
PyYAML==6.0
pyzstd==0.15.4
ray==2.3.1
regex==2023.3.23
requests==2.28.2
responses==0.18.0
rich==13.3.3
scikit-learn==1.2.0
scipy==1.10.1
sentencepiece==0.1.97
sentry-sdk==1.18.0
setproctitle==1.3.2
six==1.16.0
smmap==5.0.0
soupsieve==2.4
tabulate==0.9.0
texttable==1.6.7
threadpoolctl==3.1.0
tokenizers==0.13.2
torch==1.13.1
torchtyping==0.1.4
tqdm==4.65.0
transformers @ git+https://github.com/huggingface/transformers.git@6fc44656b43f1de939a1e62dd59c45d1fec9f1aa
trlx @ git+https://github.com/CarperAI/trlx.git@b91da7b03d8e9fa0c0d6dce10a8f2611aca3013f
typeguard==3.0.2
typing_extensions==4.5.0
urllib3==1.26.15
virtualenv==20.21.0
wandb==0.14.0
xxhash==3.2.0
yarl==1.8.2
```