### PR TITLE
Update README to indicate that deepspeed launcher should be used

### DIFF
--- a/model/model_training/README.md
+++ b/model/model_training/README.md
@@ -168,11 +168,12 @@ You can edit the configs/zero_config.json and use any stage you wish. The
 current config uses zero-stage 3. For more details on how to setup the config
 checkout [this page](https://www.deepspeed.ai/tutorials/zero/).
 
-Once you are satisfy with your deepzero config, you can add --deepspeed flag at
-the end to trigger deepspeed
+Once you are satisfied with your deepzero config, you can add the --deepspeed
+flag at the end to trigger deepspeed. You should typically use the deepspeed
+launcher to train
 
 ```
-python trainer_sft.py --configs defaults your-model-name --deepspeed
+deepspeed trainer_sft.py --configs defaults your-model-name --deepspeed
 ```
 
 ### Datasets


### PR DESCRIPTION
Was OOMing when following the instructions here. This should be more scaleproof and should still work for smaller models as far as I know