### PR TITLE
Fix inference-server dockerfile so it can run locally

### DIFF
--- a/docker/inference/Dockerfile.server
+++ b/docker/inference/Dockerfile.server
@@ -46,6 +46,8 @@ RUN adduser               \
 
 USER ${APP_USER}
 
+RUN mkdir -p "${PROMETHEUS_MULTIPROC_DIR}"
+
 WORKDIR ${APP_ROOT}
 
 


### PR DESCRIPTION
@andreaskoepf: https://github.com/LAION-AI/Open-Assistant/pull/2956 Added an env `PROMETHEUS_MULTIPROC_DIR` which causes the container to fail to run locally due to the directory not existing.

Creating the directory after setting`USER ${APP_USER}` resolves this