### PR TITLE
Add option to find missing strings in only some locales

### DIFF
--- a/scripts/frontend-development/find-missing-locales.py
+++ b/scripts/frontend-development/find-missing-locales.py
@@ -1,8 +1,8 @@
+import sys
 from collections import defaultdict
 from glob import glob
 from json import load
 from os import path
-import sys
 
 ALL_PATH = "../../website/public/locales/**/*.json"
 DIR = path.dirname(__file__)

--- a/scripts/frontend-development/find-missing-locales.py
+++ b/scripts/frontend-development/find-missing-locales.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from glob import glob
 from json import load
 from os import path
+import sys
 
 ALL_PATH = "../../website/public/locales/**/*.json"
 DIR = path.dirname(__file__)
@@ -46,9 +47,10 @@ def main():
     for en_file in glob(path.join(DIR, EN_PATH)):
         for file in glob(path.join(DIR, ALL_PATH)):
             if path.basename(en_file) == path.basename(file) and file != en_file:
-                file_info = audit(file, en_file)
                 lang = path.basename(path.dirname(file))
-                per_language_dict[lang].append(file_info)
+                if len(sys.argv) == 0 or lang in sys.argv:
+                    file_info = audit(file, en_file)
+                    per_language_dict[lang].append(file_info)
     for results in per_language_dict.values():
         list(map(lambda args: print_result(*args), results))
         print()

--- a/website/docs/add_edit_translations.md
+++ b/website/docs/add_edit_translations.md
@@ -33,6 +33,10 @@ When editing existing translations, follow these rules:
 ### Finding missing translations
 
 A script can be used to find missing and potentially untranslated locale files. Run the script from the root dir using
-`python scripts/frontend-development/find-missing-locales.py`.
+`python scripts/frontend-development/find-missing-locales.py`.  
+You may pass any languages you want to include in the search to the script like so:  
+`python scripts/frontend-development/find-missing-locales.py de ja`  
+This would only show missing/untranslated strings in the German (de) and Japanese (ja) locale files.  
+Passing nothing will default to searching all locales instead.
 
 If you have any questions or need further assistance, please reach out.

--- a/website/docs/add_edit_translations.md
+++ b/website/docs/add_edit_translations.md
@@ -33,10 +33,11 @@ When editing existing translations, follow these rules:
 ### Finding missing translations
 
 A script can be used to find missing and potentially untranslated locale files. Run the script from the root dir using
-`python scripts/frontend-development/find-missing-locales.py`.  
-You may pass any languages you want to include in the search to the script like so:  
-`python scripts/frontend-development/find-missing-locales.py de ja`  
-This would only show missing/untranslated strings in the German (de) and Japanese (ja) locale files.  
+`python scripts/frontend-development/find-missing-locales.py`.
+
+You may pass any languages you want to include in the search to the script like so:\
+`python scripts/frontend-development/find-missing-locales.py de ja`\
+This would only show missing/untranslated strings in the German (de) and Japanese (ja) locale files.\
 Passing nothing will default to searching all locales instead.
 
 If you have any questions or need further assistance, please reach out.


### PR DESCRIPTION
This adds the option to filter the output of find-missing-locales.py by passing locale codes (like ``en``) to it so that translators don't need to search for their specific languages in the output.