### PR TITLE
Added enable inference safety to playbook

### DIFF
--- a/.github/workflows/deploy-to-node.yaml
+++ b/.github/workflows/deploy-to-node.yaml
@@ -98,6 +98,7 @@ jobs:
         ${{ vars.INFERENCE_ASSISTANT_MESSAGE_TIMEOUT }}
       INFERENCE_MESSAGE_QUEUE_EXPIRE: ${{ vars.INFERENCE_MESSAGE_QUEUE_EXPIRE }}
       INFERENCE_WORK_QUEUE_MAX_SIZE: ${{ vars.INFERENCE_WORK_QUEUE_MAX_SIZE }}
+      INFERENCE_ENABLE_SAFETY: ${{ vars.INFERENCE_ENABLE_SAFETY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/ansible/inference/deploy-server.yaml
+++ b/ansible/inference/deploy-server.yaml
@@ -149,5 +149,8 @@
           WORK_QUEUE_MAX_SIZE:
             "{{ lookup('ansible.builtin.env', 'INFERENCE_WORK_QUEUE_MAX_SIZE') |
             default(100, true) }}"
+          ENABLE_SAFETY:
+            "{{ lookup('ansible.builtin.env', 'INFERENCE_ENABLE_SAFETY') |
+            default('False', true) }}"
         ports:
           - "{{ server_port }}:8080"


### PR DESCRIPTION
will not have any effect until refactor of safety to the central server (right now it's in worker)