### PR TITLE
Fix 'ConfigError: Attempted to change value of key "val_max_length" ...'

### DIFF
--- a/model/model_training/trainer_sft.py
+++ b/model/model_training/trainer_sft.py
@@ -418,7 +418,7 @@ def main():
             config=training_conf,
         )
         wandb.config["_max_length"] = training_conf.max_length
-        wandb.config["val_max_length"] = val_max_len
+        wandb.config["_val_max_length"] = val_max_len
 
     trainer = SFTTrainer(
         model=model,


### PR DESCRIPTION
Wandb doesn't allow changing val_max_len parameter:

Starting runs fails with:
`ConfigError: Attempted to change value of key "val_max_length" from None to 2048`

Installed wandb version: `wandb==0.14.0`

Stack:
```
 /home/ubuntu/koepf/Open-Assistant/model/model_training/trainer_sft.py:421 in main

   418 │   │   │   config=training_conf,
   419 │   │   )
   420 │   │   wandb.config["_max_length"] = training_conf.max_length
 ❱ 421 │   │   wandb.config["val_max_length"] = val_max_len
   422 │
   423 │   trainer = SFTTrainer(
   424 │   │   model=model,

 /home/ubuntu/koepf/venvkoepf/lib/python3.10/site-packages/wandb/sdk/wandb_config.py:150 in __setitem__

   147 │   │   with wandb.sdk.lib.telemetry.context() as tel:
   148 │   │   │   tel.feature.set_config_item = True
   149 │   │   self._raise_value_error_on_nested_artifact(val, nested=True)
 ❱ 150 │   │   key, val = self._sanitize(key, val)
   151 │   │   self._items[key] = val
   152 │   │   logger.info("config set %s = %s - %s", key, val, self._callback)
   153 │   │   if self._callback:

 /home/ubuntu/koepf/venvkoepf/lib/python3.10/site-packages/wandb/sdk/wandb_config.py:262 in _sanitize

   259 │   │   │   val = json_friendly_val(val)
   260 │   │   if not allow_val_change:
   261 │   │   │   if key in self._items and val != self._items[key]:
 ❱ 262 │   │   │   │   raise config_util.ConfigError(
   263 │   │   │   │   │   (
   264 │   │   │   │   │   │   'Attempted to change value of key "{}" '
   265 │   │   │   │   │   │   "from {} to {}\n"
   ```

@jordiclive please have a look ..