### PR TITLE
Update download_model.py

### DIFF
--- a/inference/worker/download_model.py
+++ b/inference/worker/download_model.py
@@ -1,8 +1,17 @@
 import os
 import signal
 import sys
-
+import concurrent.futures
 import transformers
+
+
+def download_model(model_id):
+    if "llama" in model_id.lower():
+        transformers.LlamaTokenizer.from_pretrained(model_id)
+        transformers.LlamaForCausalLM.from_pretrained(model_id)
+    else:
+        transformers.AutoTokenizer.from_pretrained(model_id)
+        transformers.AutoModelForCausalLM.from_pretrained(model_id)
 
 
 def terminate(signum, frame):
@@ -12,10 +21,7 @@ def terminate(signum, frame):
 
 if __name__ == "__main__":
     signal.signal(signal.SIGINT, terminate)
-    model_id = os.getenv("MODEL_ID")
-    if "llama" in model_id.lower():
-        transformers.LlamaTokenizer.from_pretrained(model_id)
-        transformers.LlamaForCausalLM.from_pretrained(model_id)
-    else:
-        transformers.AutoTokenizer.from_pretrained(model_id)
-        transformers.AutoModelForCausalLM.from_pretrained(model_id)
+    model_ids = os.getenv("MODEL_IDS").split(",")
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [executor.submit(download_model, model_id) for model_id in model_ids]
+        concurrent.futures.wait(futures)


### PR DESCRIPTION
we define a `download_model` function that takes a `model_id as input and downloads the tokenizer and model for that ID. We also define a terminate function that will be called if the script receives a SIGINT signal (e.g., when the user hits Ctrl-C).

In the main block of the script, we first split the `MODEL_IDS` environment variable by comma to get a list of model IDs to download. We then use a `ThreadPoolExecutor` to download the models in parallel. This creates a pool of worker threads that will execute the `download_model` function for each model ID. The `submit` method of the executor schedules a new task for each model ID, and returns a `Future` object representing the result of that task. We store these `Future` objects in a list so that we can wait for all of them to complete using the `wait` method of the `concurrent.futures` module.

By downloading the models in parallel using multiple threads, we can potentially speed up the download process significantly.