### PR TITLE
Added files for scraping threads, and filtering original archive tweets

### DIFF
--- a/scripts/data-collection/twitter/README.md
+++ b/scripts/data-collection/twitter/README.md
@@ -24,7 +24,11 @@ conversation, or at least as a prompt with replies.
   is potentially slower speed, and less features.
 - The official Twitter API
 
-## Currently Completed Items
+## Currently trying two methods
+
+### Processing Archive Dump
+
+#### Currently Completed Items
 
 - Downloaded various archive files (both are .tar, but each have a different
   format of json compression. One used .gz, and the other.bz2). Each json file
@@ -43,7 +47,7 @@ conversation, or at least as a prompt with replies.
 - Script can output the conversation threads into a jsonl file for further
   filtering or use in models.
 
-## Main Issue
+#### Main Issue
 
 - The issue is that we can easily scrape replies, but there is no guarantee the
   original tweet is in the archive file. Furthermore, the archives are large so
@@ -57,7 +61,7 @@ conversation, or at least as a prompt with replies.
   guarantee of the quality of the tweets.
 - The tweet quality is the other major issue. We can get conversations through
   the currently made scripts, but they most likely don't match a useful
-  instruction -> fulfillment. We are trying to filter the tweets through various
+  instruction -> fulfilment. We are trying to filter the tweets through various
   means such as matching useful hashtags, or by using cosine similarity against
   known instructions.
 - The modern Twitter API has conversation_id as a field which can be a way to
@@ -65,10 +69,11 @@ conversation, or at least as a prompt with replies.
   pagination limits. The main issue with this is it seems hard to search for it
   using alternative APIs.
 
-## TODO
+#### TODO
 
 - Write scripts to filter existing conversations into useful instructions ->
-  fulfillment with hashtags or cosine similarity.
+  fulfilment with hashtags or cosine similarity. May also try rankgen, minilm,
+  or others.
 - Train model to detect if text is a suitable instruction. This could then be
   run through the conversations (or full tweet dump) to simplify the process.
   Related to issue #143.
@@ -78,3 +83,28 @@ conversation, or at least as a prompt with replies.
   in JSONL with tree / node architecture as python dicts which is acceptable I
   believe.
 - Alternatively: Store processed tweets into DB or alternative option.(Optional)
+
+### Scraping Twitter Threads
+
+#### Currently Completed Items
+
+- Wrote script to scrape tweets to get tweet threads URL by detecting replies to
+  bots to unroll the thread. We can then store these urls and scrape them to get
+  the thread content.
+- Wrote script to clean up the thread content into a list of large strings. The
+  cleaning process removes usernames, newline characters, extra spaces, and
+  other small modifications.
+
+#### Main Issues
+
+- The threads need to be run through summarization models or similar models in
+  order to turn the thread content into useful Q&A pairs similar to our other
+  datasets.
+- Threads may still need a safety filter or similar to verify if threads are
+  suitable. While scraping threads has a higher probability of coherent text,
+  the nature of twitter is filled with spam or conspiracy theories.
+
+#### TODO
+
+- Using a summarization model to turn the thread strings into a dataset of
+  useful Q&A pairs.

--- a/scripts/data-collection/twitter/filter_tweets_with_model.py
+++ b/scripts/data-collection/twitter/filter_tweets_with_model.py
@@ -1,0 +1,33 @@
+import json
+from datetime import datetime
+
+from tqdm import tqdm
+from transformers import pipeline
+
+tweet_threads_file = "twitter-conv-trees.jsonl"
+
+tweets = []
+with open(tweet_threads_file, "r") as f:
+    for line in f:
+        json_object = json.loads(line)
+        tweets.append(json_object)
+
+classifier = pipeline("text-classification", model="jmete/tweet_instruct_detect")
+
+# Create exportable conv thread.
+instruct_threads = []
+
+for i in tqdm(tweets):
+    pred = classifier(i["root"]["text"])
+    if pred[0]["label"] == "instruction":
+        i["root"]["metadata"]["instruction_score"] = pred[0]["score"]
+        instruct_threads.append(i)
+
+print(f"Found {len(instruct_threads)} Instructions")
+
+the_date = datetime.today().strftime("%Y-%m-%d")
+
+# export instruct_threads to jsonl
+with open(f"tweet-conv-trees-instructions-{the_date}.jsonl", "w") as f:
+    for item in instruct_threads:
+        f.write(json.dumps(item) + "\n")

--- a/scripts/data-collection/twitter/requirements.txt
+++ b/scripts/data-collection/twitter/requirements.txt
@@ -1,3 +1,8 @@
+beautifulsoup4==4.11.1
 numpy==1.21.5
-polars==0.15.14
+pandas==1.3.5
+polars==0.15.16
+requests==2.25.1
+snscrape==0.5.0.20230113
 tqdm==4.64.0
+transformers

--- a/scripts/data-collection/twitter/twitter_clean_threads.py
+++ b/scripts/data-collection/twitter/twitter_clean_threads.py
@@ -1,0 +1,92 @@
+# This file takes in an input the pkl file
+# that was exported from twitter_scrape_threads
+# It cleans up that dict into a list of cleaned
+# strings and removes some empty or very short threads.
+
+import json
+import pickle
+import re
+
+from tqdm import tqdm
+
+# SET UP MAIN VARIABLES
+pickle_dict_path = "processed_threads.pkl"
+output_save = "cleaned_threads.jsonl"
+
+# HELPER FUNCTIONS
+
+
+def main(pickle_dict_path, output_save):
+    """
+    Runs main script to load pickle of threads dict,
+    cleans them and then saves the result to jsonl output.
+    """
+
+    # Load pickle
+    print("Loading dict from pickle...")
+    with open(pickle_dict_path, "rb") as f:
+        threads = pickle.load(f)
+
+    print("Cleaning threads...")
+    cleaned_threads = clean_threads(threads)
+
+    print(f"Cleaned threads resulting in {len(cleaned_threads)} threads.")
+
+    print("Saving file to jsonl...")
+    # Save to jsonl file
+    with open(output_save, "w") as file:
+        for thread in cleaned_threads:
+            flines = json.dumps(thread) + "\n"
+            file.write(flines)
+
+    print("Done. Saved jsonl file to specified directory.")
+
+
+def clean_thread(thread):
+    """
+    Takes in a thread list of tweets,
+    and cleans them into a single
+    long string of text. Removes
+    twitter usernames, newline characters,
+    and formats with single space after period.
+    """
+    cleaned_stack = ""
+    # Regex for twitter usernames and newlines
+    cleaned = [re.sub(r"(@\w+|\n)", "", tweet) for tweet in thread]
+
+    # Combined cleaned strings into 1 string.
+    for c in cleaned:
+        cleaned_stack += c
+
+    # Replace double-space with single-space after period.
+    cleaned_stack = cleaned_stack.replace(".  ", ". ")
+
+    return cleaned_stack
+
+
+def clean_threads(threads):
+    """
+    Loops through dict of threads,
+    and cleans them up.
+
+    Returns list of strings
+    representing each thread as
+    one long cleaned string.
+    """
+
+    cleaned_threads = []
+
+    for tweet in tqdm(threads):
+        # Remove empty lists
+        if len(threads[tweet]) > 0:
+            c_t = clean_thread(threads[tweet])
+            # Only save threads longer than 50 characters.
+            # Helps remove some spam or image threads.
+            if len(c_t) > 50:
+                cleaned_threads.append(c_t)
+
+    return cleaned_threads
+
+
+if __name__ == "__main__":
+    main(pickle_dict_path=pickle_dict_path, output_save=output_save)

--- a/scripts/data-collection/twitter/twitter_process_json.py
+++ b/scripts/data-collection/twitter/twitter_process_json.py
@@ -9,7 +9,7 @@
 
 # This assumes data downloaded from https://archive.org/details/twitterstream
 # and that the internal .tar files are extracted locally.
-# They are large files so using something like 7Zip or WinRar might be easier
+# They are large files so using something like 7Zip or WinRar migth be easier
 # than putting all of it in scripts, but it is a possibility.
 
 # I often work in notebooks. If you encounter any issue, please reach out to let me know.

--- a/scripts/data-collection/twitter/twitter_scrape_threads.py
+++ b/scripts/data-collection/twitter/twitter_scrape_threads.py
@@ -1,0 +1,197 @@
+# This file scrapes tweets using snscrape
+# We are searching for twitter threads by finding tweets
+# where people unroll the content. We can then
+# scrape those urls for the thread content.
+
+# This script will save pkl files for the urls
+# and a dictionary of url: thread content
+# as a list of strings.
+
+# This dict should then be run through
+# the accompanying twitter_clean_threads script
+# which will remove duplicates and clean up
+# the content into large strings.
+
+import itertools
+import pickle
+import time
+
+import pandas as pd
+import requests
+import snscrape.modules.twitter as sntwitter
+from bs4 import BeautifulSoup
+from tqdm import tqdm
+
+# SET UP MAIN VARIABLES
+search_string = "from:threadreaderapp"
+num_tweets = 100000  # Only ~50-60k in practice
+processed_file_urls_pkl = "thread_url_list.pkl"
+processed_file_list_pkl = "processed_threads.pkl"
+process_buffer = 100
+
+# HELPER FUNCTIONS
+
+
+def main(search_string, num_tweets, processed_file_urls_pkl, processed_file_list_pkl, process_buffer=100):
+    """
+    Runs main script to scrape thread URLs, content,
+    and saves to pickle files.
+    """
+
+    # Get URLs
+    print("Scraping tweets and getting URLs...")
+    url_list = get_thread_urls(
+        search_string=search_string, num_tweets=num_tweets, scrape=True, load_pkl_path=processed_file_urls_pkl
+    )
+    print("Finished scraping {len(url_list)} URLs. Be aware some of these may be duplicates or empty.")
+
+    # Scrape Threads
+    print("Scraping URLs for thread content...")
+    tweet_threads = get_threads(
+        url_list=url_list, processed_file_path=processed_file_list_pkl, process_buffer=process_buffer
+    )
+    print(f"Finished scraping {len(tweet_threads)} tweet_threads.")
+
+    print("Done. Files saved to local directory.")
+
+
+def get_processed_list(processed_file_list_pkl, need_dict=False):
+    """
+    Gets processed file list if stored, if not, creates it.
+    Helps resume operation if scrape fails.
+    """
+
+    try:
+        processed_list = pickle.load(open(processed_file_list_pkl, "rb"))
+    except (OSError, IOError) as e:
+        print(e)
+        if need_dict is True:
+            processed_list = {}
+        else:
+            processed_list = []
+        pickle.dump(processed_list, open(processed_file_list_pkl, "wb"))
+    return processed_list
+
+
+def get_thread_urls(search_string, num_tweets, scrape=True, load_pkl_path=None):
+    """
+    Uses snscrape to search for a specified
+    number of tweets and returns the list
+    of unrolled thread urls.
+
+    If scrape is True, will attempt full scrape.
+    Else, it will attempt to load from pickle.
+
+    If load_pkl_path given as a string,
+    it will attempt to load url_list
+    from that path, or use it to save it.
+
+    TODO:
+    Possibly add a filter either at the scrape
+    level or df level for english only comments.
+    """
+    if scrape:
+        # Scrape tweets if scrape is set to true
+        df = pd.DataFrame(itertools.islice(sntwitter.TwitterSearchScraper(f"{search_string}").get_items(), num_tweets))
+
+        # Drop duplicates
+        df.drop_duplicates(subset=["conversationId"], inplace=True)
+
+        # Extract URLs
+        url_list = df["rawContent"].str.findall(r"https:\S+").tolist()
+
+        # Flatten list of lists into sorted list
+        url_list = sorted([*set(itertools.chain.from_iterable(url_list))])
+
+        # Save url_list to pickle
+        if load_pkl_path:
+            pickle.dump(url_list, open(load_pkl_path, "wb"))
+        else:
+            print("No pickle path given. Please save url_list manually.")
+
+    else:
+        # If scrape is false, try to load from pickle.
+        try:
+            url_list = get_processed_list(load_pkl_path)
+            if len(url_list) == 0:
+                print("WARNING: No URLs in list")
+            else:
+                print(f"Loaded url_list with {len(url_list)} urls")
+        except TypeError as e:
+            print(e)
+            print("ERROR: Please enter valid path to load pickle from.")
+
+    return url_list
+
+
+def get_thread_content(url):
+    """
+    Takes in a URL and uses BeautifulSoup to extract
+    the twitter thread as a list of human readable
+    strings. Each entity of the list was an original
+    tweet.
+
+    TODO:
+    We could consider extending the list into one
+    big string if that is better. We could
+    also maybe pre-process strings to remove
+    certain unwanted characters.
+
+    Output:
+    List of strings
+    """
+    # Based on tutorial from:
+    # https://hackersandslackers.com/scraping-urls-with-beautifulsoup/
+    headers = {
+        "Access-Control-Allow-Origin": "*",
+        "Access-Control-Allow-Methods": "GET",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "3600",
+        "User-Agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:52.0) Gecko/20100101 Firefox/52.0",
+    }
+
+    # Parse initial HTML
+    time.sleep(0.0001)
+    req = requests.get(url, headers)
+    soup = BeautifulSoup(req.content, "html.parser")
+
+    # Get tweet content tags.
+    tweet_content = soup.find_all("div", class_="content-tweet", id=lambda x: x and x.startswith("tweet_"))
+
+    # Get human readable text. This removes unwanted HTML tags.
+    tweet_content = [t.get_text() for t in tweet_content]
+
+    return tweet_content
+
+
+def get_threads(url_list, processed_file_path, process_buffer=100):
+    """
+    Loops through list of unrolled
+    tweet thread URLs and extracts
+    the tweet thread content.
+
+    Output:
+    List of list of strings.
+    """
+    threads = get_processed_list(processed_file_list_pkl, need_dict=True)
+
+    for i, u in enumerate(tqdm(url_list)):
+        if (len(u) > 0) and (u not in threads):
+            threads[u] = get_thread_content(u)
+
+            if i % process_buffer == 0:
+                pickle.dump(threads, open(processed_file_list_pkl, "wb"))
+
+    pickle.dump(threads, open(processed_file_list_pkl, "wb"))
+
+    return threads
+
+
+if __name__ == "__main__":
+    main(
+        search_string=search_string,
+        num_tweets=num_tweets,
+        processed_file_urls_pkl=processed_file_urls_pkl,
+        processed_file_list_pkl=processed_file_list_pkl,
+        process_buffer=process_buffer,
+    )


### PR DESCRIPTION
Added scripts #126  :
- Creating clean threads from scraping and processing "rolled" threads. Where people unroll a thread using a third-party. These are often higher quality tweet threads. However, they are not immediately ready for use since we will need to use another LLM to create QA pairs or instruct pairs based on them.
- Added a script to filter the original tweet threads from archive data using a custom model I trained to help remove spam and detect instructions. It is not perfect, and has not yet filtered the children of the trees since it is not detecting replies.
- Other general fixes to the readme and other elements.