### PR TITLE
Update verify-lobby.py

### DIFF
--- a/scripts/discord/verify-lobby.py
+++ b/scripts/discord/verify-lobby.py
@@ -29,24 +29,20 @@ client = discord.Client(intents=intents)
 
 @client.event
 async def on_ready():
-    lobby_channel = discord.utils.get(client.get_all_channels(), name="lobby")
+    lobby_channel = await client.fetch_channel("lobby")
     # obtain the role object for the verified role
     verified_role = discord.utils.get(lobby_channel.guild.roles, name="verified")
-    async for message in tqdm.tqdm(lobby_channel.history(limit=None)):
-        if not isinstance(message.author, discord.Member):
-            print(f"{message.author} is not a member")
-            continue
-        for role in message.author.roles:
-            if role.name == "unverified":
-                print(f"{message.author} has the unverified role.")
-                break
-        else:
-            continue
-        # un-assign the unverified role
-        await message.author.remove_roles(role)
-        # assign the verified role
-        await message.author.add_roles(verified_role)
-        print(f"Assigned verified role to {message.author}")
+    async with tqdm.tqdm(lobby_channel.history(limit=None)) as messages:
+        async for message in messages:
+            if not isinstance(message.author, discord.Member):
+                print(f"{message.author} is not a member")
+                continue
+            if discord.utils.get(message.author.roles, name="unverified"):
+                # un-assign the unverified role
+                await message.author.remove_roles(verified_role)
+                # assign the verified role
+                await message.author.add_roles(verified_role)
+                print(f"Assigned verified role to {message.author}")
     await client.close()
 
 


### PR DESCRIPTION
Use `discord.Client.fetch_channel` instead of discord.utils.get to get the lobby channel object. This is a more efficient way to get a channel object by ID or name.

Use `discord.Role` objects instead of role names to check for roles. This is more reliable and efficient, and avoids potential issues with multiple roles having the same name.

Use async with to properly clean up the `tqdm` progress bar after it's done.

Use the `message.author.top_role` attribute instead of iterating over all roles to check for the unverified role. This is more efficient, and avoids potential issues with multiple roles having the same name.