### PR TITLE
fix: added option to specify platform for db in compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,9 @@ if you have problems):
 docker compose --profile ci up --build --attach-dependencies
 ```
 
+> **Note:** when running on MacOS with an M1 chip you have to use:
+> `DB_PLATFORM=linux/x86_64 docker compose ...`
+
 Then, navigate to `http://localhost:3000` (It may take some time to boot up) and
 interact with the website.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -11,6 +11,9 @@ database at `localhost:5432`. (See
 [FAQ](https://projects.laion.ai/Open-Assistant/docs/faq#enable-dockers-buildkit-backend)
 if you face any docker problems).
 
+> **Note:** when running on MacOS with an M1 chip you have to use:
+> `DB_PLATFORM=linux/x86_64 docker compose ...`
+
 Python 3.10 is required. It is recommended to use `pyenv` which will recognise
 the `.python-version` in the project root directory.
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
 
   # This DB is for the FastAPI Backend.
   db:
+    platform: "${DB_PLATFORM:-}"
     image: ghcr.io/laion-ai/open-assistant/oasst-postgres
     pull_policy: always
     restart: always

--- a/scripts/backend-development/README.md
+++ b/scripts/backend-development/README.md
@@ -5,6 +5,9 @@ In root directory, run
 a database. The default settings are already configured to connect to the
 database at `localhost:5432`.
 
+> **Note:** when running on MacOS with an M1 chip you have to use:
+> `DB_PLATFORM=linux/x86_64 docker compose ...`
+
 Make sure you have all requirements installed. You can do this by running
 `pip install -r requirements.txt` inside the `backend` folder,
 `pip install -e .` inside the `oasst-shared` folder and `pip install -e .`

--- a/website/README.md
+++ b/website/README.md
@@ -54,6 +54,7 @@ If you're doing active development we suggest the following workflow:
 1.  Run `npm run dev`. Now the website is up and running locally at `http://localhost:3000`.
 1.  To create an account, login via the user using email authentication and navigate to `http://localhost:1080`. Check
     the email listed and click the log in link. You're now logged in and authenticated.
+    > **Note:** when running on MacOS with an M1 chip you have to use: `DB_PLATFORM=linux/x86_64 docker compose ...`
 
 ### Using debug user credentials
 


### PR DESCRIPTION
related to issue https://github.com/LAION-AI/Open-Assistant/issues/2721

enables specifying platform for service `db` using environment variable `DB_PLATFORM`. If left unspecified (silently) defaults to current behaviour.

this solves the issue where M1 users where unable to use docker-compose as the `db` service relies on `ghcr.io/laion-ai/open-assistant/oasst-postgres` (which does not support `linux/arm64/v8` as plaform).

sadly (afaik) docker-compose does not offer something akin to `docker --platform` you have to set it in the compose-file.