### PR TITLE
Add HFSummaryPairs class & fix AnthropicRLHF parsing

### DIFF
--- a/model/model_training/configs/config_rm.yaml
+++ b/model/model_training/configs/config_rm.yaml
@@ -85,7 +85,7 @@ oasst-rm-1-pythia-1.4b:
     - webgpt:
         val_split: 0.05
         max_val_set: 1000
-    - hf_summary:
+    - hf_summary_pairs:
         fraction: 0.1
         max_val_set: 250
   use_custom_sampler: true
@@ -97,10 +97,10 @@ oasst-rm-1-pythia-1.4b:
   dtype: float32
   max_length: 2048
   use_flash_attention: true
-  warmup_steps: 10
-  gradient_accumulation_steps: 2
-  per_device_train_batch_size: 2
-  per_device_eval_batch_size: 6
+  warmup_steps: 50
+  gradient_accumulation_steps: 4
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 5
   num_train_epochs: 2
   eval_steps: 500
   save_steps: 1000

--- a/model/model_training/custom_datasets/__init__.py
+++ b/model/model_training/custom_datasets/__init__.py
@@ -19,7 +19,7 @@ from model_training.custom_datasets.qa_datasets import (
     WebGPT,
 )
 from model_training.custom_datasets.rank_datasets import AugmentedOA
-from model_training.custom_datasets.summarization import HFSummary, SummarizationDataset
+from model_training.custom_datasets.summarization import HFSummary, HFSummaryPairs, SummarizationDataset
 from model_training.custom_datasets.toxic_conversation import ProsocialDialogue, ProsocialDialogueExplaination
 from model_training.custom_datasets.translation import WMT2019, DiveMT, TEDTalk
 from sklearn.model_selection import train_test_split
@@ -50,6 +50,7 @@ RL_DATASETS = [
     "private_tuning",
     "alpaca",
     "hf_summary",
+    "hf_summary_pairs",
 ]
 
 RM_DATASETS = [
@@ -57,6 +58,7 @@ RM_DATASETS = [
     "augment_oasst",
     "anthropic_rlhf",
     "hf_summary",
+    "hf_summary_pairs",
     "shp",
     "hellaswag",
     "webgpt",
@@ -140,6 +142,9 @@ def get_one_dataset(
     elif dataset_name == "hf_summary":
         train = HFSummary(split="train", mode=mode)
         eval = HFSummary(split="valid1", mode=mode)
+    elif dataset_name == "hf_summary_pairs":
+        train = HFSummaryPairs(split="train", mode=mode)
+        eval = HFSummaryPairs(split="valid1", mode=mode)
     elif dataset_name == "augment_oasst":
         # reward model mode only
         assert mode == "rm"

--- a/model/model_training/custom_datasets/rank_datasets.py
+++ b/model/model_training/custom_datasets/rank_datasets.py
@@ -183,10 +183,15 @@ class AnthropicRLHF(Dataset):
     name = "anthropic_rlhf"
 
     @staticmethod
-    def _split_dialogue(text: str):
+    def _split_dialogue(text: str) -> list[tuple[str, str]]:
         lines = text.split("\n\n")
 
-        dialogue = []
+        dialogue: list[tuple[str, str]] = []
+
+        # go over messages and combine consecutive messages from the
+        # same speaker (OA v1 expects alternating roles)
+        role = None
+        messages = []
         for line in lines:
             if line.startswith("Human:"):
                 speaker = "Human"
@@ -196,16 +201,25 @@ class AnthropicRLHF(Dataset):
                 message = line[11:]
             else:
                 continue
-            dialogue.append((speaker, message.strip()))
+            if role != speaker:
+                if role is not None:
+                    dialogue.append((role, "\n".join(messages)))
+                    messages = []
+                role = speaker
+            messages.append(message.strip())
+
+        if role is not None and len(messages) > 0:
+            dialogue.append((role, "\n".join(messages)))
 
         return dialogue
 
-    def __init__(self, split="train") -> None:
+    def __init__(self, split: str = "train") -> None:
         super().__init__()
         assert split in ("train", "test")
         self.split = split
         self.data = []
         dataset = load_dataset("Anthropic/hh-rlhf")[split]
+
         for entry in dataset:
             chosen = entry["chosen"]
 
@@ -215,14 +229,17 @@ class AnthropicRLHF(Dataset):
             rejected = entry["rejected"]
             chosen = self._split_dialogue(chosen)
             rejected = self._split_dialogue(rejected)
+            assert rejected[0][0] == "Human" and chosen[0][0] == "Human"
 
-            prefix = [line for (speaker, line) in chosen[:-1]]
-            good_reply = chosen[-1][1]  # last part of dialog, the text
-            bad_reply = rejected[-1][1]  # last part of dialog, the text
-            self.data.append((prefix, [good_reply, bad_reply]))
+            # only very few items have non matching lengths
+            if len(rejected) == len(chosen):
+                prefix = [line for (speaker, line) in chosen[:-1]]
+                good_reply = chosen[-1][1]  # last part of dialog, the text
+                bad_reply = rejected[-1][1]  # last part of dialog, the text
+                self.data.append((prefix, [good_reply, bad_reply]))
 
-    def __len__(self):
+    def __len__(self) -> int:
         return len(self.data)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> tuple[str, list[str]]:
         return self.data[index]

--- a/model/model_training/tests/test_ranking_collator.py
+++ b/model/model_training/tests/test_ranking_collator.py
@@ -12,17 +12,17 @@ def test_rm_datasets():
     # dummy configuration
     config = Namespace(cache_dir=".cache", model_name="EleutherAI/pythia-70m-deduped")
 
-    dataset_names = ["webgpt", "hf_summary", "hellaswag", "shp", "anthropic_rlhf"]
+    dataset_names = ["anthropic_rlhf", "hf_summary_pairs", "webgpt", "hellaswag", "shp", "hf_summary"]
     for name in dataset_names:
         train, val = get_one_dataset(conf=config, dataset_name=name, mode="rm")
-        print(f"dataset: {name}  (train ({type(train)}): {len(train)}, val({type(val)}): {len(val)})")
+        print(f"dataset: '{name}' (train ({type(train)}): {len(train)}, val({type(val)}): {len(val)})")
 
         avg_number_continuations = sum(len(x[1]) for x in train) / len(train)
         num_more_than_two = sum(1 if len(x[1]) > 2 else 0 for x in train)
         print(f"Average number of continuations: {avg_number_continuations} (with >2: {num_more_than_two})")
 
-        for i in range(2):
-            item = train[i]
+        for i in range(10):
+            item = train[i + 100]
             print(f"[{i}] Prefix: {item[0]}")
             continuations = item[1]
             print(f"[{i}] Continuations ({len(continuations)}):")


### PR DESCRIPTION
- add simpler version of HFSummaries which directly uses the pairs of the OpenAI dataset
- combine consecutive messages of same speaker during loading of AnthropicRLHF dataset, ignore examples with different structure between positive & negative example (only very few)