### PR TITLE
Fix custom preset display

### DIFF
--- a/website/src/components/Chat/WorkParameters.tsx
+++ b/website/src/components/Chat/WorkParameters.tsx
@@ -5,8 +5,6 @@ import { memo } from "react";
 import { JsonCard } from "src/components/JsonCard";
 import { InferenceMessage, SamplingParameters } from "src/types/Chat";
 
-import { useChatContext } from "./ChatContext";
-
 export const areParametersEqual = (a: SamplingParameters, b: SamplingParameters) => {
   return (
     a.top_k === b.top_k &&
@@ -26,11 +24,6 @@ export const WorkParametersDisplay = memo(function WorkParametersDisplay({
   const { seed: _, ...rest } = parameters;
   const model_id = parameters.model_config.model_id.replace("OpenAssistant/", "");
   const { t } = useTranslation("chat");
-  const { modelInfos } = useChatContext();
-  const presetName =
-    modelInfos[0].parameter_configs.find((preset) =>
-      areParametersEqual(preset.sampling_parameters, parameters.sampling_parameters)
-    )?.name ?? t("preset_custom");
 
   return (
     <>
@@ -56,12 +49,6 @@ export const WorkParametersDisplay = memo(function WorkParametersDisplay({
                 {t("model")}:{" "}
                 <Text as="span" fontWeight="medium">
                   {model_id}
-                </Text>
-              </span>
-              <span>
-                {t("preset")}:{" "}
-                <Text as="span" fontWeight="medium">
-                  {presetName}
                 </Text>
               </span>
             </Flex>

--- a/website/src/components/Chat/WorkParameters.tsx
+++ b/website/src/components/Chat/WorkParameters.tsx
@@ -24,12 +24,11 @@ export const WorkParametersDisplay = memo(function WorkParametersDisplay({
   parameters: NonNullable<InferenceMessage["work_parameters"]>;
 }) {
   const { seed: _, ...rest } = parameters;
-  const model_id = parameters.model_config.model_id;
+  const model_id = parameters.model_config.model_id.replace("OpenAssistant/", "");
   const { t } = useTranslation("chat");
   const { modelInfos } = useChatContext();
-  const modelInfo = modelInfos.find((modelInfo) => modelInfo.name === model_id);
   const presetName =
-    modelInfo?.parameter_configs.find((preset) =>
+    modelInfos[0].parameter_configs.find((preset) =>
       areParametersEqual(preset.sampling_parameters, parameters.sampling_parameters)
     )?.name ?? t("preset_custom");
 


### PR DESCRIPTION
fix #2544
The problem is the `model_id` in `work_parameters` is not the same as the name in `ModelInfo`. So I assume all models have the same preset config.
