### PR TITLE
Changed profile of inference-safety in docker compose to avoid huge build times

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -266,7 +266,7 @@ services:
     volumes:
       - "./oasst-shared:/opt/inference/lib/oasst-shared"
       - "./inference/safety:/opt/inference/safety"
-    profiles: ["inference"]
+    profiles: ["inference-safety"]
 
   prometheus:
     image: prom/prometheus


### PR DESCRIPTION
Until the dockerfile of safety is refactored, we should take it out of the compose build for inference