### PR TITLE
add translate button to important readme's

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/CONTRIBUTING.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # I’m in! Now what?
 
 [Join the OpenAssistant Contributors Discord Server!](https://ykilcher.com/open-assistant-discord),

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 <a href="https://github.com/LAION-AI/Open-Assistant/actions/workflows/production-deploy.yaml">![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/LAION-AI/Open-Assistant/production-deploy.yaml?label=deploy-production)</a>
 <a href="https://github.com/LAION-AI/Open-Assistant/actions/workflows/release.yaml">![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/LAION-AI/Open-Assistant/release.yaml?label=deploy-release)</a>
 <a href="https://github.com/LAION-AI/Open-Assistant/releases">![GitHub release (latest by date)](https://img.shields.io/github/v/release/LAION-AI/Open-Assistant)</a>
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
 
 </div>
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/backend/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Open-Assistant REST Backend
 
 ## Backend Development Setup

--- a/copilot/README.md
+++ b/copilot/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/copilot/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Deploying on AWS
 
 ## Introduction

--- a/data/datasets/README.md
+++ b/data/datasets/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/data/datasets/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 ## **Overview**
 
 This repository aims to provide a diverse and accessible collection of datasets

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/docs/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Docs Site
 
 https://laion-ai.github.io/Open-Assistant/

--- a/inference/README.md
+++ b/inference/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/inference/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # OpenAssistant Inference
 
 Preliminary implementation of the inference engine for OpenAssistant.

--- a/model/README.md
+++ b/model/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/model/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 ## Reproduction directions
 
 Here are some minimal commands to tun to whole pipeline on the collected data.

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -1,11 +1,9 @@
-# Deprecated
+# Notebooks
 
-This `notebooks` directory is being retired in favour of new dataset
-contributions going to the `data/datasets` directory, following the guidelines
-[here](https://github.com/LAION-AI/Open-Assistant/blob/main/data/datasets/README.md).
-Please do not submit future data notebooks here.
+This directory is used to hold useful notebooks related to understanding how
+various parts of the project work.
 
-## Notebooks
-
-This directory was designed to hold notebooks, primarily for data scraping and
-augmentation.
+> Note for dataset contributions: The `notebooks` directory is being retired in
+> favour of new dataset contributions going to the `data/datasets` directory,
+> following the guidelines
+> [here](https://github.com/LAION-AI/Open-Assistant/blob/main/data/datasets/README.md).

--- a/oasst-data/README.md
+++ b/oasst-data/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/oasst-data/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Open Assistant Data Module (oasst_data)
 
 ## Installation of oasst_data

--- a/safety/README.md
+++ b/safety/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/safety/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Train & Evaluate Safety models
 
 This is the Open Assistant Safety Folder and contains the following:

--- a/website/README.md
+++ b/website/README.md
@@ -1,3 +1,5 @@
+<a href="https://github-com.translate.goog/LAION-AI/Open-Assistant/blob/main/website/README.md?_x_tr_sl=auto&_x_tr_tl=en&_x_tr_hl=en&_x_tr_pto=wapp">![Translate](https://img.shields.io/badge/Translate-blue)</a>
+
 # Open-Assistant NextJS Website
 
 ## Purpose


### PR DESCRIPTION
- add translate button to some readme to make it easy for users to just press it and then google translate that docs into whatever language they want

related to discussion following this PR https://github.com/LAION-AI/Open-Assistant/pull/2762

for example see the "Translate" badge at top of page here: https://github.com/andrewm4894/Open-Assistant/blob/add-translate-button-to-readmes/CONTRIBUTING.md

unsure if add's noise or not but flip side is an attempt to make it as easy as possible for non English speakers to just see if a quick google translate is of any us to them.