### PR TITLE
Instructional Dataset for Stable Diffusion prompt generation

### DIFF
--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -25,6 +25,7 @@ INSTRUCTION_DATASETS = {
     "poetry_instruction": "checkai/instruction-poems",
     "oa_stackexchange": "donfu/oa-stackexchange",
     "multilingual_wikihow_qa_8k": "0x22almostEvil/multilingual-wikihow-qa-8k",
+    "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset"
 }
 
 SAFETY_DATASETS = {

--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -25,7 +25,7 @@ INSTRUCTION_DATASETS = {
     "poetry_instruction": "checkai/instruction-poems",
     "oa_stackexchange": "donfu/oa-stackexchange",
     "multilingual_wikihow_qa_8k": "0x22almostEvil/multilingual-wikihow-qa-8k",
-    "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset"
+    "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset",
 }
 
 SAFETY_DATASETS = {


### PR DESCRIPTION
Greetings,

I am adding this dataset:

https://huggingface.co/datasets/MadVoyager/stable_diffusion_instructional_dataset

That is an instructional version of this dataset: https://huggingface.co/datasets/Gustavosta/Stable-Diffusion-Prompts

I believe this should be able to help Open Assistant's ability in providing accurate Stable Diffusion prompts with image quality tags, artists and other styling specifications. The Dataset already uses OA's format, so no script is needed.

Thank you