### PR TITLE
Add Bulgarian Reasoning Dataset

### DIFF
--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -27,6 +27,7 @@ INSTRUCTION_DATASETS = {
     "oa_stackexchange": "donfu/oa-stackexchange",
     "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset",
     "ru_riddles_337": "0x22almostEvil/ru-riddles-377",
+    "instructional_codesearchnet_python": "Nan-Do/instructional_codesearchnet_python",
     "tatoeba_mt_qna_oa": "0x22almostEvil/tatoeba-mt-qna-oa",
     "reasoning_bg_oa": "0x22almostEvil/reasoning_bg_oa",
 }

--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -28,6 +28,7 @@ INSTRUCTION_DATASETS = {
     "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset",
     "ru_riddles_337": "0x22almostEvil/ru-riddles-377",
     "tatoeba_mt_qna_oa": "0x22almostEvil/tatoeba-mt-qna-oa",
+    "0x22almostEvil/reasoning_bg_oa": "0x22almostEvil/reasoning_bg_oa",
 }
 
 SAFETY_DATASETS = {

--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -28,7 +28,7 @@ INSTRUCTION_DATASETS = {
     "stable_diffusion_instructional_dataset": "MadVoyager/stable_diffusion_instructional_dataset",
     "ru_riddles_337": "0x22almostEvil/ru-riddles-377",
     "tatoeba_mt_qna_oa": "0x22almostEvil/tatoeba-mt-qna-oa",
-    "0x22almostEvil/reasoning_bg_oa": "0x22almostEvil/reasoning_bg_oa",
+    "reasoning_bg_oa": "0x22almostEvil/reasoning_bg_oa",
 }
 
 SAFETY_DATASETS = {

--- a/data/datasets/reasoning_bg_oa/README.MD
+++ b/data/datasets/reasoning_bg_oa/README.MD
@@ -2,7 +2,7 @@
 
 ### Dataset Summary
 
-*  License: apache-2.0
+* License: apache-2.0
 * Contains Parquet of a list of instructions and answers in Bulgarian language.
 
 Each row consists of

--- a/data/datasets/reasoning_bg_oa/README.MD
+++ b/data/datasets/reasoning_bg_oa/README.MD
@@ -2,8 +2,8 @@
 
 ### Dataset Summary
 
-License: apache-2.0
-Contains Parquet of a list of instructions and answer in Bulgarian language.
+*  License: apache-2.0
+* Contains Parquet of a list of instructions and answers in Bulgarian language.
 
 Each row consists of
 
@@ -12,5 +12,7 @@ Each row consists of
 * SOURCE (reasoning_bg)
 * METADATA (json with language, url, id).
 
+### Link:
+* https://huggingface.co/datasets/0x22almostEvil/reasoning_bg_oa
 ### Original Dataset is available here:
 * https://huggingface.co/datasets/reasoning_bg

--- a/data/datasets/reasoning_bg_oa/README.MD
+++ b/data/datasets/reasoning_bg_oa/README.MD
@@ -1,0 +1,16 @@
+# Dataset Card for Bulgarian QnA reasoning with ~2.7K entries.
+
+### Dataset Summary
+
+License: apache-2.0
+Contains Parquet of a list of instructions and answer in Bulgarian language.
+
+Each row consists of
+
+* INSTRUCTION
+* RESPONSE
+* SOURCE (reasoning_bg)
+* METADATA (json with language, url, id).
+
+### Original Dataset is available here:
+* https://huggingface.co/datasets/reasoning_bg

--- a/data/datasets/reasoning_bg_oa/README.MD
+++ b/data/datasets/reasoning_bg_oa/README.MD
@@ -2,17 +2,20 @@
 
 ### Dataset Summary
 
-* License: apache-2.0
-* Contains Parquet of a list of instructions and answers in Bulgarian language.
+- License: apache-2.0
+- Contains Parquet of a list of instructions and answers in Bulgarian language.
 
 Each row consists of
 
-* INSTRUCTION
-* RESPONSE
-* SOURCE (reasoning_bg)
-* METADATA (json with language, url, id).
+- INSTRUCTION
+- RESPONSE
+- SOURCE (reasoning_bg)
+- METADATA (json with language, url, id).
 
 ### Link:
-* https://huggingface.co/datasets/0x22almostEvil/reasoning_bg_oa
+
+- https://huggingface.co/datasets/0x22almostEvil/reasoning_bg_oa
+
 ### Original Dataset is available here:
-* https://huggingface.co/datasets/reasoning_bg
+
+- https://huggingface.co/datasets/reasoning_bg

--- a/data/datasets/reasoning_bg_oa/data_process.py
+++ b/data/datasets/reasoning_bg_oa/data_process.py
@@ -18,15 +18,13 @@ class QnA:
 
 # format in QnA
 def create_qna(row):
-    instruction = row["question"] + " " + ", ".join(row["answers"]) + "?"
+    instruction = f'{row["question"]} {", ".join(row["answers"])}?'
     response = row["correct"].translate(str.maketrans("", "", "();"))
     source = "reasoning_bg"
-    url = row["url"]
-    id_str = row["id"]
     metadata = {
         "language": "bg",
-        "url": f"{url}",
-        "id": f"{id_str}",
+        "url": f'{row["url"]}',
+        "id": f'{row["id"]}',
     }
     metadata_str = json.dumps(metadata)
     return QnA(instruction, response, source, metadata_str)

--- a/data/datasets/reasoning_bg_oa/data_process.py
+++ b/data/datasets/reasoning_bg_oa/data_process.py
@@ -24,7 +24,7 @@ def create_qna(row):
     url = row["url"]
     id_str = row["id"]
     metadata = {
-        "language": f"bg",
+        "language": "bg",
         "url": f"{url}",
         "id": f"{id_str}",
     }

--- a/data/datasets/reasoning_bg_oa/data_process.py
+++ b/data/datasets/reasoning_bg_oa/data_process.py
@@ -1,0 +1,47 @@
+from datasets import load_dataset, concatenate_datasets
+from dataclasses import dataclass
+import pandas as pd
+
+import json
+
+configs = ["biology-12th", "philosophy-12th", "geography-12th", "history-12th", "history-quiz"]
+datasets = []
+
+@dataclass
+class QnA:
+    INSTRUCTION: str
+    RESPONSE: str
+    SOURCE: str
+    METADATA: str
+
+# format in QnA
+def create_qna(row):
+    instruction = row["question"] + " " + ", ".join(row["answers"]) + "?"
+    response = row["correct"].translate(str.maketrans("", "", "();"))
+    source = "reasoning_bg"
+    url = row["url"]
+    id_str = row["id"]
+    metadata = {
+        "language": f"bg",
+        "url": f"{url}",
+        "id": f"{id_str}",
+    }
+    metadata_str = json.dumps(metadata)
+    return QnA(instruction, response, source, metadata_str)
+
+# merge dataset configs into one
+for config in configs:
+    dataset = load_dataset("reasoning_bg", config, split="train")
+    datasets.append(dataset)
+
+merged_dataset = concatenate_datasets(datasets)
+
+print(merged_dataset)
+
+# convert the dataset to a pandas dataframe
+df = pd.DataFrame(merged_dataset)
+
+qna_list = df.apply(create_qna, axis=1).tolist()
+
+qna_df = pd.DataFrame(qna_list, columns=["INSTRUCTION", "RESPONSE", "SOURCE", "METADATA"])
+qna_df.to_parquet("reasoning-bg-oa.parquet", row_group_size=100, engine="pyarrow", index=False)

--- a/data/datasets/reasoning_bg_oa/data_process.py
+++ b/data/datasets/reasoning_bg_oa/data_process.py
@@ -1,11 +1,12 @@
-from datasets import load_dataset, concatenate_datasets
-from dataclasses import dataclass
-import pandas as pd
-
 import json
+from dataclasses import dataclass
+
+import pandas as pd
+from datasets import concatenate_datasets, load_dataset
 
 configs = ["biology-12th", "philosophy-12th", "geography-12th", "history-12th", "history-quiz"]
 datasets = []
+
 
 @dataclass
 class QnA:
@@ -13,6 +14,7 @@ class QnA:
     RESPONSE: str
     SOURCE: str
     METADATA: str
+
 
 # format in QnA
 def create_qna(row):
@@ -28,6 +30,7 @@ def create_qna(row):
     }
     metadata_str = json.dumps(metadata)
     return QnA(instruction, response, source, metadata_str)
+
 
 # merge dataset configs into one
 for config in configs:


### PR DESCRIPTION
Part of this: https://github.com/LAION-AI/Open-Assistant/issues/3122
https://huggingface.co/datasets/0x22almostEvil/reasoning_bg_oa
---
# Dataset Card for Bulgarian QnA reasoning with ~2.7K entries.

### Dataset Summary

Contains Parquet of a list of instructions and answer.

Each row consists of

* INSTRUCTION
* RESPONSE
* SOURCE (reasoning_bg)
* METADATA (json with language, url, id).

### Original Dataset is available here:
* https://huggingface.co/datasets/reasoning_bg