### PR TITLE
Update check_dataset_appearances.py

### DIFF
--- a/model/model_training/check_dataset_appearances.py
+++ b/model/model_training/check_dataset_appearances.py
@@ -9,7 +9,6 @@ python check_dataset_appearances.py -d gpt4all webgpt --cache_dir .cache --mode 
 import argparse
 import pprint
 from collections import defaultdict
-
 from model_training.custom_datasets import get_one_dataset
 from model_training.custom_datasets.entities import Mode
 from model_training.custom_datasets.formatting import DatasetEntry
@@ -19,11 +18,8 @@ from model_training.custom_datasets.qa_datasets import (
     re_whitespace_newline_match,
 )
 from model_training.custom_datasets.utils import FILTER_BY_WORDS
-
 RE_TO_CHECK = [re_whitespace_newline_match, re_reference_remove, re_single_reference_remove]
-STRINGS_TO_CHECK = [*FILTER_BY_WORDS]
-
-
+FILTER_WORDS = set(FILTER_BY_WORDS)
 def argument_parsing():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -34,62 +30,52 @@ def argument_parsing():
         help="""
         Multiple datasets can be passed to set different options.
         For example, run as:
-
            ./check_dataset_counts.py --datasets math oasst_export_eu
-
         to check the counts of the math and the oasst_export_eu dataset.
     """,
     )
     parser.add_argument("--mode", dest="mode", type=Mode, choices=list(Mode))
     parser.add_argument("--cache_dir", dest="cache_dir", type=str)
-
     args, _ = parser.parse_known_args()
-
     return args
-
-
 def check_in_dataset_row(row: str | list[str] | tuple[str], matched=dict[str, list]):
     def _check_single_string(row: str, matched: dict[str, list]) -> dict[str, list]:
         for exp in RE_TO_CHECK:
             if exp.match(row) is not None:
                 matched[exp].append(row)
-        for string in STRINGS_TO_CHECK:
-            if string in row:
-                string_idx = row.index(string)
-                matched[string].append(row[max(string_idx - 50, 0) : string_idx + 50])
+        for i, word in enumerate(row.split()):
+            if word in FILTER_WORDS:
+                matched[word].append(row[max(i - 50, 0) : i + 50])
         return matched
-
-    if isinstance(row, str):
-        matched = _check_single_string(row, matched)
-    elif isinstance(row, (list, tuple)):
-        for r in row:
-            if not isinstance(r, str):
-                raise ValueError(f"Unexpected type: {type(row)}")
-            matched = _check_single_string(r, matched)
-    elif isinstance(row, DatasetEntry):
-        formatted = row.get_formatted(mode=args.mode, eos_token="</s>")
-        for r in formatted:
-            if not isinstance(r, str):
-                raise ValueError(f"Unexpected type: {type(r)}")
-            matched = _check_single_string(
-                r.replace("<|assistant|>", "").replace("<|prompter|>", "").replace("</s>", ""), matched
-            )
-    else:
-        raise ValueError(f"Received unexpected type: {type(row)}.")
+    try:
+        if isinstance(row, str):
+            matched = _check_single_string(row, matched)
+        elif isinstance(row, (list, tuple)):
+            for r in row:
+                if not isinstance(r, str):
+                    raise ValueError(f"Unexpected type: {type(row)}")
+                matched = _check_single_string(r, matched)
+        elif isinstance(row, DatasetEntry):
+            formatted = row.get_formatted(mode=args.mode, eos_token="</s>")
+            for r in formatted:
+                if not isinstance(r, str):
+                    raise ValueError(f"Unexpected type: {type(r)}")
+                matched = _check_single_string(
+                    r.replace("", "").replace("", "").replace("</s>", ""), matched
+                )
+        else:
+            raise ValueError(f"Received unexpected type: {type(row)}.")
+    except ValueError as e:
+        print(f"Ignoring row: {row}. Reason: {str(e)}")
     return matched
-
-
 def iterate_over_dataset(ds):
     matched = defaultdict(list)
     for row in ds:
         check_in_dataset_row(row, matched)
     return matched
-
-
 if __name__ == "__main__":
     args = argument_parsing()
     pp = pprint.PrettyPrinter(indent=4)
-
     train_datasets, val_datasets = {}, {}
     for dataset_name in args.datasets:
         print(f"start with dataset {dataset_name}")


### PR DESCRIPTION
Use a `set` to store the filter words instead of a list to improve the lookup speed. Use `enumerate` instead of index to get the index of the filter word in the row. Use a `try-except` block instead of an if statement to catch the `ValueError` raised when the row is not a string.