### PR TITLE
Remove auth_token from args stored in sampling reports

### DIFF
--- a/model/model_eval/manual/sampling_report.py
+++ b/model/model_eval/manual/sampling_report.py
@@ -316,10 +316,13 @@ def main():
     if args.n:
         prompts = prompts[: args.n]
 
+    args_dict = vars(args)
+    if "auth_token" in args_dict:
+        del args_dict["auth_token"]
     report = SamplingReport(
         model_name=model_name,
         date=datetime.utcnow().isoformat(),
-        args=vars(args),
+        args=args_dict,
         prompts=sample_prompt_continuations(
             prompts=prompts,
             model=model,


### PR DESCRIPTION
HF auth-tokens leaked into sampling reports a couple of times. This PR explicitly removes the auth_token from the args written into the sampling report.