### PR TITLE
add inference worker container for amd rdna3

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -197,12 +197,12 @@ services:
       interval: 2s
       timeout: 2s
       retries: 10
-    profiles: ["inference"]
+    profiles: ["inference", "inference-amd"]
 
   inference-redis:
     image: redis
     restart: always
-    profiles: ["inference"]
+    profiles: ["inference", "inference-amd"]
     ports:
       - 6389:6379
     healthcheck:
@@ -240,7 +240,7 @@ services:
         condition: service_healthy
       inference-db:
         condition: service_healthy
-    profiles: ["inference"]
+    profiles: ["inference", "inference-amd"]
 
   inference-worker:
     build:
@@ -258,6 +258,31 @@ services:
     deploy:
       replicas: 1
     profiles: ["inference"]
+
+  inference-worker-amd:
+    devices:
+      - "/dev/kfd"
+      - "/dev/dri"
+    ipc: host
+    cap-add:
+      - SYS_PTRACE 
+    security-opt:
+      - seccomp=unconfined
+    build:
+      dockerfile: docker/inference/Dockerfile.worker-amd
+      context: .
+    image: oasst-inference-worker-amd:dev
+    environment:
+      API_KEY: "0000"
+      MODEL_CONFIG_NAME: ${MODEL_CONFIG_NAME:-distilgpt2}
+      BACKEND_URL: "ws://inference-server:8000"
+      PARALLELISM: 1
+    volumes:
+      - "./oasst-shared:/opt/inference/lib/oasst-shared"
+      - "./inference/worker:/opt/inference/worker"
+    deploy:
+      replicas: 1
+    profiles: ["inference-amd"]
 
   inference-safety:
     build:

--- a/docker/inference/Dockerfile.worker-amd
+++ b/docker/inference/Dockerfile.worker-amd
@@ -1,0 +1,38 @@
+# for now we use evshirons rocm_lab, as it already supports RDNA3. in future in might make sense to use official images from AMD
+FROM ghcr.io/evshiron/rocm_lab:rocm5.5-ub22.04-torch2.0.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
+ARG MODULE="inference"
+ARG SERVICE="worker"
+
+ARG APP_RELATIVE_PATH="${MODULE}/${SERVICE}"
+
+WORKDIR /worker
+
+RUN python3 -m venv /opt/venv
+
+COPY ./oasst-shared /tmp/oasst-shared
+RUN /opt/venv/bin/pip install /tmp/oasst-shared
+
+COPY ./${APP_RELATIVE_PATH}/requirements.txt .
+COPY ./${APP_RELATIVE_PATH}/requirements-hf.txt .
+RUN /opt/venv/bin/pip install /root/torch-*-linux_x86_64.whl /root/torchvision-*-linux_x86_64.whl
+RUN /opt/venv/bin/pip install -r requirements.txt
+RUN /opt/venv/bin/pip install -r requirements-hf.txt
+
+COPY ./${APP_RELATIVE_PATH}/*.py .
+COPY ./${APP_RELATIVE_PATH}/worker_amd_main.sh /entrypoint.sh
+
+ENV MODEL_CONFIG_NAME="distilgpt2"
+ENV NUM_SHARDS="1"
+
+# These are upper bounds for the inference server.
+ENV MAX_INPUT_LENGTH="4096"
+ENV MAX_TOTAL_TOKENS="8192"
+
+ENV BACKEND_URL="ws://localhost:8000"
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/inference/worker/worker_amd_main.sh
+++ b/inference/worker/worker_amd_main.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+export HF_HOME=${HF_HOME:-"$HOME/.cache/huggingface"}
+load_sleep=${LOAD_SLEEP:-0}
+
+mkdir -p $HF_HOME
+echo -n "$HF_TOKEN" > $HF_HOME/token
+
+export HUGGING_FACE_HUB_TOKEN=$HF_TOKEN
+
+export MODEL_CONFIG_NAME=${MODEL_CONFIG_NAME:-"OA_SFT_Pythia_12B"}
+export MODEL_ID=$(/opt/venv/bin/python3 get_model_config_prop.py model_id)
+export QUANTIZE=$(/opt/venv/bin/python3 get_model_config_prop.py quantized)
+
+# echo "Downloading model $MODEL_ID"
+#CUDA_VISIBLE_DEVICES="" /opt/venv/bin/python3 download_model_hf.py
+
+export MAX_PARALLEL_REQUESTS=${MAX_PARALLEL_REQUESTS:-1}
+
+worker_port=8300
+
+echo "Starting worker server on port $worker_port"
+/opt/venv/bin/python3 -m uvicorn --host 0.0.0.0 --port $worker_port basic_hf_server:app &
+export INFERENCE_SERVER_URL="http://localhost:$worker_port"
+
+echo "Starting worker"
+
+/opt/venv/bin/python /worker &
+
+trap "trap - SIGTERM && kill -- -$$" SIGINT SIGTERM EXIT
+
+wait -n
+
+exit $?


### PR DESCRIPTION
This PR adds a container for running inference on RDNA3 GPUs as a starting point. I tested this on my RX7900xt.