### PR TITLE
Cleaned up backend plugin code: Part 1

### DIFF
--- a/inference/worker/utils.py
+++ b/inference/worker/utils.py
@@ -64,6 +64,19 @@ class TokenBuffer:
             yield from self.tokens
 
 
+def add_prefix_to_prompt(prompt: str):
+    if V2_PROMPTER_PREFIX not in prompt:
+        new_prompt = V2_PROMPTER_PREFIX + prompt
+    return new_prompt
+
+
+def get_max_input_length(worker_config: interface.WorkerConfig, plugin_used: bool):
+    max_input_length = worker_config.model_config.max_input_length
+    if plugin_used:
+        max_input_length = max_input_length - 1
+    return max_input_length
+
+
 def truncate_prompt(
     tokenizer: transformers.PreTrainedTokenizer,
     worker_config: inference.WorkerConfig,
@@ -74,28 +87,22 @@ def truncate_prompt(
     with shared_tokenizer_lock:
         ids = tokenizer.encode(prompt)
 
-    max_input_length = worker_config.model_config.max_input_length
-
-    # make room for prompter prefix
-    if plugin_used:
-        max_input_length = max_input_length - 1
+    max_input_length = get_max_input_length(worker_config, plugin_used)
 
     max_total_tokens = worker_config.model_config.max_total_length
     if len(ids) > max_input_length:
-        logger.warning(f"Prompt too long, left-truncating to {max_input_length} tokens")
+        logger.debug(f"Prompt too long, left-truncating to {max_input_length} tokens")
         ids = ids[-(max_input_length - 1) :]
         with shared_tokenizer_lock:
             prompt = tokenizer.decode(ids)
-            # If there is no prompter prefix, due to truncation, add it back.
-            if V2_PROMPTER_PREFIX not in prompt:
-                prompt = V2_PROMPTER_PREFIX + prompt
+            prompt = add_prefix_to_prompt(prompt)
 
     input_length = len(ids)
     spare = max_total_tokens - input_length - 1
     if not parameters.max_new_tokens:
         parameters.max_new_tokens = spare
     elif parameters.max_new_tokens > spare:
-        logger.warning(f"Max new tokens too high, reducing to {spare}")
+        logger.debug(f"Max new tokens too high, reducing to {spare}")
         parameters.max_new_tokens = spare
     return prompt
 
@@ -110,7 +117,7 @@ def wait_for_inference_server(http: "HttpClient", timeout: int = 600):
             if time.time() > time_limit:
                 raise
             sleep_duration = random.uniform(0, 10)
-            logger.warning(f"Inference server not ready. Retrying in {sleep_duration:.2f} seconds")
+            logger.debug(f"Inference server not ready. Retrying in {sleep_duration:.2f} seconds")
             time.sleep(sleep_duration)
         else:
             logger.info("Inference server is ready")
@@ -154,9 +161,9 @@ ws_lock = threading.Lock()
 
 def send_response(
     ws: websocket.WebSocket,
-    repsonse: inference.WorkerResponse | inference.WorkerInfo,
+    response: inference.WorkerResponse | inference.WorkerInfo,
 ):
-    msg = repsonse.json()
+    msg = response.json()
     with ws_lock:
         ws.send(msg)
 
@@ -169,7 +176,7 @@ class HttpClient(pydantic.BaseModel):
     @property
     def auth(self):
         if self.basic_auth_username and self.basic_auth_password:
-            return (self.basic_auth_username, self.basic_auth_password)
+            return self.basic_auth_username, self.basic_auth_password
         else:
             return None
 

--- a/inference/worker/utils.py
+++ b/inference/worker/utils.py
@@ -70,7 +70,7 @@ def add_prefix_to_prompt(prompt: str):
     return new_prompt
 
 
-def get_max_input_length(worker_config: interface.WorkerConfig, plugin_used: bool):
+def get_max_input_length(worker_config: inference.WorkerConfig, plugin_used: bool):
     max_input_length = worker_config.model_config.max_input_length
     if plugin_used:
         max_input_length = max_input_length - 1


### PR DESCRIPTION
From the issue #3037. I have implemented the first two suggestions which I will paste here for convenience. 
I plan on looking more of the plugin backend code to see if there is more to fix as suggested in #3037. 

* Reduce severity of logs on prompt truncation from warning
* Make [truncation code](https://github.com/LAION-AI/Open-Assistant/blob/main/inference/worker/utils.py#L67) clearer, particularly re use of if plugin_used and prefixing with prompter prefix