### PR TITLE
Fullwidth comma was used by mistake for data field in Chinese translation.

### DIFF
--- a/website/public/locales/zh/leaderboard.json
+++ b/website/public/locales/zh/leaderboard.json
@@ -7,9 +7,9 @@
   "label": "标注",
   "labels_full": "标注 (完整版)",
   "labels_simple": "标注 (缩略版)",
-  "last_updated_at": "上次更新时间: {{val，datetime}}",
+  "last_updated_at": "上次更新时间: {{val, datetime}}",
   "leaderboard": "排行榜",
-  "level_progress_message": "您总共获得 {{score}} 分, 已达到 {{level，number，integer}} 级!",
+  "level_progress_message": "您总共获得 {{score}} 分, 已达到 {{level, number, integer}} 级!",
   "month": "月",
   "monthly": "每月",
   "next": "下一页",
@@ -33,7 +33,7 @@
   "view_all": "查看全部",
   "week": "周",
   "weekly": "每周",
-  "xp_progress_message": "您需要 {{need，number，integer}} 分才能达到下一个等级!",
+  "xp_progress_message": "您需要 {{need, number, integer}} 分才能达到下一个等级!",
   "your_account": "您的账户",
   "your_stats": "您的统计数据"
 }


### PR DESCRIPTION
- Before this pull request:
![image](https://user-images.githubusercontent.com/21303772/232770610-9a6ce312-bcd4-4445-a638-60ac3bff9e5f.png)
and
![image](https://user-images.githubusercontent.com/21303772/232770742-2f64c2e7-26ec-493c-b021-d80ed3708671.png)
- After this fix:
![image](https://user-images.githubusercontent.com/21303772/232770791-0bdccd8a-13a7-4672-b2d0-639a8f7791e8.png)
and
![image](https://user-images.githubusercontent.com/21303772/232770808-15130318-36cd-4332-855e-9918fca14c1b.png)

