### PR TITLE
update gpt4all to add multiround

### DIFF
--- a/model/model_training/custom_datasets/prompt_dialogue.py
+++ b/model/model_training/custom_datasets/prompt_dialogue.py
@@ -125,7 +125,7 @@ class Gpt4All(Dataset):
         self.rows.extend(multi_round_conversations)
 
     @staticmethod
-    def process_conversation(conv: list[dict[str, None | str]]) -> tuple[str] | None:
+    def process_conversation(conv: list[dict[str, None | str]]) -> list[str] | None:
         dialogue = []
         role = None
         messages = []
@@ -150,7 +150,7 @@ class Gpt4All(Dataset):
 
         if role is not None and len(messages) > 0:
             dialogue.append("\n".join(messages))
-        return tuple(dialogue)
+        return dialogue
 
     def __len__(self):
         return len(self.rows)

--- a/model/model_training/custom_datasets/prompt_dialogue.py
+++ b/model/model_training/custom_datasets/prompt_dialogue.py
@@ -113,12 +113,44 @@ class Gpt4All(Dataset):
         )
         self.rows = [(row["prompt"], row["response"]) for row in dataset["train"]]
 
+        dataset_multi = load_dataset(
+            "Nebulous/gpt4all_pruned",
+            data_files="data_multiround_pruned_3.jsonl",
+            cache_dir=cache_dir,
+        )
+        self.rows.extend([self.process_conversation(row) for row in dataset_multi["train"]["conversation"]])
+
+    @staticmethod
+    def process_conversation(conv: list[dict[str, None | str]]) -> tuple[str]:
+        dialogue = []
+        role = None
+        messages = []
+        for line in conv:
+            if line["User"] and line["Bot"]:
+                raise ValueError("Unexpected dataformat. Should receive only User or Bot data, not both.")
+            if (message := line["User"]) is not None:
+                speaker = "Human"
+            elif (message := line["Bot"]) is not None:
+                speaker = "Assistant"
+            else:
+                continue
+            if role != speaker:
+                if role is not None:
+                    dialogue.append("\n".join(messages))
+                    messages = []
+                role = speaker
+            messages.append(message.strip())
+
+        if role is not None and len(messages) > 0:
+            dialogue.append("\n".join(messages))
+        return tuple(dialogue)
+
     def __len__(self):
         return len(self.rows)
 
     def __getitem__(self, index):
-        question, answer = self.rows[index]
+        dialogue = self.rows[index]
         if self.mode == "sft":
-            return (question, answer)
+            return dialogue
         elif self.mode == "rl":
-            return (question,)
+            return (dialogue[:-1],)

--- a/model/model_training/custom_datasets/prompt_dialogue.py
+++ b/model/model_training/custom_datasets/prompt_dialogue.py
@@ -118,13 +118,20 @@ class Gpt4All(Dataset):
             data_files="data_multiround_pruned_3.jsonl",
             cache_dir=cache_dir,
         )
-        self.rows.extend([self.process_conversation(row) for row in dataset_multi["train"]["conversation"]])
+        multi_round_conversations = []
+        for row in dataset_multi["train"]["conversation"]:
+            if (processed_conversation := self.process_conversation(row)) is not None:
+                multi_round_conversations.append(processed_conversation)
+        self.rows.extend(multi_round_conversations)
 
     @staticmethod
-    def process_conversation(conv: list[dict[str, None | str]]) -> tuple[str]:
+    def process_conversation(conv: list[dict[str, None | str]]) -> tuple[str] | None:
         dialogue = []
         role = None
         messages = []
+        # drop conversations that start with Bot
+        if conv[0]["Bot"] is not None:
+            return None
         for line in conv:
             if line["User"] and line["Bot"]:
                 raise ValueError("Unexpected dataformat. Should receive only User or Bot data, not both.")


### PR DESCRIPTION
fixes #2346

Add support for multiround gpt4all. Since the column names are different I need to load the datasets seperately. Otherwise the newly added functionality follows the `_split_dialogue` function from [this commit](https://github.com/LAION-AI/Open-Assistant/blob/b575c399f6aba1cb58419da5652a5e3ca9441e84/model/model_training/custom_datasets/rank_datasets.py)