### PR TITLE
Safety level control

### DIFF
--- a/inference/worker/settings.py
+++ b/inference/worker/settings.py
@@ -25,7 +25,6 @@ class Settings(pydantic.BaseSettings):
     basic_auth_password: str | None = None
 
     enable_safety: bool = False
-    safety_level: int = 1
 
 
 settings = Settings()

--- a/inference/worker/settings.py
+++ b/inference/worker/settings.py
@@ -25,6 +25,7 @@ class Settings(pydantic.BaseSettings):
     basic_auth_password: str | None = None
 
     enable_safety: bool = False
+    safety_level: int = 1
 
 
 settings = Settings()

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -115,7 +115,7 @@ def handle_work_request(
     if settings.enable_safety and work_request.safety_parameters.level:
         safety_request = inference.SafetyRequest(inputs=prompt, parameters=work_request.safety_parameters)
         safety_response = get_safety_server_response(safety_request)
-        prompt = get_safety_opinion(prompt, safety_response.outputs, settings.safety_level)
+        prompt = get_safety_opinion(prompt, safety_response.outputs, work_request.safety_parameters.level)
         logger.debug(f"Safe prompt: {prompt}")
 
     stream_response = None

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -80,16 +80,25 @@ def make_prompt_and_parameters(
     return prompt, parameters
 
 
-def prepare_safe_prompt(prompt: str, safety_opinion: str):
+def prepare_safe_prompt(prompt:str, label:str, rots:str):
+
+    pre_prompt = f"Answer the following request with {label} as responsible chatbot that believes that {rots}: "
+    input_list = prompt.split(V2_PROMPTER_PREFIX)
+    input_list[-1] = pre_prompt + input_list[-1]
+    return V2_PROMPTER_PREFIX.join(input_list)
+
+def get_safety_opinion(prompt: str, safety_opinion: str, safety_level:int):
     safety_opinion = re.sub(r"<pad>|</s>", "", safety_opinion).split("<sep>")
     label, rots = safety_opinion[0], "and".join([x.strip(".") for x in safety_opinion[1:]])
-    if label.strip() == "__casual__":
-        return prompt
+    label = label.replace("<pad>","").strip()
+
+    if "caution" in label and safety_level>1:
+        return prepare_safe_prompt(prompt, label, rots)
+    elif "intervention" in label and safety_level>0:
+        return prepare_safe_prompt(prompt, label, rots)
     else:
-        pre_prompt = f"Answer the following request with {label} as responsible chatbot that believes that {rots}: "
-        input_list = prompt.split(V2_PROMPTER_PREFIX)
-        input_list[-1] = pre_prompt + input_list[-1]
-        return V2_PROMPTER_PREFIX.join(input_list)
+        return prompt
+      
 
 
 def handle_work_request(
@@ -107,7 +116,7 @@ def handle_work_request(
     if settings.enable_safety and work_request.safety_parameters.level:
         safety_request = inference.SafetyRequest(inputs=prompt, parameters=work_request.safety_parameters)
         safety_response = get_safety_server_response(safety_request)
-        prompt = prepare_safe_prompt(prompt, safety_response.outputs)
+        prompt = get_safety_opinion(prompt, safety_response.outputs, settings.safety_level)
         logger.debug(f"Safe prompt: {prompt}")
 
     stream_response = None

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -80,25 +80,24 @@ def make_prompt_and_parameters(
     return prompt, parameters
 
 
-def prepare_safe_prompt(prompt:str, label:str, rots:str):
-
+def prepare_safe_prompt(prompt: str, label: str, rots: str):
     pre_prompt = f"Answer the following request with {label} as responsible chatbot that believes that {rots}: "
     input_list = prompt.split(V2_PROMPTER_PREFIX)
     input_list[-1] = pre_prompt + input_list[-1]
     return V2_PROMPTER_PREFIX.join(input_list)
 
-def get_safety_opinion(prompt: str, safety_opinion: str, safety_level:int):
+
+def get_safety_opinion(prompt: str, safety_opinion: str, safety_level: int):
     safety_opinion = re.sub(r"<pad>|</s>", "", safety_opinion).split("<sep>")
     label, rots = safety_opinion[0], "and".join([x.strip(".") for x in safety_opinion[1:]])
-    label = label.replace("<pad>","").strip()
+    label = label.replace("<pad>", "").strip()
 
-    if "caution" in label and safety_level>1:
+    if "caution" in label and safety_level > 1:
         return prepare_safe_prompt(prompt, label, rots)
-    elif "intervention" in label and safety_level>0:
+    elif "intervention" in label and safety_level > 0:
         return prepare_safe_prompt(prompt, label, rots)
     else:
         return prompt
-      
 
 
 def handle_work_request(


### PR DESCRIPTION
This will enable us to control the safety level. There are two levels for safety Bot now
- safety_level set to `1` means we intervene only in prompts considered highly harmful like CSAM whereas in `2` topics like body shaming, etc will be intervened. 
 
 