### PR TITLE
Focus on input on edit chat title clicked

### DIFF
--- a/website/src/components/Chat/ChatForm.tsx
+++ b/website/src/components/Chat/ChatForm.tsx
@@ -44,7 +44,6 @@ export const ChatForm = forwardRef<HTMLTextAreaElement, ChatFormProps>((props, r
         _dark={{
           bg: "gray.800",
         }}
-        autoFocus
       />
       <Grid gridTemplateColumns="1fr 50px" gap={2} mt="4">
         <Button

--- a/website/src/components/Chat/ChatForm.tsx
+++ b/website/src/components/Chat/ChatForm.tsx
@@ -44,6 +44,7 @@ export const ChatForm = forwardRef<HTMLTextAreaElement, ChatFormProps>((props, r
         _dark={{
           bg: "gray.800",
         }}
+        autoFocus
       />
       <Grid gridTemplateColumns="1fr 50px" gap={2} mt="4">
         <Button

--- a/website/src/components/Chat/ChatListItem.tsx
+++ b/website/src/components/Chat/ChatListItem.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, CircularProgress, Flex, Input, Tooltip, useBoolean, useOutsideClick } from "@chakra-ui/react";
-import { Check, LucideIcon, Pencil, EyeOff, X } from "lucide-react";
+import { Check, EyeOff, LucideIcon, Pencil, X } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { useTranslation } from "next-i18next";
@@ -95,6 +95,10 @@ export const ChatListItem = ({
             pe="50px"
             borderRadius="lg"
             maxLength={100}
+            autoFocus
+            onFocus={(e) => {
+              e.target.select();
+            }}
           ></Input>
           <Flex
             position="absolute"

--- a/website/src/components/Chat/ChatListItem.tsx
+++ b/website/src/components/Chat/ChatListItem.tsx
@@ -95,7 +95,7 @@ export const ChatListItem = ({
             pe="50px"
             borderRadius="lg"
             maxLength={100}
-            autoFocus 
+            autoFocus
           ></Input>
           <Flex
             position="absolute"

--- a/website/src/components/Chat/ChatListItem.tsx
+++ b/website/src/components/Chat/ChatListItem.tsx
@@ -95,10 +95,7 @@ export const ChatListItem = ({
             pe="50px"
             borderRadius="lg"
             maxLength={100}
-            autoFocus
-            onFocus={(e) => {
-              e.target.select();
-            }}
+            autoFocus 
           ></Input>
           <Flex
             position="absolute"

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -124,6 +124,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
             _dark={{
               bg: "gray.800",
             }}
+            autoFocus
           ></Textarea>
         </Box>
       )}


### PR DESCRIPTION
This PR brings following changes:
1. When clicking on edit chat title button the input field will now be on focus.
2. Clicking on edit prompt button will set the focus on chat box

Fixes #2519