### PR TITLE
Fix #2354, introduce line-buffering + yield multiple objects from list in chat_stream.ts

### DIFF
--- a/website/jest.setup.js
+++ b/website/jest.setup.js
@@ -1,13 +1,12 @@
 // jest.setup.js
 import "@testing-library/jest-dom/extend-expect";
+
+// polyfill for node
+import { TextDecoderStream } from "@stardazed/streams-text-encoding";
 import { TextDecoder, TextEncoder } from "util";
 import { ReadableStream } from "web-streams-polyfill/es6";
-import { TextDecoderStream } from "@stardazed/streams-text-encoding";
-// import {  } from 'stream';
-// import * as stream from 'stream';
-// global.stream = stream;
+
 global.TextEncoder = TextEncoder;
-// global.TextDecoder = TextDecoder;
 global.TextDecoderStream = TextDecoderStream;
 global.TextDecoder = TextDecoder;
 global.ReadableStream = ReadableStream;

--- a/website/jest.setup.js
+++ b/website/jest.setup.js
@@ -1,5 +1,16 @@
 // jest.setup.js
 import "@testing-library/jest-dom/extend-expect";
+import { TextDecoder, TextEncoder } from "util";
+import { ReadableStream } from "web-streams-polyfill/es6";
+import { TextDecoderStream } from "@stardazed/streams-text-encoding";
+// import {  } from 'stream';
+// import * as stream from 'stream';
+// global.stream = stream;
+global.TextEncoder = TextEncoder;
+// global.TextDecoder = TextDecoder;
+global.TextDecoderStream = TextDecoderStream;
+global.TextDecoder = TextDecoder;
+global.ReadableStream = ReadableStream;
 
 const CONSOLE_FAIL_TYPES = ["error", "warn"];
 

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -68,6 +68,7 @@
         "@babel/core": "^7.21.3",
         "@chakra-ui/storybook-addon": "^4.0.16",
         "@faker-js/faker": "^7.6.0",
+        "@stardazed/streams-text-encoding": "^1.0.2",
         "@storybook/addon-actions": "^6.5.15",
         "@storybook/addon-essentials": "^6.5.16",
         "@storybook/addon-interactions": "^6.5.16",
@@ -98,7 +99,8 @@
         "prisma": "^4.11.0",
         "ts-essentials": "^9.3.1",
         "ts-node": "^10.9.1",
-        "typescript": "^4.9.5"
+        "typescript": "^4.9.5",
+        "web-streams-polyfill": "^3.2.1"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -6230,6 +6232,12 @@
       "dependencies": {
         "@sinonjs/commons": "^2.0.0"
       }
+    },
+    "node_modules/@stardazed/streams-text-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stardazed/streams-text-encoding/-/streams-text-encoding-1.0.2.tgz",
+      "integrity": "sha512-f2Z15BId3t44a/u21yYSGXFAkCyKocmAyduoAy7swnZ4xIfbaZlOWsgly/jDNNOuj6hYQN72UaBRe3Z/tOHfqg==",
+      "dev": true
     },
     "node_modules/@storybook/addon-actions": {
       "version": "6.5.16",
@@ -17465,24 +17473,6 @@
       "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
       "dev": true
     },
-    "node_modules/cssstyle": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
-      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
-      "dev": true,
-      "dependencies": {
-        "cssom": "~0.3.6"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/cssstyle/node_modules/cssom": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
-      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
-      "dev": true
-    },
     "node_modules/csstype": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
@@ -17749,20 +17739,6 @@
       },
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/data-urls": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
-      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/date-fns": {
@@ -24045,6 +24021,18 @@
         "@types/yargs-parser": "*"
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/acorn": {
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
+      "dev": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/jest-environment-jsdom/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -24094,6 +24082,64 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/jest-environment-jsdom/node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true
+    },
+    "node_modules/jest-environment-jsdom/node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/jest-environment-jsdom/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -24134,6 +24180,63 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/jest-environment-jsdom/node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/parse5": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^4.4.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/jest-environment-jsdom/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -24144,6 +24247,55 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tough-cookie": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
+      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
+      "dev": true,
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/jest-environment-node": {
@@ -26471,125 +26623,6 @@
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
       "dev": true
-    },
-    "node_modules/jsdom": {
-      "version": "20.0.3",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
-      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
-      "dev": true,
-      "dependencies": {
-        "abab": "^2.0.6",
-        "acorn": "^8.8.1",
-        "acorn-globals": "^7.0.0",
-        "cssom": "^0.5.0",
-        "cssstyle": "^2.3.0",
-        "data-urls": "^3.0.2",
-        "decimal.js": "^10.4.2",
-        "domexception": "^4.0.0",
-        "escodegen": "^2.0.0",
-        "form-data": "^4.0.0",
-        "html-encoding-sniffer": "^3.0.0",
-        "http-proxy-agent": "^5.0.0",
-        "https-proxy-agent": "^5.0.1",
-        "is-potential-custom-element-name": "^1.0.1",
-        "nwsapi": "^2.2.2",
-        "parse5": "^7.1.1",
-        "saxes": "^6.0.0",
-        "symbol-tree": "^3.2.4",
-        "tough-cookie": "^4.1.2",
-        "w3c-xmlserializer": "^4.0.0",
-        "webidl-conversions": "^7.0.0",
-        "whatwg-encoding": "^2.0.0",
-        "whatwg-mimetype": "^3.0.0",
-        "whatwg-url": "^11.0.0",
-        "ws": "^8.11.0",
-        "xml-name-validator": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "peerDependencies": {
-        "canvas": "^2.5.0"
-      },
-      "peerDependenciesMeta": {
-        "canvas": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.8.2",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "dev": true,
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/jsdom/node_modules/entities": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
-      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.12"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/jsdom/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/jsdom/node_modules/parse5": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
-      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
-      "dev": true,
-      "dependencies": {
-        "entities": "^4.4.0"
-      },
-      "funding": {
-        "url": "https://github.com/inikulin/parse5?sponsor=1"
-      }
-    },
-    "node_modules/jsdom/node_modules/tough-cookie": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.2.tgz",
-      "integrity": "sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==",
-      "dev": true,
-      "dependencies": {
-        "psl": "^1.1.33",
-        "punycode": "^2.1.1",
-        "universalify": "^0.2.0",
-        "url-parse": "^1.5.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/jsdom/node_modules/universalify": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4.0.0"
-      }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -38043,18 +38076,6 @@
       "resolved": "https://registry.npmjs.org/toygrad/-/toygrad-2.6.0.tgz",
       "integrity": "sha512-g4zBmlSbvzOE5FOILxYkAybTSxijKLkj1WoNqVGnbMcWDyj4wWQ+eYSr3ik7XOpIgMq/7eBcPRTJX3DM2E0YMg=="
     },
-    "node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/trim": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
@@ -39575,6 +39596,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -39585,9 +39615,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.76.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
-      "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
+      "version": "5.78.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.78.0.tgz",
+      "integrity": "sha512-gT5DP72KInmE/3azEaQrISjTvLYlSM0j1Ezhht/KLVkrqtv10JoP/RXhwmX/frrutOPuSq3o5Vq0ehR/4Vmd1g==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
@@ -39902,19 +39932,6 @@
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
       "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
       "dev": true,
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
-      },
       "engines": {
         "node": ">=12"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -86,6 +86,7 @@
     "@babel/core": "^7.21.3",
     "@chakra-ui/storybook-addon": "^4.0.16",
     "@faker-js/faker": "^7.6.0",
+    "@stardazed/streams-text-encoding": "^1.0.2",
     "@storybook/addon-actions": "^6.5.15",
     "@storybook/addon-essentials": "^6.5.16",
     "@storybook/addon-interactions": "^6.5.16",
@@ -116,7 +117,8 @@
     "prisma": "^4.11.0",
     "ts-essentials": "^9.3.1",
     "ts-node": "^10.9.1",
-    "typescript": "^4.9.5"
+    "typescript": "^4.9.5",
+    "web-streams-polyfill": "^3.2.1"
   },
   "msw": {
     "workerDirectory": "public"

--- a/website/src/lib/chat_stream.test.ts
+++ b/website/src/lib/chat_stream.test.ts
@@ -92,4 +92,95 @@ describe("iteratorSSE", () => {
     }
     expect(idx).toBe(outputs.length);
   });
+
+  it("iteratorSSE newline", async () => {
+    const inputs = ["dat", "a: {", '"test": "\\n"}\r\n'];
+    const outputs = [{ data: '{"test": "\\n"}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE comma", async () => {
+    const inputs = ["dat", "a: {", '"test": ","}\r\n'];
+    const outputs = [{ data: '{"test": ","}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE dot", async () => {
+    const inputs = ["dat", "a: {", '"test": "."}\r\n'];
+    const outputs = [{ data: '{"test": "."}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(outputs.length).toBeGreaterThan(idx);
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE complete text", async () => {
+    const inputs = [
+      "dat",
+      "a: {",
+      `"token": "The"}\r\n
+data: {"token": "re"}
+data: {"token": " "}
+data: {"token": "should"}
+data: {"token": " "}
+data: {"token": "be"}
+data: {"token": " "}
+data: {"token": "no"}
+data: {"token": " "}
+data: {"token": "problem"}
+data: {"token": " "}
+data: {"token": "with"}
+data: {"token": " "}
+data: {"token": "\`"}
+data: {"token": ","}
+data: {"token": "\\"}
+data: {"token": "."}\n`,
+    ];
+    const output_tokens: Array<string> = [
+      "The",
+      "re",
+      " ",
+      "should",
+      " ",
+      "be",
+      " ",
+      "no",
+      " ",
+      "problem",
+      " ",
+      "with",
+      " ",
+      "`",
+      ",",
+      "\\",
+      ".",
+    ];
+    const outputs = [];
+    for (const output_token of output_tokens) {
+      outputs.push({ data: '{"token": "' + output_token + '"}' });
+    }
+    let idx = 0;
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(outputs.length).toBeGreaterThan(idx);
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
 });

--- a/website/src/lib/chat_stream.test.ts
+++ b/website/src/lib/chat_stream.test.ts
@@ -1,0 +1,95 @@
+import { iteratorSSE } from "./chat_stream";
+
+function streamFromIt(it) {
+  return new ReadableStream({
+    async pull(controller) {
+      const { value, done } = await it.next();
+
+      if (done) {
+        controller.close();
+      } else {
+        controller.enqueue(value);
+      }
+    },
+  });
+}
+
+async function* generatorFromList(inpList: Array<string>) {
+  for (const inp of inpList) {
+    yield new TextEncoder().encode(inp);
+  }
+}
+
+describe("iteratorSSE", () => {
+  it("iteratorSSE line-buffering", async () => {
+    const inputs = ["dat", "a: {", '"test": "123"}\n'];
+    const outputs = [{ data: '{"test": "123"}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE line-buffering \\r\\n", async () => {
+    const inputs = ["dat", "a: {", '"test": "123"}\r\n'];
+    const outputs = [{ data: '{"test": "123"}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE line-buffering2", async () => {
+    const inputs = ["test:", "\n"];
+    const outputs = [{ test: "" }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE multiple lines ", async () => {
+    const inputs = ['data: {"test": "123"}\ndata: {"test": "234"}\n'];
+    const outputs = [{ data: '{"test": "123"}' }, { data: '{"test": "234"}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE multiple lines - unfinished line ", async () => {
+    const inputs = ['data: {"test": "123"}\ndata: {"test": "234"}\ndata: {"test": "', '345"}\n'];
+    const outputs = [{ data: '{"test": "123"}' }, { data: '{"test": "234"}' }, { data: '{"test": "345"}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+
+  it("iteratorSSE multiple lines - unfinished line no end", async () => {
+    const inputs = ['data: {"test": "123"}\ndata: {"test": "234"}\ndata: {"test": "', '345"}'];
+    const outputs = [{ data: '{"test": "123"}' }, { data: '{"test": "234"}' }];
+    let idx = 0;
+
+    for await (const res of iteratorSSE(streamFromIt(generatorFromList(inputs)))) {
+      expect(res).toEqual(outputs[idx]);
+      idx += 1;
+    }
+    expect(idx).toBe(outputs.length);
+  });
+});

--- a/website/src/lib/chat_stream.ts
+++ b/website/src/lib/chat_stream.ts
@@ -64,24 +64,20 @@ export async function* iteratorSSE(stream: ReadableStream<Uint8Array>) {
       continue;
     }
     const full_value = unfinished_line + value;
-    const lines = full_value
-    .split(/\r?\n/)
-    .filter(Boolean);
+    const lines = full_value.split(/\r?\n/).filter(Boolean);
     // do line buffering - otherwise leads to parsing errors
-    if (full_value[full_value.length - 1] != '\n'){
+    if (full_value[full_value.length - 1] != "\n") {
       unfinished_line = lines.pop();
-    }
-    else{
+    } else {
       unfinished_line = "";
     }
 
-    const fields = 
-      lines.map((line) => {
-        const colonIdx = line.indexOf(":");
-        return [line.slice(0, colonIdx), line.slice(colonIdx + 1).trimStart()];
-      });
+    const fields = lines.map((line) => {
+      const colonIdx = line.indexOf(":");
+      return [line.slice(0, colonIdx), line.slice(colonIdx + 1).trimStart()];
+    });
     // yield multiple messages distinctly
-    for (const fidx in fields){
+    for (const fidx in fields) {
       yield Object.fromEntries([fields[fidx]]);
     }
   }

--- a/website/src/lib/chat_stream.ts
+++ b/website/src/lib/chat_stream.ts
@@ -54,6 +54,7 @@ export async function* iteratorSSE(stream: ReadableStream<Uint8Array>) {
 
   let done = false,
     value: string | undefined = "";
+  let unfinished_line = "";
   while (!done) {
     ({ value, done } = await reader.read());
     if (done) {
@@ -62,15 +63,26 @@ export async function* iteratorSSE(stream: ReadableStream<Uint8Array>) {
     if (!value) {
       continue;
     }
+    const full_value = unfinished_line + value;
+    const lines = full_value
+    .split(/\r?\n/)
+    .filter(Boolean);
+    // do line buffering - otherwise leads to parsing errors
+    if (full_value[full_value.length - 1] != '\n'){
+      unfinished_line = lines.pop();
+    }
+    else{
+      unfinished_line = "";
+    }
 
-    const fields = value
-      .split(/\r?\n/)
-      .filter(Boolean)
-      .map((line) => {
+    const fields = 
+      lines.map((line) => {
         const colonIdx = line.indexOf(":");
         return [line.slice(0, colonIdx), line.slice(colonIdx + 1).trimStart()];
       });
-
-    yield Object.fromEntries(fields);
+    // yield multiple messages distinctly
+    for (const fidx in fields){
+      yield Object.fromEntries([fields[fidx]]);
+    }
   }
 }

--- a/website/src/lib/chat_stream.ts
+++ b/website/src/lib/chat_stream.ts
@@ -66,19 +66,18 @@ export async function* iteratorSSE(stream: ReadableStream<Uint8Array>) {
     const full_value = unfinished_line + value;
     const lines = full_value.split(/\r?\n/).filter(Boolean);
     // do line buffering - otherwise leads to parsing errors
-    if (full_value[full_value.length - 1] != "\n") {
+    if (full_value[full_value.length - 1] !== "\n") {
       unfinished_line = lines.pop();
     } else {
       unfinished_line = "";
     }
-
     const fields = lines.map((line) => {
       const colonIdx = line.indexOf(":");
       return [line.slice(0, colonIdx), line.slice(colonIdx + 1).trimStart()];
     });
     // yield multiple messages distinctly
-    for (const fidx in fields) {
-      yield Object.fromEntries([fields[fidx]]);
+    for (const field of fields) {
+      yield Object.fromEntries([field]);
     }
   }
 }


### PR DESCRIPTION
I found two bugs in chat_stream.ts, one is the possibility of incomplete lines, so the `iteratorSSE` has to buffer those. The second is the main cause for issue #2354, the Object.fromEntries dictionary creator iteratively overwrites 'data' keys, so the yield has to be wrapped in a loop for yielding all lines.

This PR should resolve issue #2354    