### PR TITLE
Added an argument for the correct non-ascii export.

### DIFF
--- a/backend/oasst_backend/utils/tree_export.py
+++ b/backend/oasst_backend/utils/tree_export.py
@@ -140,7 +140,7 @@ def write_trees_to_file(filename: str | None, trees: list[ExportMessageTree], us
     with out_buff as f:
         for tree in trees:
             file_data = jsonable_encoder(tree, exclude_none=True)
-            json.dump(file_data, f)
+            json.dump(file_data, f, ensure_ascii=False)
             f.write("\n")
 
 


### PR DESCRIPTION
Due to the incorrect saving of trees in a json file, the result appeared in the wrong encoding if the characters were non-ascii (for example, cyrillic).

Docs:
https://docs.python.org/3/library/json.html#basic-usage
If ensure_ascii is true (the default), the output is guaranteed to have all incoming non-ASCII characters escaped. If ensure_ascii is false, these characters will be output as-is.