### PR TITLE
set PROMETHEUS_MULTIPROC_DIR env var

### DIFF
--- a/docker/inference/Dockerfile.server
+++ b/docker/inference/Dockerfile.server
@@ -37,6 +37,7 @@ ENV PATH="${PATH}:${APP_LIBS}/bin"
 ENV PYTHONPATH="${PYTHONPATH}:${APP_LIBS}"
 
 ENV PORT="8080"
+ENV PROMETHEUS_MULTIPROC_DIR="/tmp/oasst-inference-prometheus-metrics"
 
 RUN adduser               \
       --disabled-password \

--- a/inference/server/server_main.sh
+++ b/inference/server/server_main.sh
@@ -4,8 +4,11 @@ gunicorn_workers=${GUNICORN_WORKERS:-1}
 
 # if 1 worker, stay with uvicorn
 if [ $gunicorn_workers -eq 1 ]; then
+    unset PROMETHEUS_MULTIPROC_DIR
     uvicorn main:app --host 0.0.0.0 --port "$PORT"
 else
+    if [ -d "${PROMETHEUS_MULTIPROC_DIR}" ]; then rm -rf "${PROMETHEUS_MULTIPROC_DIR}"; fi
+    mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
     port=${PORT:-8080}
     gunicorn main:app --workers $gunicorn_workers --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:$port
 fi


### PR DESCRIPTION
We recently upgraded to Gunicorn for inference (multi-proc), which broke our prometheus stats and we got strange drops (see  https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/50 ). For multi process model setting `PROMETHEUS_MULTIPROC_DIR` is required, see [here](https://github.com/prometheus/client_python/blob/master/README.md#multiprocess-mode-eg-gunicorn).