### PR TITLE
Remove safety deployment dependency in release playbook

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,6 @@ jobs:
       - build-web
       - build-bot
       - build-inference-server
-      - build-inference-safety
     uses: ./.github/workflows/deploy-to-node.yaml
     secrets: inherit
     with:


### PR DESCRIPTION
the dependency is not needed as the safety server must be deployed separately