### PR TITLE
Downgrade `react-simple-icons`

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -15,7 +15,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@emotion/react": "^11.10.6",
         "@emotion/styled": "^11.10.6",
-        "@icons-pack/react-simple-icons": "^7.2.0",
+        "@icons-pack/react-simple-icons": "^5.11.0",
         "@marsidev/react-turnstile": "^0.0.7",
         "@next-auth/prisma-adapter": "^1.0.5",
         "@next/bundle-analyzer": "^13.2.4",
@@ -3768,9 +3768,9 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA=="
     },
     "node_modules/@icons-pack/react-simple-icons": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-7.2.0.tgz",
-      "integrity": "sha512-XmyAiE+cDWDoCQGboie4se79ph2xAj/lQV+YVmLlX0nAFf92lci2ciVxWSN28f4MWZojskRWsu9S9BoH8UCQgg==",
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@icons-pack/react-simple-icons/-/react-simple-icons-5.11.0.tgz",
+      "integrity": "sha512-hFJ4Q4JcYe/wQUab+gIug1BONjBUelaUVFYsZ1FKv5CEX/fP56qGet4CPmx18BqDhxrOehidYNlLyGppXL9/7w==",
       "peerDependencies": {
         "react": "^16.13 || ^17 || ^18"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -33,7 +33,7 @@
     "@dnd-kit/utilities": "^3.2.1",
     "@emotion/react": "^11.10.6",
     "@emotion/styled": "^11.10.6",
-    "@icons-pack/react-simple-icons": "^7.2.0",
+    "@icons-pack/react-simple-icons": "^5.11.0",
     "@marsidev/react-turnstile": "^0.0.7",
     "@next-auth/prisma-adapter": "^1.0.5",
     "@next/bundle-analyzer": "^13.2.4",

--- a/website/src/components/CallToAction.tsx
+++ b/website/src/components/CallToAction.tsx
@@ -1,5 +1,5 @@
 import { Box, Link, Text, useColorMode } from "@chakra-ui/react";
-import { SiDiscord, SiGithub } from "@icons-pack/react-simple-icons";
+import { Discord, Github } from "@icons-pack/react-simple-icons";
 import { Users } from "lucide-react";
 import { useTranslation } from "next-i18next";
 import { useId } from "react";
@@ -73,7 +73,7 @@ export function CallToAction() {
                 type="button"
                 className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >
-                <SiDiscord size={20} />
+                <Discord size={20} />
                 <Text as="span" className="ml-3" fontSize={["sm", "md", "lg"]}>
                   {t("discord")}
                 </Text>
@@ -84,7 +84,7 @@ export function CallToAction() {
                 type="button"
                 className="mb-2 flex items-center rounded-md border border-transparent bg-blue-600 px-4 py-3 text-base font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
               >
-                <SiGithub size={20} />
+                <Github size={20} />
                 <Text as="span" className="ml-3" fontSize={["sm", "md", "lg"]}>
                   {t("github")}
                 </Text>

--- a/website/src/components/TeamMember.tsx
+++ b/website/src/components/TeamMember.tsx
@@ -1,5 +1,5 @@
 import { Avatar, Badge, Box, Flex, Text, useColorModeValue } from "@chakra-ui/react";
-import { SiGithub } from "@icons-pack/react-simple-icons";
+import { Github } from "@icons-pack/react-simple-icons";
 import Link from "next/link";
 
 export interface TeamMemberProps {
@@ -26,7 +26,7 @@ export function TeamMember({ name, url, imageURL, githubURL, title }: TeamMember
           {githubURL && (
             <Link href={githubURL} target="_default" rel="noreferrer" title="github">
               <Badge mb="1">
-                <SiGithub size={12} />
+                <Github size={12} />
               </Badge>
             </Link>
           )}

--- a/website/src/components/UserDisplayNameCell.tsx
+++ b/website/src/components/UserDisplayNameCell.tsx
@@ -1,5 +1,5 @@
 import { Flex, Link, Tooltip } from "@chakra-ui/react";
-import { SiDiscord, SiGoogle } from "@icons-pack/react-simple-icons";
+import { Discord, Google } from "@icons-pack/react-simple-icons";
 import { Mail } from "lucide-react";
 import NextLink from "next/link";
 import { useHasAnyRole } from "src/hooks/auth/useHasAnyRole";
@@ -10,8 +10,8 @@ import { UserAvatar } from "./UserAvatar";
 
 const AUTH_METHOD_TO_ICON: Record<AuthMethod, JSX.Element> = {
   local: <Mail size="20" />,
-  discord: <SiDiscord size="20" />,
-  google: <SiGoogle size="20" />,
+  discord: <Discord size="20" />,
+  google: <Google size="20" />,
 };
 
 export const UserDisplayNameCell = ({

--- a/website/src/pages/auth/signin.tsx
+++ b/website/src/pages/auth/signin.tsx
@@ -9,7 +9,7 @@ import {
   useColorModeValue,
 } from "@chakra-ui/react";
 import { useColorMode } from "@chakra-ui/react";
-import { SiDiscord, SiGoogle } from "@icons-pack/react-simple-icons";
+import { Discord, Google } from "@icons-pack/react-simple-icons";
 import { TurnstileInstance } from "@marsidev/react-turnstile";
 import { boolean } from "boolean";
 import { Bug, Mail } from "lucide-react";
@@ -104,7 +104,7 @@ function Signin({ providers, enableEmailSignin, enableEmailSigninCaptcha, cloudf
               _active={{ bg: "#454FBF" }}
               size="lg"
               color="white"
-              leftIcon={<SiDiscord />}
+              leftIcon={<Discord />}
               onClick={() => signIn(discord.id, { callbackUrl: "/" })}
             >
               Continue with Discord
@@ -117,7 +117,7 @@ function Signin({ providers, enableEmailSignin, enableEmailSigninCaptcha, cloudf
               _active={{ bg: "#454FBF" }}
               size="lg"
               color="white"
-              leftIcon={<SiGoogle />}
+              leftIcon={<Google />}
               onClick={() => signIn(google.id, { callbackUrl: "/" })}
             >
               Continue with Google


### PR DESCRIPTION
The latest version has a tree shaking problem https://github.com/icons-pack/react-simple-icons/issues/140, which caused some of our pages to have 2MB! of javascript:

https://github.com/LAION-AI/Open-Assistant/actions/runs/4706456312/jobs/8347722304#step:8:449

The problem does not exists in older versions, so I downgraded until it is fixed.