### PR TITLE
use most recent preset sampling parameters for custom preset

### DIFF
--- a/website/src/components/Chat/ChatConfigForm.tsx
+++ b/website/src/components/Chat/ChatConfigForm.tsx
@@ -96,13 +96,19 @@ export const ChatConfigForm = memo(function ChatConfigForm() {
   const presets = modelInfos.find((model) => model.name === selectedModel)!.parameter_configs;
   const [selectedPresetName, setSelectedPresetName] = useState(() => findPresetName(presets, getValues()));
   const [lockPresetSelection, setLockPresetSelection] = useState(false);
+  const [previousPresetParameters, setPreviousPresetParameters] = useState<SamplingParameters | null>(null);
 
   const handlePresetChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       const newPresetName = e.target.value;
+
+      if (newPresetName !== customPresetName) {
+        setPreviousPresetName(newPresetName);
+      }
+
       const config =
         newPresetName === customPresetName
-          ? customPresetDefaultValue
+          ? presets.find((preset) => preset.name === previousPresetName)!.sampling_parameters
           : presets.find((preset) => preset.name === newPresetName)!.sampling_parameters;
 
       for (const [key, value] of Object.entries(config) as Array<[keyof SamplingParameters, number]>) {
@@ -110,7 +116,7 @@ export const ChatConfigForm = memo(function ChatConfigForm() {
       }
       setSelectedPresetName(newPresetName);
     },
-    [presets, setValue]
+    [presets, setValue, previousPresetName]
   );
 
   // Lock preset selection if any plugin is enabled

--- a/website/src/components/Chat/ChatConfigForm.tsx
+++ b/website/src/components/Chat/ChatConfigForm.tsx
@@ -96,28 +96,28 @@ export const ChatConfigForm = memo(function ChatConfigForm() {
   const presets = modelInfos.find((model) => model.name === selectedModel)!.parameter_configs;
   const [selectedPresetName, setSelectedPresetName] = useState(() => findPresetName(presets, getValues()));
   const [lockPresetSelection, setLockPresetSelection] = useState(false);
-  const [previousPresetParameters, setPreviousPresetParameters] = useState<SamplingParameters | null>(null);
+  const [previousPreset, setPreviousPreset] = useState(customPresetDefaultValue);
 
   const handlePresetChange = useCallback(
     (e: ChangeEvent<HTMLSelectElement>) => {
       const newPresetName = e.target.value;
-
-      if (newPresetName !== customPresetName) {
-        setPreviousPresetName(newPresetName);
-      }
-
       const config =
         newPresetName === customPresetName
-          ? presets.find((preset) => preset.name === previousPresetName)!.sampling_parameters
+          ? previousPreset
           : presets.find((preset) => preset.name === newPresetName)!.sampling_parameters;
+
+      if (newPresetName !== customPresetName) {
+        setPreviousPreset(config);
+      }
 
       for (const [key, value] of Object.entries(config) as Array<[keyof SamplingParameters, number]>) {
         setValue(key, value, { shouldDirty: true }); // force dirty so the ChatConfigSaver will update the cache
       }
       setSelectedPresetName(newPresetName);
     },
-    [presets, setValue, previousPresetName]
+    [presets, setValue, previousPreset]
   );
+
 
   // Lock preset selection if any plugin is enabled
   useEffect(() => {


### PR DESCRIPTION
This PR fixes: #2859. We now store the most recent preset used and use that as default for when you select custom preset.

Honestly, we could just get rid of the "customPresetDefaultValue" but not necessary.

My first real PR here, hopefully the first of many! Let me know if any changes are needed :)