### PR TITLE
Add max_replies parameter for trainer_rm

### DIFF
--- a/model/model_training/configs/config_rm.yaml
+++ b/model/model_training/configs/config_rm.yaml
@@ -42,27 +42,91 @@ defaults_rm:
   datasets_extra: []
   metrics: ["accuracy", "kendalltau"]
   deepspeed_config: configs/zero_config.json
+  max_replies: 5
 
-oasst-rm-1-pythia-6B:
+oasst-rm-1-pythia-6.9b:
+  is_reward_model: true
+  pooling: last
+  datasets:
+    - augment_oasst:
+        #input_file_path: augmented_latin_cyrillic_oasst_2023-03-27.jsonl
+        input_file_path: augmented_latin_cyrillic_oasst_2023-03-27_v2.jsonl
+    - anthropic_rlhf:
+        fraction: 0.1
+        max_val_set: 1000
+    - shp:
+        max_val_set: 1000
+    - hellaswag:
+        fraction: 0.5
+        max_val_set: 1000
+    - webgpt:
+        val_split: 0.05
+        max_val_set: 1000
+    - hf_summary_pairs:
+        fraction: 0.1
+        max_val_set: 250
+  sort_by_length: false
+  use_custom_sampler: true
+  model_name: andreaskoepf/pythia-6.9b-gpt4all-pretrain
+  learning_rate: 1e-5
+  residual_dropout: 0.0
+  weight_decay: 0.0
+  max_length: 2048
+  use_flash_attention: true
+  gradient_checkpointing: true
+  warmup_steps: 50
+  dtype: float16
+  gradient_accumulation_steps: 4
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 4
+  num_train_epochs: 3
+  eval_steps: 251
+  save_steps: 500
+  deepspeed_config: configs/zero3_config_sft.json
+
+oasst-rm-1-pythia-2.8b:
   is_reward_model: true
   pooling: last
   datasets:
     - oasst_export:
         lang: "en,es,de,fr"
         input_file_path: 2023-03-27_oasst_research_ready_synth.jsonl.gz
+        val_split: 0.1
+    - augment_oasst:
+        #input_file_path: augmented_latin_cyrillic_oasst_2023-03-27.jsonl
+        input_file_path: augmented_latin_cyrillic_oasst_2023-03-27_v2.jsonl
+    - anthropic_rlhf:
+        fraction: 0.1
+        max_val_set: 1000
+    - shp:
+        max_val_set: 1000
+    - hellaswag:
+        fraction: 0.5
+        max_val_set: 1000
+    - webgpt:
+        val_split: 0.05
+        max_val_set: 1000
+    - hf_summary_pairs:
+        fraction: 0.1
+        max_val_set: 250
+  use_custom_sampler: true
   sort_by_length: false
-  model_name: EleutherAI/pythia-6.9b-deduped
+  model_name: andreaskoepf/pythia-2.8b-gpt4all-pretrain
   learning_rate: 1e-5
-  residual_dropout: 0.08
-  weight_decay: 0.075
-  max_length: 512
-  warmup_steps: 20
-  gradient_accumulation_steps: 2
-  per_device_train_batch_size: 2
-  per_device_eval_batch_size: 3
-  eval_steps: 25
-  num_train_epochs: 2
+  residual_dropout: 0.01
+  weight_decay: 0.0
+  dtype: float32
+  max_length: 2048
+  use_flash_attention: true
+  gradient_checkpointing: true
+  warmup_steps: 50
+  gradient_accumulation_steps: 4
+  per_device_train_batch_size: 1
+  per_device_eval_batch_size: 5
+  num_train_epochs: 3
+  eval_steps: 251
   save_steps: 500
+  deepspeed_config: configs/zero3_config_sft.json
 
 oasst-rm-1-pythia-1.4b:
   is_reward_model: true

--- a/model/model_training/configs/zero3_config_sft.json
+++ b/model/model_training/configs/zero3_config_sft.json
@@ -25,7 +25,8 @@
       "warmup_min_lr": "auto",
       "warmup_max_lr": "auto",
       "warmup_num_steps": "auto",
-      "warmup_type": "linear"
+      "warmup_type": "linear",
+      "total_num_steps": "auto"
     }
   },
   "zero_optimization": {

--- a/model/model_training/custom_datasets/ranking_collator.py
+++ b/model/model_training/custom_datasets/ranking_collator.py
@@ -17,9 +17,15 @@ class RankingDataCollator:
     max_length: Optional[int] = None
     min_prefix_length: int = 256
     pad_to_multiple_of: Optional[int] = None
+    max_replies: Optional[int] = 5
 
     def process_one(self, example, return_length=False):
         messages, replies = example
+
+        if self.max_replies:
+            assert self.max_replies > 1, "max_replies parameter must be > 1 or None"
+            if len(replies) > self.max_replies:
+                replies = replies[: self.max_replies]
 
         assert self.tokenizer.eos_token
         eos = self.tokenizer.eos_token

--- a/model/model_training/trainer_rm.py
+++ b/model/model_training/trainer_rm.py
@@ -195,11 +195,13 @@ def main():
         tokenizer,
         max_length=training_conf.max_length,
         pad_to_multiple_of=16,
+        max_replies=training_conf.max_replies,
     )
     eval_collate_fn = RankingDataCollator(
         tokenizer,
         max_length=training_conf.max_length,
         pad_to_multiple_of=16,
+        max_replies=training_conf.max_replies,
     )
 
     show_dataset_stats = (training_conf.verbose or training_conf.show_dataset_stats) and (


### PR DESCRIPTION
- optionally limit number of replies considered in `RankingDataCollator` class 
- fix zero3 sft config (missing total_num_steps parameter)
- add basic configurations for RM training at 1.4B, 2.8B and 6.9B scales (based on pre-trained pythia models)

Background:
Batch size for RM is specified in prefixes. For most dataset entries (>95%) the reply/continuation count < 5 .. some training examples have potentially a higher reply count which in rare cases increases the effective batch size (and makes OOM errors more likely).