### PR TITLE
Add camel-ai dataset

### DIFF
--- a/data/datasets/oa_camel/README.md
+++ b/data/datasets/oa_camel/README.md
@@ -1,5 +1,5 @@
 Dataset Description
-This is the chemistry, biology, math, and physics datasets created by CAMEL ai. https://huggingface.co/camel-ai They have been combined and converted to the Open Assistant format.
+This is the chemistry, biology, math, and physics datasets created by CAMEL ai. https://huggingface.co/camel-ai. They have been combined and converted to the Open Assistant format.
 
 There are 110000 entries.
 
@@ -9,15 +9,18 @@ English
 Dataset Structure
 This dataset follows the OA format, which is:
 
-INSTRUCTION (string): Instruction text
-RESPONSE (string): Expected response to the instruction
-SOURCE (string): Original data source short name, e.g. "wikipedia"
-METADATA (JSON string, optional): Any other useful information stored in JSON
-For example, NSFW content can be marked as {"nsfw": true}
-The metadata contains both the topic and subtopic.
+INSTRUCTION (string): This is the "message_1" from the original dataset, which is the user's question.
+
+RESPONSE (string): "message_2" from original dataset, which is the assistant response.
+
+SOURCE (string): The source is the name of the dataset the entry is sourced from (for example, "camel-ai/chemistry").
+
+METADATA (JSON String):
+{"Topic": "Topic sourced from the original dataset",
+"Sub-Topic": "More detailed Sub-Topic from original dataset"}
 
 Preparing the Dataset
-The dataset can be created with prepare.py. Make sure to install the required libraries inrequirements.txt!
+The dataset can be created with prepare.py. Make sure to install the required libraries in requirements.txt!
 
 Contributions
 Converted by Check

--- a/data/datasets/oa_camel/README.md
+++ b/data/datasets/oa_camel/README.md
@@ -1,0 +1,23 @@
+Dataset Description
+This is the chemistry, biology, math, and physics datasets created by CAMEL ai. https://huggingface.co/camel-ai They have been combined and converted to the Open Assistant format.
+
+There are 110000 entries.
+
+Languages
+English
+
+Dataset Structure
+This dataset follows the OA format, which is:
+
+INSTRUCTION (string): Instruction text
+RESPONSE (string): Expected response to the instruction
+SOURCE (string): Original data source short name, e.g. "wikipedia"
+METADATA (JSON string, optional): Any other useful information stored in JSON
+For example, NSFW content can be marked as {"nsfw": true}
+The metadata contains both the topic and subtopic.
+
+Preparing the Dataset
+The dataset can be created with prepare.py. Make sure to install the required libraries inrequirements.txt!
+
+Contributions
+Converted by Check

--- a/data/datasets/oa_camel/prepare.py
+++ b/data/datasets/oa_camel/prepare.py
@@ -4,7 +4,7 @@ import pandas as pd
 from datasets import load_dataset
 import json
 
-# Load the datasets from Hugging Face
+# Load the datasets from Hugging Face. The datasets are licensed under CC-BY-4.0.
 datasets = [
   'camel-ai/biology', 'camel-ai/physics', 'camel-ai/chemistry', 'camel-ai/math'
 ]

--- a/data/datasets/oa_camel/prepare.py
+++ b/data/datasets/oa_camel/prepare.py
@@ -1,0 +1,34 @@
+# This program prepares Camel datasets to the Open Assistant format.
+
+import pandas as pd
+from datasets import load_dataset
+import json
+
+# Load the datasets from Hugging Face
+datasets = [
+  'camel-ai/biology', 'camel-ai/physics', 'camel-ai/chemistry', 'camel-ai/math'
+]
+
+transformed_data = []
+
+# Loop through each dataset and process it
+for dataset_id in datasets:
+  dataset = load_dataset(dataset_id)
+  for entry in dataset['train']:
+    metadata = {'Topic': entry['topic;'], 'Sub-Topic': entry['sub_topic']}
+    transformed_entry = {
+      'INSTRUCTION': entry['message_1'],
+      'RESPONSE': entry['message_2'],
+      'SOURCE': dataset_id,
+      'METADATA': json.dumps(metadata)
+    }
+    transformed_data.append(transformed_entry)
+
+# Combine the results into a single DataFrame
+df = pd.DataFrame(transformed_data)
+
+# Save the DataFrame to disk in the Parquet format
+df.to_parquet('output.parquet', row_group_size=100)
+
+# Print the amount of entries in the final converted dataset
+print(f'Converted {len(df)} entries')

--- a/data/datasets/oa_camel/prepare.py
+++ b/data/datasets/oa_camel/prepare.py
@@ -28,7 +28,7 @@ for dataset_id in datasets:
 df = pd.DataFrame(transformed_data)
 
 # Save the DataFrame to disk in the Parquet format
-df.to_parquet('output.parquet', row_group_size=100)
+df.to_parquet("output.parquet", row_group_size=100, engine="pyarrow", index=False)
 
 # Print the amount of entries in the final converted dataset
 print(f'Converted {len(df)} entries')

--- a/data/datasets/oa_camel/requirements.txt
+++ b/data/datasets/oa_camel/requirements.txt
@@ -1,0 +1,2 @@
+pandas==
+datasets==


### PR DESCRIPTION
Added the oa_camel folder in data. 

This dataset is quite large, at 110,000 entries. The original source is found on their page on HF: https://huggingface.co/camel-ai

It contains question-answer pairs about physics, chemisty, biology, and math, all combined into one dataset in the OA format.

Closes #2501. The dataset is uploaded to my HF at: https://huggingface.co/datasets/checkai/oaCamel