### PR TITLE
Add Dataset with Russian Riddles

### DIFF
--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -25,7 +25,7 @@ INSTRUCTION_DATASETS = {
     "poetry_instruction": "checkai/instruction-poems",
     "oa_stackexchange": "donfu/oa-stackexchange",
     "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset",
-    "ru_riddles_337": "0x22almostEvil/ru-riddles-377"
+    "ru_riddles_337": "0x22almostEvil/ru-riddles-377",
 }
 
 SAFETY_DATASETS = {

--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -25,6 +25,7 @@ INSTRUCTION_DATASETS = {
     "poetry_instruction": "checkai/instruction-poems",
     "oa_stackexchange": "donfu/oa-stackexchange",
     "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset",
+    "ru_riddles_337": "0x22almostEvil/ru-riddles-377"
 }
 
 SAFETY_DATASETS = {


### PR DESCRIPTION
# Dataset Card for Russian riddles with answers with 377 entries.

### Dataset Summary

Contains parquet of QnA with riddle & answer pairs.

Each row consists of

* INSTRUCTION
* RESPONSE
* SOURCE
* METADATA (json with language).

### Licensing Information

Data is scrapped from several sites. Since most of the riddles and answers are publicly available and popular, any ToS and licensing of the sites themselves is irrelevant. I reserve the right to put a public and permissive license.
Moreover, there was no licensing information on these sites, which makes sense, due to the public availability and prominence of the content they provide.

### Acknowledgements

Thanks Freddie#5762 for providing this data!
He mentioned these URLs:
- https://azbyka.ru/deti/logicheskie-i-zanimatelnye-zadachi
- https://bbf.ru/riddles/

---

Resolves https://github.com/LAION-AI/Open-Assistant/issues/3078