### PR TITLE
Provide a warning with a message when GPU info cannot be detected

### DIFF
--- a/oasst-shared/oasst_shared/schemas/inference.py
+++ b/oasst-shared/oasst_shared/schemas/inference.py
@@ -8,6 +8,7 @@ from typing import Annotated, Literal, Union
 import psutil
 import pydantic
 import pynvml
+from loguru import logger
 from oasst_shared.model_configs import ModelConfig
 
 INFERENCE_PROTOCOL_VERSION = "1"
@@ -54,8 +55,8 @@ class WorkerHardwareInfo(pydantic.BaseModel):
                 name = pynvml.nvmlDeviceGetName(handle)
                 total_memory = pynvml.nvmlDeviceGetMemoryInfo(handle).total
                 data["gpus"].append(WorkerGpuInfo(name=name, total_memory=total_memory))
-        except Exception:
-            pass
+        except Exception as error:
+            logger.warning(f"No GPU's detected, are you missing a dependency? Error was: {error}")
         super().__init__(**data)
 
 


### PR DESCRIPTION
Then detectedin the worker hardware info an error in the GPU device detetion dependency would silently fail and catch all sorts of exception types (possibly many unexpected ones) without at least a warning that could speed up debugging effort.