### PR TITLE
Avoid chat flash render

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -61,7 +61,8 @@
         "storybook-addon-next-router": "^4.0.2",
         "swr": "2.0.3",
         "tailwindcss": "^3.2.7",
-        "use-debounce": "^9.0.3"
+        "use-debounce": "^9.0.3",
+        "usehooks-ts": "^2.9.1"
       },
       "devDependencies": {
         "@babel/core": "^7.21.3",
@@ -38954,6 +38955,19 @@
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/usehooks-ts": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/usehooks-ts/-/usehooks-ts-2.9.1.tgz",
+      "integrity": "sha512-2FAuSIGHlY+apM9FVlj8/oNhd+1y+Uwv5QNkMQz1oSfdHk4PXo1qoCw9I5M7j0vpH8CSWFJwXbVPeYDjLCx9PA==",
+      "engines": {
+        "node": ">=16.15.0",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0  || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0  || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/website/package.json
+++ b/website/package.json
@@ -79,7 +79,8 @@
     "storybook-addon-next-router": "^4.0.2",
     "swr": "2.0.3",
     "tailwindcss": "^3.2.7",
-    "use-debounce": "^9.0.3"
+    "use-debounce": "^9.0.3",
+    "usehooks-ts": "^2.9.1"
   },
   "devDependencies": {
     "@babel/core": "^7.21.3",

--- a/website/src/components/Chat/ChatConfigSaver.tsx
+++ b/website/src/components/Chat/ChatConfigSaver.tsx
@@ -1,0 +1,18 @@
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+import { useCacheConfig } from "src/hooks/chat/useCacheConfig";
+import { ChatConfigForm } from "src/types/Chat";
+
+export const ChatConfigSaver = () => {
+  const { watch } = useFormContext<ChatConfigForm>();
+  const newValues = watch();
+  const [oldValues, setConfig] = useCacheConfig();
+  useEffect(() => {
+    // have to compare otherwise it will cause maximum update depth exceeded
+    if (JSON.stringify(oldValues) !== JSON.stringify(newValues)) {
+      setConfig(newValues);
+    }
+  }, [setConfig, newValues, oldValues]);
+
+  return null;
+};

--- a/website/src/components/Chat/ChatConfigSummary.tsx
+++ b/website/src/components/Chat/ChatConfigSummary.tsx
@@ -1,28 +1,24 @@
 import { Grid, Text } from "@chakra-ui/react";
 import { useTranslation } from "next-i18next";
 import React from "react";
-import { useFormContext } from "react-hook-form";
-import { ChatConfigForm } from "src/types/Chat";
+import { useCacheConfig } from "src/hooks/chat/useCacheConfig";
 
-export const ChatConfigSummary = () => {
-  const { watch } = useFormContext<ChatConfigForm>();
+export default function ChatConfigSummary() {
+  const [config] = useCacheConfig();
   const { t } = useTranslation("chat");
-
-  const values = watch();
-  const { model_config_name } = values;
 
   return (
     <Grid gridTemplateColumns="repeat(2, max-content)" columnGap={4} fontSize="sm">
       <Text>{t("model")}</Text>
-      <Text>{model_config_name}</Text>
-      {Object.keys(values)
-        .filter((key) => key !== "model_config_name" && values[key] !== null)
-        .map((key) => (
+      <Text>{config["model_config_name"]}</Text>
+      {Object.entries(config)
+        .filter(([key, value]) => key !== "model_config_name" && value !== null)
+        .map(([key, value]) => (
           <React.Fragment key={key}>
             <Text>{t(key as any)}</Text>
-            <Text>{values[key]}</Text>
+            <Text>{value}</Text>
           </React.Fragment>
         ))}
     </Grid>
   );
-};
+}

--- a/website/src/components/Chat/ChatContext.tsx
+++ b/website/src/components/Chat/ChatContext.tsx
@@ -1,16 +1,17 @@
 import { createContext, PropsWithChildren, useContext, useMemo } from "react";
-import { ModelInfo } from "src/types/Chat";
+import { InferenceMessage, ModelInfo } from "src/types/Chat";
 
 export type ChatContext = {
   modelInfos: ModelInfo[];
+  messages: InferenceMessage[];
 };
 
 const chatContext = createContext<ChatContext>({} as ChatContext);
 
 export const useChatContext = () => useContext(chatContext);
 
-export const ChatContextProvider = ({ children, modelInfos }: PropsWithChildren<ChatContext>) => {
-  const value = useMemo(() => ({ modelInfos }), [modelInfos]);
+export const ChatContextProvider = ({ children, modelInfos, messages }: PropsWithChildren<ChatContext>) => {
+  const value = useMemo(() => ({ modelInfos, messages }), [messages, modelInfos]);
 
   return <chatContext.Provider value={value}>{children}</chatContext.Provider>;
 };

--- a/website/src/components/Chat/ChatConversation.tsx
+++ b/website/src/components/Chat/ChatConversation.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { Button, CircularProgress, Flex, Icon, Text, useBoolean, useColorModeValue } from "@chakra-ui/react";
-import { XCircle } from "lucide-react";
+import { Flex, useBoolean } from "@chakra-ui/react";
 import router from "next/router";
-import { useSession } from "next-auth/react";
-import { useTranslation } from "next-i18next";
-import { memo, ReactNode, useCallback, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useMemo, useRef, useState } from "react";
 import { useFormContext } from "react-hook-form";
 import { useMessageVote } from "src/hooks/chat/useMessageVote";
 import { get, post } from "src/lib/api";
@@ -17,21 +14,19 @@ import {
   InferencePostAssistantMessageParams,
   InferencePostPrompterMessageParams,
 } from "src/types/Chat";
-import useSWR, { mutate } from "swr";
+import { mutate } from "swr";
 
-import { BaseMessageEntry } from "../Messages/BaseMessageEntry";
-import { MessageEmojiButton } from "../Messages/MessageEmojiButton";
-import { MessageInlineEmojiRow } from "../Messages/MessageInlineEmojiRow";
+import { useChatContext } from "./ChatContext";
 import { ChatForm } from "./ChatForm";
-import { WorkParametersDisplay } from "./WorkParameters";
+import { ChatMessageEntry, ChatMessageEntryProps, PendingMessageEntry } from "./ChatMessageEntry";
 
 interface ChatConversationProps {
   chatId: string | null; // will be null when render on chat list page (/chat)
 }
 
-export const ChatConversation = ({ chatId: chatIdProps }: ChatConversationProps) => {
+export const ChatConversation = memo(function ChatConversation({ chatId: chatIdProps }: ChatConversationProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const [messages, setMessages] = useState<InferenceMessage[]>([]);
+  const [messages, setMessages] = useState<InferenceMessage[]>(useChatContext().messages);
 
   const [streamedResponse, setResponse] = useState<string | null>(null);
   const [queueInfo, setQueueInfo] = useState<QueueInfo | null>(null);
@@ -58,9 +53,6 @@ export const ChatConversation = ({ chatId: chatIdProps }: ChatConversationProps)
     return threadMessages;
   }, [messages]);
 
-  useSWR<ChatItem>(chatIdProps === null ? null : API_ROUTES.GET_CHAT(chatIdProps), get, {
-    onSuccess: (chat) => setMessages(chat.messages.sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at))),
-  });
   const { getValues: getFormValues } = useFormContext<ChatConfigForm>();
 
   const initiate_assistant_message = useCallback(
@@ -137,7 +129,7 @@ export const ChatConversation = ({ chatId: chatIdProps }: ChatConversationProps)
     setMessages((messages) => [...messages, prompter_message]);
 
     await initiate_assistant_message(prompter_message.id, currentChatId);
-    await router.push(ROUTES.CHAT(currentChatId));
+    router.push(ROUTES.CHAT(currentChatId));
   }, [setIsSending, chatIdProps, currentThread, initiate_assistant_message]);
 
   const sendVote = useMessageVote();
@@ -178,19 +170,11 @@ export const ChatConversation = ({ chatId: chatIdProps }: ChatConversationProps)
       currentThread.map((message) => (
         <ChatMessageEntry
           key={message.id}
-          isAssistant={message.role === "assistant"}
-          messageId={message.id}
-          parentId={message.parent_id}
-          chatId={message.chat_id}
-          score={message.score}
-          state={message.state}
+          message={message}
           onVote={handleOnVote}
           onRetry={handleOnRetry}
           isSending={isSending}
-          workParameters={message.work_parameters}
-        >
-          {message.content}
-        </ChatMessageEntry>
+        ></ChatMessageEntry>
       )),
     [handleOnVote, currentThread, handleOnRetry, isSending]
   );
@@ -203,139 +187,4 @@ export const ChatConversation = ({ chatId: chatIdProps }: ChatConversationProps)
       <ChatForm ref={inputRef} isSending={isSending} onSubmit={send} queueInfo={queueInfo}></ChatForm>
     </Flex>
   );
-};
-
-type ChatMessageEntryProps = {
-  isAssistant: boolean;
-  children: InferenceMessage["content"];
-  state: InferenceMessage["state"];
-  chatId: string;
-  messageId: string;
-  parentId: InferenceMessage["parent_id"];
-  workParameters?: InferenceMessage["work_parameters"];
-  score: number;
-  onVote: (data: { newScore: number; oldScore: number; chatId: string; messageId: string }) => void;
-  onRetry?: (messageId: string, chatId: string) => void;
-  isSending?: boolean;
-};
-
-const getNewScore = (emoji: "+1" | "-1", currentScore: number) => {
-  if (emoji === "+1") {
-    if (currentScore === 1) {
-      return 0;
-    }
-    return 1;
-  }
-  // emoji is -1
-  if (currentScore === -1) {
-    return 0;
-  }
-  return -1;
-};
-
-const ChatMessageEntry = memo(function ChatMessageEntry({
-  children,
-  isAssistant,
-  chatId,
-  messageId,
-  parentId,
-  score,
-  state,
-  onVote,
-  onRetry,
-  isSending,
-  workParameters,
-}: ChatMessageEntryProps) {
-  const { t } = useTranslation("common");
-  const handleVote = useCallback(
-    (emoji: "+1" | "-1") => {
-      const newScore = getNewScore(emoji, score);
-      onVote({ newScore, chatId, messageId, oldScore: score });
-    },
-    [chatId, messageId, onVote, score]
-  );
-
-  const handleThumbsUp = useCallback(() => {
-    handleVote("+1");
-  }, [handleVote]);
-
-  const handleThumbsDown = useCallback(() => {
-    handleVote("-1");
-  }, [handleVote]);
-
-  const handleRetry = useCallback(() => {
-    if (onRetry && parentId) {
-      onRetry(parentId, chatId);
-    }
-  }, [chatId, onRetry, parentId]);
-
-  return (
-    <PendingMessageEntry isAssistant={isAssistant} content={children!}>
-      {isAssistant && (
-        <MessageInlineEmojiRow>
-          {(state === "pending" || state === "in_progress") && (
-            <CircularProgress isIndeterminate size="20px" title={state} />
-          )}
-          {(state === "aborted_by_worker" || state === "cancelled" || state === "timeout") && (
-            <>
-              <Icon as={XCircle} color="red" />
-              <Text color="red">{`Error: ${state}`}</Text>
-              {onRetry && !isSending && <Button onClick={handleRetry}>{t("retry")}</Button>}
-            </>
-          )}
-          {state === "complete" && (
-            <>
-              <MessageEmojiButton
-                emoji={{ name: "+1", count: 0 }}
-                checked={score === 1}
-                userReacted={false}
-                userIsAuthor={false}
-                forceHideCount
-                onClick={handleThumbsUp}
-              />
-              <MessageEmojiButton
-                emoji={{ name: "-1", count: 0 }}
-                checked={score === -1}
-                userReacted={false}
-                userIsAuthor={false}
-                forceHideCount
-                onClick={handleThumbsDown}
-              />
-              {workParameters && <WorkParametersDisplay parameters={workParameters} />}
-            </>
-          )}
-        </MessageInlineEmojiRow>
-      )}
-    </PendingMessageEntry>
-  );
 });
-
-type PendingMessageEntryProps = {
-  isAssistant: boolean;
-  content: string;
-  children?: ReactNode;
-};
-
-const PendingMessageEntry = ({ content, isAssistant, children }: PendingMessageEntryProps) => {
-  const bgUser = useColorModeValue("white", "gray.700");
-  const bgAssistant = useColorModeValue("#DFE8F1", "#42536B");
-  const { data: session } = useSession();
-  const image = session?.user?.image;
-
-  const avatarProps = useMemo(
-    () => ({ src: isAssistant ? `/images/logos/logo.png` : image ?? "/images/temp-avatars/av1.jpg" }),
-    [isAssistant, image]
-  );
-
-  return (
-    <BaseMessageEntry
-      avatarProps={avatarProps}
-      bg={isAssistant ? bgAssistant : bgUser}
-      content={content || ""}
-      width="full"
-      maxWidth="full"
-    >
-      {children}
-    </BaseMessageEntry>
-  );
-};

--- a/website/src/components/Chat/ChatForm.tsx
+++ b/website/src/components/Chat/ChatForm.tsx
@@ -43,6 +43,7 @@ export const ChatForm = forwardRef<HTMLTextAreaElement, ChatFormProps>((props, r
           type="submit"
           onClick={handleSubmit}
           isLoading={isSending}
+          overflow="hidden"
           spinner={queueInfo ? <QueueInfoMessage info={queueInfo} /> : undefined}
           size="lg"
           borderRadius="xl"

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -1,0 +1,133 @@
+import { Button, CircularProgress, Icon, Text, useColorModeValue } from "@chakra-ui/react";
+import { XCircle } from "lucide-react";
+import { useSession } from "next-auth/react";
+import { useTranslation } from "next-i18next";
+import { memo, ReactNode, useCallback, useMemo } from "react";
+import { InferenceMessage } from "src/types/Chat";
+
+import { BaseMessageEntry } from "../Messages/BaseMessageEntry";
+import { MessageEmojiButton } from "../Messages/MessageEmojiButton";
+import { MessageInlineEmojiRow } from "../Messages/MessageInlineEmojiRow";
+import { WorkParametersDisplay } from "./WorkParameters";
+
+export type ChatMessageEntryProps = {
+  message: InferenceMessage;
+  onVote: (data: { newScore: number; oldScore: number; chatId: string; messageId: string }) => void;
+  onRetry?: (messageId: string, chatId: string) => void;
+  isSending?: boolean;
+};
+
+export const ChatMessageEntry = memo(function ChatMessageEntry({
+  onVote,
+  onRetry,
+  isSending,
+  message,
+}: ChatMessageEntryProps) {
+  const { t } = useTranslation("common");
+  const { chat_id: chatId, parent_id: parentId, id: messageId, content, score, state, work_parameters } = message;
+  const handleVote = useCallback(
+    (emoji: "+1" | "-1") => {
+      const newScore = getNewScore(emoji, score);
+      onVote({ newScore, chatId, messageId, oldScore: score });
+    },
+    [chatId, messageId, onVote, score]
+  );
+
+  const handleThumbsUp = useCallback(() => {
+    handleVote("+1");
+  }, [handleVote]);
+
+  const handleThumbsDown = useCallback(() => {
+    handleVote("-1");
+  }, [handleVote]);
+
+  const handleRetry = useCallback(() => {
+    if (onRetry && parentId) {
+      onRetry(parentId, chatId);
+    }
+  }, [chatId, onRetry, parentId]);
+  const isAssistant = message.role === "assistant";
+  return (
+    <PendingMessageEntry isAssistant={isAssistant} content={content!}>
+      {isAssistant && (
+        <MessageInlineEmojiRow>
+          {(state === "pending" || state === "in_progress") && (
+            <CircularProgress isIndeterminate size="20px" title={state} />
+          )}
+          {(state === "aborted_by_worker" || state === "cancelled" || state === "timeout") && (
+            <>
+              <Icon as={XCircle} color="red" />
+              <Text color="red">{`Error: ${state}`}</Text>
+              {onRetry && !isSending && <Button onClick={handleRetry}>{t("retry")}</Button>}
+            </>
+          )}
+          {state === "complete" && (
+            <>
+              <MessageEmojiButton
+                emoji={{ name: "+1", count: 0 }}
+                checked={score === 1}
+                userReacted={false}
+                userIsAuthor={false}
+                forceHideCount
+                onClick={handleThumbsUp}
+              />
+              <MessageEmojiButton
+                emoji={{ name: "-1", count: 0 }}
+                checked={score === -1}
+                userReacted={false}
+                userIsAuthor={false}
+                forceHideCount
+                onClick={handleThumbsDown}
+              />
+            </>
+          )}
+        </MessageInlineEmojiRow>
+      )}
+      {work_parameters && <WorkParametersDisplay parameters={work_parameters} />}
+    </PendingMessageEntry>
+  );
+});
+
+type PendingMessageEntryProps = {
+  isAssistant: boolean;
+  content: string;
+  children?: ReactNode;
+};
+
+export const PendingMessageEntry = ({ content, isAssistant, children }: PendingMessageEntryProps) => {
+  const bgUser = useColorModeValue("white", "gray.700");
+  const bgAssistant = useColorModeValue("#DFE8F1", "#42536B");
+  const { data: session } = useSession();
+  const image = session?.user?.image;
+
+  const avatarProps = useMemo(
+    () => ({ src: isAssistant ? `/images/logos/logo.png` : image ?? "/images/temp-avatars/av1.jpg" }),
+    [isAssistant, image]
+  );
+
+  return (
+    <BaseMessageEntry
+      avatarProps={avatarProps}
+      bg={isAssistant ? bgAssistant : bgUser}
+      content={content || ""}
+      width="full"
+      maxWidth="full"
+    >
+      {children}
+    </BaseMessageEntry>
+  );
+};
+
+const getNewScore = (emoji: "+1" | "-1", currentScore: number) => {
+  if (emoji === "+1") {
+    if (currentScore === 1) {
+      return 0;
+    }
+    return 1;
+  }
+  // emoji is -1
+  if (currentScore === -1) {
+    return 0;
+  }
+  return -1;
+};

--- a/website/src/components/Chat/ChatSection.tsx
+++ b/website/src/components/Chat/ChatSection.tsx
@@ -1,37 +1,37 @@
 import { Card, CardBody, Divider } from "@chakra-ui/react";
+import dynamic from "next/dynamic";
 import { FormProvider, useForm } from "react-hook-form";
+import { useCacheConfig } from "src/hooks/chat/useCacheConfig";
 import { ChatConfigForm } from "src/types/Chat";
 
-import { ChatConfigSummary } from "./ChatConfigSummary";
+import { ChatConfigSaver } from "./ChatConfigSaver";
 import { useChatContext } from "./ChatContext";
 import { ChatConversation } from "./ChatConversation";
 import { InferencePoweredBy } from "./InferencePoweredBy";
+
+const ChatConfigSummary = dynamic(() => import("./ChatConfigSummary"), { ssr: false });
 
 export const ChatSection = ({ chatId }: { chatId: string | null }) => {
   const { modelInfos } = useChatContext();
 
   console.assert(modelInfos.length > 0, "No model config was found");
-  const form = useForm<ChatConfigForm>({
-    //NOTE: we should at some point validate the cache, in case models were added or deleted
-    // or certain parameters disabled
-    defaultValues: {
-      ...modelInfos[0].parameter_configs[0].sampling_parameters,
-      model_config_name: modelInfos[0].name,
-    },
-  });
+  const [config] = useCacheConfig();
 
-  // useCacheChatForm(form);
+  const form = useForm<ChatConfigForm>({
+    defaultValues: config,
+  });
 
   return (
     <FormProvider {...form}>
       <Card className="max-w-5xl mx-auto">
         <CardBody display="flex" flexDirection="column" gap="2">
-          <ChatConversation chatId={chatId} />
+          <ChatConversation chatId={chatId} key={chatId} />
           <ChatConfigSummary />
           <Divider />
           <InferencePoweredBy />
         </CardBody>
       </Card>
+      <ChatConfigSaver />
     </FormProvider>
   );
 };

--- a/website/src/components/Chat/WorkParameters.tsx
+++ b/website/src/components/Chat/WorkParameters.tsx
@@ -1,22 +1,88 @@
-import { Accordion, AccordionButton, AccordionItem, AccordionPanel, IconButton } from "@chakra-ui/react";
-import { Sliders } from "lucide-react";
+import { Accordion, AccordionButton, AccordionItem, AccordionPanel, Divider, Flex, Text } from "@chakra-ui/react";
+import { ChevronDown } from "lucide-react";
+import { useTranslation } from "next-i18next";
 import { memo } from "react";
 import { JsonCard } from "src/components/JsonCard";
-import { InferenceMessage } from "src/types/Chat";
+import { InferenceMessage, SamplingParameters } from "src/types/Chat";
+
+import { useChatContext } from "./ChatContext";
+
+export const areParametersEqual = (a: SamplingParameters, b: SamplingParameters) => {
+  return (
+    a.top_k === b.top_k &&
+    a.top_p === b.top_p &&
+    a.typical_p === b.typical_p &&
+    a.temperature === b.temperature &&
+    a.repetition_penalty === b.repetition_penalty &&
+    a.max_new_tokens === b.max_new_tokens
+  );
+};
 
 export const WorkParametersDisplay = memo(function WorkParametersDisplay({
   parameters,
 }: {
-  parameters: InferenceMessage["work_parameters"];
+  parameters: NonNullable<InferenceMessage["work_parameters"]>;
 }) {
+  const { seed: _, ...rest } = parameters;
+  const model_id = parameters.model_config.model_id;
+  const { t } = useTranslation("chat");
+  const { modelInfos } = useChatContext();
+  const modelInfo = modelInfos.find((modelInfo) => modelInfo.name === model_id);
+  const presetName =
+    modelInfo?.parameter_configs.find((preset) =>
+      areParametersEqual(preset.sampling_parameters, parameters.sampling_parameters)
+    )?.name ?? t("preset_custom");
+
   return (
-    <Accordion allowToggle>
-      <AccordionItem border="none">
-        <AccordionButton as={IconButton} icon={<Sliders />} bg="inherit" />
-        <AccordionPanel>
-          <JsonCard>{parameters}</JsonCard>
-        </AccordionPanel>
-      </AccordionItem>
-    </Accordion>
+    <>
+      <Divider
+        my="0.5"
+        borderColor="blackAlpha.300"
+        _dark={{
+          borderColor: "blackAlpha.700",
+        }}
+      />
+      <Accordion allowToggle>
+        <AccordionItem border="none">
+          <Flex
+            justifyContent="space-between"
+            alignItems="end"
+            textColor="gray.600"
+            _dark={{
+              textColor: "gray.400",
+            }}
+          >
+            <Flex gap="4" flexGrow="1" fontSize="sm" w="full">
+              <span>
+                {t("model")}:{" "}
+                <Text as="span" fontWeight="medium">
+                  {model_id}
+                </Text>
+              </span>
+              <span>
+                {t("preset")}:{" "}
+                <Text as="span" fontWeight="medium">
+                  {presetName}
+                </Text>
+              </span>
+            </Flex>
+            <AccordionButton
+              as={ChevronDown}
+              borderRadius="md"
+              w="auto"
+              p="0.5"
+              size="24px"
+              bg="inherit"
+              flexGrow={0}
+            />
+          </Flex>
+          <AccordionPanel>
+            <JsonCard fontSize="sm" bodyProps={{ p: 3 }}>
+              {rest}
+            </JsonCard>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </>
   );
 });

--- a/website/src/components/JsonCard.tsx
+++ b/website/src/components/JsonCard.tsx
@@ -1,10 +1,17 @@
 import { Card, CardBody } from "@chakra-ui/card";
+import { CardBodyProps, CardProps } from "@chakra-ui/react";
+import { StrictOmit } from "ts-essentials";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const JsonCard = ({ children }: { children: any }) => {
+type JsonCardProps = StrictOmit<CardProps, "children"> & {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  children: any;
+  bodyProps?: CardBodyProps;
+};
+
+export const JsonCard = ({ children, bodyProps, ...props }: JsonCardProps) => {
   return (
-    <Card variant="json">
-      <CardBody overflowX="auto">
+    <Card variant="json" {...props}>
+      <CardBody overflowX="auto" {...bodyProps}>
         <pre>{JSON.stringify(children, null, 2)}</pre>
       </CardBody>
     </Card>

--- a/website/src/components/Messages/BaseMessageEntry.tsx
+++ b/website/src/components/Messages/BaseMessageEntry.tsx
@@ -1,53 +1,67 @@
-import { Avatar, AvatarProps, Box, BoxProps, HStack, useBreakpointValue, useColorModeValue } from "@chakra-ui/react";
-import { forwardRef, lazy, Suspense, useMemo } from "react";
+import { Avatar, AvatarProps, Box, BoxProps, Flex, useColorModeValue } from "@chakra-ui/react";
+import { forwardRef, lazy, Suspense } from "react";
+import { colors } from "src/styles/Theme/colors";
+import { StrictOmit } from "ts-essentials";
 
 const RenderedMarkdown = lazy(() => import("./RenderedMarkdown"));
 
-export type BaseMessageEntryProps = BoxProps & {
+export type BaseMessageEntryProps = StrictOmit<BoxProps, "bg" | "backgroundColor"> & {
   content: string;
   avatarProps: Pick<AvatarProps, "name" | "src">;
-  containerProps?: BoxProps;
+  bg?: string;
+  highlight?: boolean;
 };
 
-// eslint-disable-next-line react/display-name
-export const BaseMessageEntry = forwardRef<HTMLDivElement, BaseMessageEntryProps>(
-  ({ content, avatarProps, children, ...props }, ref) => {
-    const inlineAvatar = useBreakpointValue({ base: true, md: false });
-    const borderColor = useColorModeValue("blackAlpha.200", "whiteAlpha.200");
-    const bg = useColorModeValue("#DFE8F1", "#42536B");
+export const BaseMessageEntry = forwardRef<HTMLDivElement, BaseMessageEntryProps>(function BaseMessageEntry(
+  { content, avatarProps, children, highlight, ...props },
+  ref
+) {
+  const bg = useColorModeValue("#DFE8F1", "#42536B");
+  const actualBg = props.bg ?? bg;
 
-    const avatar = useMemo(
-      () => (
-        <Avatar
-          borderColor={borderColor}
-          size={inlineAvatar ? "xs" : "sm"}
-          mr={inlineAvatar ? 2 : 0}
-          mt={inlineAvatar ? 0 : `6px`}
-          mb={inlineAvatar ? 1.5 : 0}
-          {...avatarProps}
-        />
-      ),
-      [avatarProps, borderColor, inlineAvatar]
-    );
-    return (
-      <HStack ref={ref} gap={0.5} alignItems="start" maxW="full" position="relative">
-        {!inlineAvatar && avatar}
-        <Box
-          width={["full", "full", "full", "fit-content"]}
-          maxWidth={["full", "full", "full", "2xl"]}
-          p={[3, 4]}
-          borderRadius="18px"
-          bg={bg}
-          overflowX="auto"
-          {...props}
-        >
-          {inlineAvatar && avatar}
-          <Suspense fallback={content}>
-            <RenderedMarkdown markdown={content}></RenderedMarkdown>
-          </Suspense>
-          {children}
-        </Box>
-      </HStack>
-    );
-  }
-);
+  return (
+    <Flex
+      ref={ref}
+      gap={0.5}
+      flexDirection={{ base: "column", md: "row" }}
+      alignItems="start"
+      maxWidth="full"
+      position="relative"
+      p={{ base: 3, md: 0 }}
+      borderRadius={{ base: "18px", md: 0 }}
+      bg={{ base: actualBg, md: "transparent" }}
+      outline={highlight ? { base: `2px solid black`, md: "0px" } : undefined}
+      outlineColor={colors.light.active}
+      _dark={{ outlineColor: colors.dark.active }}
+    >
+      <Avatar
+        borderColor="blackAlpha.200"
+        _dark={{
+          borderColor: "whiteAlpha.200",
+        }}
+        size={{ base: "xs", md: "sm" }}
+        mr={{ base: 0, md: 2 }}
+        mt={{ base: 0, md: `6px` }}
+        mb={{ base: 1.5, md: 0 }}
+        {...avatarProps}
+      />
+      <Box
+        width={["full", "full", "full", "fit-content"]}
+        maxWidth={["full", "full", "full", "2xl"]}
+        p={{ base: 0, md: 4 }}
+        borderRadius={{ base: 0, md: "18px" }}
+        bg={bg}
+        overflowX="auto"
+        outline={highlight ? { base: "0px", md: `2px solid black` } : undefined}
+        outlineColor={{ md: colors.light.active }}
+        {...props}
+        _dark={{ outlineColor: { md: colors.dark.active }, ...props._dark }}
+      >
+        <Suspense fallback={content}>
+          <RenderedMarkdown markdown={content}></RenderedMarkdown>
+        </Suspense>
+        {children}
+      </Box>
+    </Flex>
+  );
+});

--- a/website/src/components/Messages/MessageTableEntry.tsx
+++ b/website/src/components/Messages/MessageTableEntry.tsx
@@ -77,8 +77,6 @@ export const MessageTableEntry = forwardRef<HTMLDivElement, MessageTableEntryPro
     const { isOpen: reportPopupOpen, onOpen: showReportPopup, onClose: closeReportPopup } = useDisclosure();
     const { isOpen: labelPopupOpen, onOpen: showLabelPopup, onClose: closeLabelPopup } = useDisclosure();
 
-    const highlightColor = useColorModeValue(colors.light.active, colors.dark.active);
-
     const { trigger: sendEmojiChange } = useSWRMutation(`/api/messages/${message.id}/emoji`, post, {
       onSuccess: (data) => {
         data.emojis["+1"] = data.emojis["+1"] || 0;
@@ -107,11 +105,10 @@ export const MessageTableEntry = forwardRef<HTMLDivElement, MessageTableEntryPro
           name: `${boolean(message.is_assistant) ? "Assistant" : "User"}`,
           src: `${boolean(message.is_assistant) ? "/images/logos/logo.png" : "/images/temp-avatars/av1.jpg"}`,
         }}
-        outline={highlight ? "2px solid black" : undefined}
-        outlineColor={highlightColor}
         cursor={enabled ? "pointer" : undefined}
         overflowX="auto"
         onClick={handleOnClick}
+        highlight={highlight}
       >
         <Flex justifyContent="space-between" mt="2" alignItems="center">
           {showCreatedDate ? (

--- a/website/src/hooks/chat/useCacheConfig.ts
+++ b/website/src/hooks/chat/useCacheConfig.ts
@@ -1,25 +1,14 @@
-import { useEffect } from "react";
-import { UseFormReturn } from "react-hook-form";
-import { ChatConfigForm } from "src/types/Chat";
+import { useChatContext } from "src/components/Chat/ChatContext";
+import { useLocalStorage } from "usehooks-ts";
 
 const CHAT_CONFIG_KEY = "CHAT_CONFIG";
 
-export const getCachedChatForm = (): ChatConfigForm | null => {
-  if (typeof localStorage !== "undefined") {
-    const oldConfig = localStorage.getItem(CHAT_CONFIG_KEY);
-    if (oldConfig) {
-      return JSON.parse(oldConfig);
-    }
-  }
-  return null;
-};
-
-export const useCacheChatForm = (form: UseFormReturn<ChatConfigForm>) => {
-  const config = form.watch();
-
-  useEffect(() => {
-    if (typeof localStorage !== "undefined") {
-      localStorage.setItem(CHAT_CONFIG_KEY, JSON.stringify(config));
-    }
-  }, [config]);
+export const useCacheConfig = () => {
+  const { modelInfos } = useChatContext();
+  //NOTE: we should at some point validate the cache, in case models were added or deleted
+  // or certain parameters disabled
+  return useLocalStorage(CHAT_CONFIG_KEY, {
+    ...modelInfos[0].parameter_configs[0].sampling_parameters,
+    model_config_name: modelInfos[0].name,
+  });
 };

--- a/website/src/pages/chat/index.tsx
+++ b/website/src/pages/chat/index.tsx
@@ -23,7 +23,7 @@ const ChatList = ({ modelInfos }: InferGetServerSidePropsType<typeof getServerSi
       <Head>
         <title>{t("chat")}</title>
       </Head>
-      <ChatContextProvider modelInfos={modelInfos}>
+      <ChatContextProvider modelInfos={modelInfos} messages={[]}>
         <ChatSection chatId={null} />
       </ChatContextProvider>
     </>


### PR DESCRIPTION
 - Fix flash when rendering chat conversation. The logic when render avatar in MessageTableEntry now rely on CSS instead of JS.
 - Fix `ChatConfigSummary` cause hydration error. Sorry about this unrelated change, I though it was an easy fix so I include in this PR but turn out it's quite complex
 - fix #2385
 New UI of ChatMessageEntry
 
![image](https://user-images.githubusercontent.com/33456881/231311613-ddbd1634-b66d-4bd8-b417-73d4620cc088.png)
