### PR TITLE
Fix trlx import

### DIFF
--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "fastlangid>=1.0.11",
     "flash_attn>=0.2.8",
     "gdown",
-    "trlx @ git+https://github.com/CarperAI/trlx.git@v0.6.0",
+    "trlx @ git+https://github.com/CarperAI/trlx.git",
     "ninja>=1.11.1",
     "nltk>=3.8.1",
     "numpy>=1.22.4",


### PR DESCRIPTION
trlx/main uses now the stable version of ray. We can switch to the main branch.