### PR TITLE
Fix display name spill-over (#2851)

### DIFF
--- a/website/src/components/DataTable/DataTable.tsx
+++ b/website/src/components/DataTable/DataTable.tsx
@@ -199,7 +199,7 @@ const DataTableRow = <T,>({ row }: { row: Row<T> }) => {
       {renderCells.map((cell) => {
         const props = cell.column.columnDef.meta?.cellProps?.(cell);
         return (
-          <Td key={cell.id} {...props} colSpan={cell.span}>
+          <Td key={cell.id} {...props} colSpan={cell.span} style={{ overflow: "hidden" }}>
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </Td>
         );

--- a/website/src/components/DataTable/DataTable.tsx
+++ b/website/src/components/DataTable/DataTable.tsx
@@ -199,7 +199,7 @@ const DataTableRow = <T,>({ row }: { row: Row<T> }) => {
       {renderCells.map((cell) => {
         const props = cell.column.columnDef.meta?.cellProps?.(cell);
         return (
-          <Td key={cell.id} {...props} colSpan={cell.span} style={{ overflow: "hidden" }}>
+          <Td key={cell.id} {...props} colSpan={cell.span}>
             {flexRender(cell.column.columnDef.cell, cell.getContext())}
           </Td>
         );

--- a/website/src/components/Header/UserMenu.tsx
+++ b/website/src/components/Header/UserMenu.tsx
@@ -73,14 +73,14 @@ export function UserMenu() {
       <MenuButton border="solid" borderRadius="full" borderWidth="thin" borderColor={borderColor}>
         <Box display="flex" alignItems="center" gap="3" p="1">
           <Avatar size="sm" src={session.user.image!} />
-          <Text data-cy="username" className="hidden lg:flex ltr:pr-2 rtl:pl-2">
+          <Text data-cy="username" className="hidden lg:flex ltr:pr-2 rtl:pl-2" style={{ overflow: "hidden" }}>
             {session.user.name || "New User"}
           </Text>
         </Box>
       </MenuButton>
       <MenuList p="2" borderRadius="xl" shadow="none">
         <Box display="flex" flexDirection="column" alignItems="center" borderRadius="md" p="1" gap="2">
-          <Text>
+          <Text style={{ overflow: "hidden" }}>
             {session.user.name}
             {isAdminOrMod ? (
               <Badge size="xs" ml="2" fontSize="xs" textTransform="capitalize">

--- a/website/src/components/UserDisplayNameCell.tsx
+++ b/website/src/components/UserDisplayNameCell.tsx
@@ -32,13 +32,13 @@ export const UserDisplayNameCell = ({
       <UserAvatar displayName={displayName} avatarUrl={avatarUrl} />
       {isAdminOrMod ? (
         <>
-          <Link as={NextLink} href={ROUTES.ADMIN_USER_DETAIL(userId)}>
+          <Link as={NextLink} href={ROUTES.ADMIN_USER_DETAIL(userId)} style={{ overflow: "hidden" }}>
             {displayName}
           </Link>
           <Tooltip label={`Signed in with ${authMethod}`}>{AUTH_METHOD_TO_ICON[authMethod]}</Tooltip>
         </>
       ) : (
-        displayName
+        <div style={{ overflow: "hidden" }}>{displayName}</div>
       )}
     </Flex>
   );

--- a/website/src/components/UserTable.tsx
+++ b/website/src/components/UserTable.tsx
@@ -1,5 +1,5 @@
 import { Card, CardBody, IconButton } from "@chakra-ui/react";
-import { createColumnHelper } from "@tanstack/react-table";
+import { createColumnHelper, Cell } from "@tanstack/react-table";
 import { Pencil } from "lucide-react";
 import Link from "next/link";
 import { memo, useState } from "react";
@@ -30,6 +30,11 @@ const columns: DataTableColumnDef<User>[] = [
       header: "Name",
     }),
     filterable: true,
+    meta: {
+      cellProps: (x) => {
+        return { style: { overflow: "hidden" } };
+      },
+    },
   },
   columnHelper.accessor("role", {
     header: "Role",

--- a/website/src/pages/account/index.tsx
+++ b/website/src/pages/account/index.tsx
@@ -43,7 +43,7 @@ export default function Account() {
             <Divider />
             <Grid gridTemplateColumns="repeat(2, max-content)" alignItems="center" gap={6} py={4}>
               <Text as="b">{t("username")}</Text>
-              <Flex gap={2}>
+              <Flex gap={2} style={{ overflow: "hidden" }}>
                 {session.user.name ?? t("no_username")}
                 <Link href="/account/edit">
                   <Icon boxSize={5} as={Pencil} size="1em" />


### PR DESCRIPTION
This fixes display names spilling over the rest of the ui.

Below is an image showing what the result looks like on the leader board.

![image](https://user-images.githubusercontent.com/50634068/233856264-f909d34f-92e0-4f27-937d-b9cb91cbcc03.png)

Closes #2851
