### PR TITLE
Update the developer guide with changes in the docker-file

### DIFF
--- a/docs/docs/guides/developers.md
+++ b/docs/docs/guides/developers.md
@@ -243,12 +243,15 @@ website directory.
 
 - `inference`. It includes these containers:
 
-  - `inference-db`, `inference-server`, `inference-worker`, `inference-redis`,
-    `inference-safety`
+  - `inference-db`, `inference-server`, `inference-worker`, `inference-redis`
 
 - `inference-dev`. It includes these containers:
 
   - `db`, `web-db`, `backend`
+
+- `inference-safety`. It includes these containers:
+
+  - `inference-safety`
 
 - `observability`. It includes tools to monitor the application. It includes
   these containers:


### PR DESCRIPTION
Per #3e703a, the inference-safety is no longer part of the inference profile