### PR TITLE
Allow overriding of MODEL_CONFIG_NAME from environment

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -246,7 +246,7 @@ services:
     image: oasst-inference-worker:dev
     environment:
       API_KEY: "0000"
-      MODEL_CONFIG_NAME: distilgpt2
+      MODEL_CONFIG_NAME: ${MODEL_CONFIG_NAME:-distilgpt2}
       BACKEND_URL: "ws://inference-server:8000"
       PARALLELISM: 2
     volumes:


### PR DESCRIPTION
(Attempts to address #2696)

This change allows docker compose to use a `MODEL_CONFIG_NAME` value from the environment if it is present, otherwise it will default to the `distilgpt2` model value.

Example usage:
```
MODEL_CONFIG_NAME=OA_SFT_Pythia_12Bq docker compose --profile ci --profile inference up --build --attach-dependencies
```

Output observed in docker compose console:
```
open-assistant-inference-worker-1     | Downloading model OpenAssistant/oasst-sft-1-pythia-12b
```