### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ backend/openapi.json
 
 *.log
 *.db
+
 # edit docs using obsidian.md, these files should not appear in the repo
 .obsidian/
 .pytest_cache/


### PR DESCRIPTION
added an enter on line 19 for formatting.

First and second comment has a break line before the comment. 

There is now break line for the last comment.