### PR TITLE
simplify default `post_create_command.sh`

### DIFF
--- a/.devcontainer/post_create_command.sh
+++ b/.devcontainer/post_create_command.sh
@@ -1,11 +1,6 @@
 #!/bin/bash
 
-# Run both backend-dev and frontend-dev post_create scripts
+# do as little as possible in this script to keep the container creation fast.
+# for more specific devcontainer use cases use the different devcontainer subfolders.
 
-./.devcontainer/backend-dev/post_create_command.sh
-./.devcontainer/frontend-dev/post_create_command.sh
-
-# run yarn install in docs folder
-cd docs
-yarn install
-cd ..
+echo "done"


### PR DESCRIPTION
I have been trying to use default codespace for testing some PR's and finding it somewhat impossible to use in github codespaces as it seems to be trying to do too much automatically. 

- we should run as little as possible in the default devcontainer to make it as fast and easy to get going with.
- if does not make sense to run the post create scripts of the other devcontainers, their own devcontainer.jsons call those scripts themselves.