### PR TITLE
Add prioritisation to prompt lottery

### DIFF
--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -20,6 +20,7 @@ from oasst_backend.models import (
     TextLabels,
     User,
     UserStats,
+    UserStatsTimeFrame,
     message_tree_state,
 )
 from oasst_backend.prompt_repository import PromptRepository
@@ -274,7 +275,9 @@ class TreeManager:
                     .select_from(MessageTreeState)
                     .join(Message, MessageTreeState.message_tree_id == Message.id)
                     .join(User, Message.user_id == User.id)
-                    .join(UserStats, and_(UserStats.user_id == User.id, UserStats.time_frame == "week"))
+                    .join(
+                        UserStats, and_(UserStats.user_id == User.id, UserStats.time_frame == UserStatsTimeFrame.month)
+                    )
                     .filter(
                         MessageTreeState.state == message_tree_state.State.PROMPT_LOTTERY_WAITING,
                         Message.lang == lang,

--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -271,11 +271,11 @@ class TreeManager:
             def activate_one(db: Session) -> int:
                 # select among distinct users
                 authors_qry = (
-                    db.query(Message.user_id, UserStats.reply_ranked_1)
+                    db.query(Message.user_id, func.coalesce(UserStats.reply_ranked_1, 0).label("reply_ranked_1"))
                     .select_from(MessageTreeState)
                     .join(Message, MessageTreeState.message_tree_id == Message.id)
                     .join(User, Message.user_id == User.id)
-                    .join(
+                    .outerjoin(
                         UserStats, and_(UserStats.user_id == User.id, UserStats.time_frame == UserStatsTimeFrame.month)
                     )
                     .filter(

--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -19,6 +19,7 @@ from oasst_backend.models import (
     Task,
     TextLabels,
     User,
+    UserStats,
     message_tree_state,
 )
 from oasst_backend.prompt_repository import PromptRepository
@@ -269,10 +270,11 @@ class TreeManager:
             def activate_one(db: Session) -> int:
                 # select among distinct users
                 authors_qry = (
-                    db.query(Message.user_id)
+                    db.query(Message.user_id, UserStats.reply_ranked_1)
                     .select_from(MessageTreeState)
                     .join(Message, MessageTreeState.message_tree_id == Message.id)
                     .join(User, Message.user_id == User.id)
+                    .join(UserStats, and_(UserStats.user_id == User.id, UserStats.time_frame == "week"))
                     .filter(
                         MessageTreeState.state == message_tree_state.State.PROMPT_LOTTERY_WAITING,
                         Message.lang == lang,
@@ -284,16 +286,21 @@ class TreeManager:
                     .distinct(Message.user_id)
                 )
 
-                author_ids = authors_qry.all()
-                if len(author_ids) == 0:
+                author_data: list[tuple[UUID, int]] = authors_qry.all()
+                if len(author_data) == 0:
                     logger.info(
                         f"No prompts for prompt lottery available ({num_missing_growing=}, trees missing for {lang=})."
                     )
                     return False
 
+                author_ids = [data[0] for data in author_data]
+                # add one to avoid any scenario where all weights are 0
+                # this also means inactive users can still occasionally be selected
+                weights = [data[1] + 1 for data in author_data]
+
                 # first select an author
-                prompt_author_id: UUID = random.choice(author_ids)["user_id"]
-                logger.info(f"Selected random prompt author {prompt_author_id} among {len(author_ids)} candidates.")
+                prompt_author_id: UUID = random.choices(author_ids, weights=weights)[0]
+                logger.info(f"Selected random prompt author {prompt_author_id} among {len(author_data)} candidates.")
 
                 # select random prompt of author
                 qry = (

--- a/backend/oasst_backend/tree_manager.py
+++ b/backend/oasst_backend/tree_manager.py
@@ -286,17 +286,17 @@ class TreeManager:
                     .distinct(Message.user_id)
                 )
 
-                author_data: list[tuple[UUID, int]] = authors_qry.all()
+                author_data = authors_qry.all()
                 if len(author_data) == 0:
                     logger.info(
                         f"No prompts for prompt lottery available ({num_missing_growing=}, trees missing for {lang=})."
                     )
                     return False
 
-                author_ids = [data[0] for data in author_data]
+                author_ids = [data["user_id"] for data in author_data]
                 # add one to avoid any scenario where all weights are 0
                 # this also means inactive users can still occasionally be selected
-                weights = [data[1] + 1 for data in author_data]
+                weights = [data["reply_ranked_1"] + 1 for data in author_data]
 
                 # first select an author
                 prompt_author_id: UUID = random.choices(author_ids, weights=weights)[0]


### PR DESCRIPTION
This aims to improve the quality of initial prompts by prioritising authors with a (recent) history of writing high quality assistant replies. Based on conversations re gamification on Discord.