### PR TITLE
Allow google login to backend

### DIFF
--- a/oasst-shared/oasst_shared/schemas/protocol.py
+++ b/oasst-shared/oasst_shared/schemas/protocol.py
@@ -26,7 +26,7 @@ class TaskRequestType(str, enum.Enum):
 class User(BaseModel):
     id: str
     display_name: str
-    auth_method: Literal["discord", "local", "system"]
+    auth_method: Literal["discord", "google", "local", "system"]
 
 
 class Account(BaseModel):


### PR DESCRIPTION
We want to add google login support to our website, I was looking for around for necessary changes in the backend, this is the only place that I found. All other parts of the code expect a generic string as provider.

Maybe someone else knows better.