### PR TITLE
fix sponsored by text appearing after sponsors

### DIFF
--- a/website/src/components/Chat/InferencePoweredBy.tsx
+++ b/website/src/components/Chat/InferencePoweredBy.tsx
@@ -14,14 +14,14 @@ const rootProps = {
 export const InferencePoweredBy = () => {
   return (
     <Flex direction="column" justifyContent="center" borderTopWidth="1px" p="2">
+      <Flex justifyContent="center" pb="2" fontSize="sm" color="gray.500">
+        Sponsored By
+      </Flex>
       {sponsors.map((id) => (
         <Fragment key={id}>
           <TeamMember {...data.people[id]} rootProps={rootProps}></TeamMember>
         </Fragment>
       ))}
-      <Flex justifyContent="center" pb="2" fontSize="sm" color="gray.500">
-        Sponsored By
-      </Flex>
     </Flex>
   );
 };


### PR DESCRIPTION
fixes the "sponsored by" text appearing after the actual sponsors.

before:
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/11602629/235602845-a99d75d8-e0c9-4f18-a6b0-f6d42c2678a8.png">

after:
<img width="1189" alt="image" src="https://user-images.githubusercontent.com/11602629/235603071-ef2b1362-a321-4c9a-82e7-3e5be535a373.png">

let me know if any other changes are recommended =)