### PR TITLE
Show work config on each message

### DIFF
--- a/inference/server/oasst_inference_server/models/chat.py
+++ b/inference/server/oasst_inference_server/models/chat.py
@@ -56,6 +56,7 @@ class DbMessage(SQLModel, table=True):
             role=self.role,
             state=self.state,
             score=self.score,
+            work_parameters=self.work_parameters,
             reports=[r.to_read() for r in self.reports],
         )
 

--- a/oasst-shared/oasst_shared/schemas/inference.py
+++ b/oasst-shared/oasst_shared/schemas/inference.py
@@ -166,6 +166,8 @@ class MessageRead(pydantic.BaseModel):
     state: MessageState
     score: int
     reports: list[Report] = []
+    # work parameters will be None on user prompts
+    work_parameters: WorkParameters | None
 
     @property
     def is_assistant(self) -> bool:

--- a/website/src/components/Chat/ChatConversation.tsx
+++ b/website/src/components/Chat/ChatConversation.tsx
@@ -33,6 +33,7 @@ import { MessageEmojiButton } from "../Messages/MessageEmojiButton";
 import { MessageInlineEmojiRow } from "../Messages/MessageInlineEmojiRow";
 import { ChatConfigDrawer } from "./ChatConfigDrawer";
 import { QueueInfoMessage } from "./QueueInfoMessage";
+import { WorkParametersDisplay } from "./WorkParameters";
 interface ChatConversationProps {
   chatId: string;
 }
@@ -189,6 +190,7 @@ export const ChatConversation = ({ chatId }: ChatConversationProps) => {
           onVote={handleOnVote}
           onRetry={handleOnRetry}
           isSending={isSending}
+          workParameters={message.work_parameters}
         >
           {message.content}
         </ChatMessageEntry>
@@ -226,6 +228,7 @@ type ChatMessageEntryProps = {
   chatId: string;
   messageId: string;
   parentId?: string;
+  workParameters?: InferenceMessage["work_parameters"];
   score: number;
   onVote: (data: { newScore: number; oldScore: number; chatId: string; messageId: string }) => void;
   onRetry?: (messageId: string) => void;
@@ -257,6 +260,7 @@ const ChatMessageEntry = memo(function ChatMessageEntry({
   onVote,
   onRetry,
   isSending,
+  workParameters,
 }: ChatMessageEntryProps) {
   const { t } = useTranslation("common");
   const handleVote = useCallback(
@@ -313,6 +317,7 @@ const ChatMessageEntry = memo(function ChatMessageEntry({
                 forceHideCount
                 onClick={handleThumbsDown}
               />
+              <WorkParametersDisplay parameters={workParameters} />
             </>
           )}
         </MessageInlineEmojiRow>

--- a/website/src/components/Chat/ChatConversation.tsx
+++ b/website/src/components/Chat/ChatConversation.tsx
@@ -317,7 +317,7 @@ const ChatMessageEntry = memo(function ChatMessageEntry({
                 forceHideCount
                 onClick={handleThumbsDown}
               />
-              <WorkParametersDisplay parameters={workParameters} />
+              {workParameters && <WorkParametersDisplay parameters={workParameters} />}
             </>
           )}
         </MessageInlineEmojiRow>

--- a/website/src/components/Chat/WorkParameters.tsx
+++ b/website/src/components/Chat/WorkParameters.tsx
@@ -1,0 +1,22 @@
+import { Accordion, AccordionButton, AccordionItem, AccordionPanel, IconButton } from "@chakra-ui/react";
+import { Sliders } from "lucide-react";
+import { memo } from "react";
+import { JsonCard } from "src/components/JsonCard";
+import { InferenceMessage } from "src/types/Chat";
+
+export const WorkParametersDisplay = memo(function WorkParametersDisplay({
+  parameters,
+}: {
+  parameters: InferenceMessage["work_parameters"];
+}) {
+  return (
+    <Accordion allowToggle>
+      <AccordionItem border="none">
+        <AccordionButton as={IconButton} icon={<Sliders />} bg="inherit" />
+        <AccordionPanel>
+          <JsonCard>{parameters}</JsonCard>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+});

--- a/website/src/components/Messages/MessageInlineEmojiRow.tsx
+++ b/website/src/components/Messages/MessageInlineEmojiRow.tsx
@@ -1,9 +1,11 @@
 import { HStack } from "@chakra-ui/react";
 import { ReactNode } from "react";
 
+const stopPropagation = (e) => e.stopPropagation();
+
 export const MessageInlineEmojiRow = ({ children }: { children: ReactNode }) => {
   return (
-    <HStack justifyContent="end" style={{ position: "relative" }} onClick={(e) => e.stopPropagation()}>
+    <HStack justifyContent="end" pos="relative" onClick={stopPropagation}>
       {children}
     </HStack>
   );

--- a/website/src/components/Messages/MessageInlineEmojiRow.tsx
+++ b/website/src/components/Messages/MessageInlineEmojiRow.tsx
@@ -1,7 +1,7 @@
 import { HStack } from "@chakra-ui/react";
-import { ReactNode } from "react";
+import { ReactNode, SyntheticEvent } from "react";
 
-const stopPropagation = (e) => e.stopPropagation();
+const stopPropagation = (e: SyntheticEvent) => e.stopPropagation();
 
 export const MessageInlineEmojiRow = ({ children }: { children: ReactNode }) => {
   return (

--- a/website/src/types/Chat.ts
+++ b/website/src/types/Chat.ts
@@ -35,6 +35,17 @@ export interface InferenceMessage {
   role: "assistant" | "prompter";
   score: number;
   reports: any[];
+  work_parameters?: {
+    do_sample: boolean;
+    seed: number;
+    sampling_parameters: SamplingParameters;
+    model_config: {
+      model_id: string;
+      max_input_length: number;
+      max_total_length: number;
+      quantized: boolean;
+    };
+  };
 }
 
 export interface GetChatsResponse {


### PR DESCRIPTION
I considered using a tooltip at the beginning, but I decided to show the config inline just so it is easier to copy for debugging / reproducability purposes. Design could be improved, especially when expanded, but functionality is there.

I am not sure if we want to show all of this info, or if some stuff is "confidential" and should be hidden.

![image](https://user-images.githubusercontent.com/24505302/230589231-d23385d2-4a77-4d87-adc2-43af589a2914.png)


![image](https://user-images.githubusercontent.com/24505302/230589260-b23f75d3-e775-4a3a-9ee9-823ac211cda5.png)
