### PR TITLE
remove openai references from datasets

### DIFF
--- a/model/model_training/custom_datasets/prompt_dialogue.py
+++ b/model/model_training/custom_datasets/prompt_dialogue.py
@@ -7,6 +7,7 @@ from typing import Optional
 import requests
 from datasets import load_dataset
 from model_training.custom_datasets.oasst_dataset import ListDataset
+from model_training.custom_datasets.utils import _filter_by_words
 from torch import Generator, randperm
 from torch.utils.data import Dataset, random_split
 
@@ -139,6 +140,8 @@ class Gpt4All(Dataset):
                 speaker = "Assistant"
             else:
                 continue
+            if _filter_by_words(message) is None:
+                return None
             if role != speaker:
                 if role is not None:
                     dialogue.append("\n".join(messages))

--- a/model/model_training/custom_datasets/qa_datasets.py
+++ b/model/model_training/custom_datasets/qa_datasets.py
@@ -12,6 +12,7 @@ from urllib.request import urlopen
 
 import numpy as np
 from datasets import load_dataset
+from model_training.custom_datasets.utils import _filter_by_words
 from torch import Generator
 from torch.utils.data import Dataset, Subset, random_split
 
@@ -457,12 +458,15 @@ def load_alpaca_dataset(
         dataset: Subset, reverse_augmentation: bool = False, keep_unreversed: bool = True
     ) -> list[tuple[str, str]]:
         data = []
+        print("new version")
         for row in dataset:
             question = row["instruction"]
             if len(row["input"]) > 0:
                 input_ = "{}\n{}".format(question, row["input"])
             else:
                 input_ = question
+            if (_filter_by_words(input_) is None) or (_filter_by_words(row["output"]) is None):
+                continue
             if reverse_augmentation:
                 data.append((row["output"], input_))
                 # in case of reverse augmentation we just keep both, reversed and unreversed data
@@ -503,6 +507,9 @@ class Vicuna(Dataset):
         for line in data["conversations"]:
             speaker = line["from"]  # 'human' or 'gpt'
             message = line["value"]
+            # if _filter_by_words(message) is None:
+            #     print(message)
+            #     return None
             if role != speaker:
                 if role is not None:
                     dialogue.append("\n".join(messages))

--- a/model/model_training/custom_datasets/qa_datasets.py
+++ b/model/model_training/custom_datasets/qa_datasets.py
@@ -507,9 +507,6 @@ class Vicuna(Dataset):
         for line in data["conversations"]:
             speaker = line["from"]  # 'human' or 'gpt'
             message = line["value"]
-            # if _filter_by_words(message) is None:
-            #     print(message)
-            #     return None
             if role != speaker:
                 if role is not None:
                     dialogue.append("\n".join(messages))

--- a/model/model_training/custom_datasets/utils.py
+++ b/model/model_training/custom_datasets/utils.py
@@ -1,0 +1,19 @@
+FILTER_BY_WORDS = ["openai"]
+
+
+def _filter_by_words(text: str, filter_words: list[str] | None = None) -> None | str:
+    """Used to filter text that contains one of the `FILTER_BY_WORDS`. If so we return `None`
+       otherwise we return the string
+
+    Args:
+        text (str): text to be filtered
+
+    Returns:
+        None | str: filtered text
+    """
+    filter_words = filter_words or FILTER_BY_WORDS
+    for word in filter_words:
+        if word in text.lower():
+            print(text)
+            return None
+    return text

--- a/model/model_training/utils.py
+++ b/model/model_training/utils.py
@@ -364,9 +364,6 @@ def get_dataset(
 
     for data_config in conf.datasets + conf.datasets_extra:
         dataset_name, kwargs = get_dataset_name_and_kwargs_from_data_config(data_config)
-        import pdb
-
-        pdb.set_trace()
         train, val = get_one_dataset(conf, dataset_name, mode=mode, **kwargs)
         train_datasets.append(train)
 

--- a/model/model_training/utils.py
+++ b/model/model_training/utils.py
@@ -364,6 +364,9 @@ def get_dataset(
 
     for data_config in conf.datasets + conf.datasets_extra:
         dataset_name, kwargs = get_dataset_name_and_kwargs_from_data_config(data_config)
+        import pdb
+
+        pdb.set_trace()
         train, val = get_one_dataset(conf, dataset_name, mode=mode, **kwargs)
         train_datasets.append(train)
 


### PR DESCRIPTION
#2389

remove openai from the datasets:
 - gpt4all
 - alpaca
 - code_alpaca

I checked the following datasets additionally but did not found any entries mentioning openai:
    - joke
    - webgpt
    - minimath
    - humaneval_mbpp_codegen_qa
    - humaneval_mbpp_testgen_qa
    - grade_school_math_instructions
    - recipes
    - cmu_wiki_qa
    - oa_wiki_qa_bart_10000row
    - prosocial_dialogue:
    - explain_prosocial
