### PR TITLE
Add semantics WS dataset

### DIFF
--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -31,6 +31,7 @@ INSTRUCTION_DATASETS = {
     "tatoeba_mt_qna_oa": "0x22almostEvil/tatoeba-mt-qna-oa",
     "reasoning_bg_oa": "0x22almostEvil/reasoning_bg_oa",
     "reasoning_gsm_qna_oa": "0x22almostEvil/reasoning-gsm-qna-oa",
+    "semantics_ws_qna_oa": "0x22almostEvil/semantics-ws-qna-oa",
 }
 
 SAFETY_DATASETS = {

--- a/data/datasets/semantics_ws_qna_oa/README.MD
+++ b/data/datasets/semantics_ws_qna_oa/README.MD
@@ -1,0 +1,14 @@
+# Dataset Card for semantics-ws-qna-oa with ~2K entries.
+
+### Dataset Summary
+
+License: Apache-2.0. Contains parquet of INSTRUCTION, RESPONSE, SOURCE and
+METADATA.
+
+- ### Original Datasets are available here:
+
+- https://leviants.com/multilingual-simlex999-and-wordsim353/
+
+### Paper of original Dataset:
+
+- https://arxiv.org/pdf/1508.00106v5.pdf

--- a/data/datasets/semantics_ws_qna_oa/data_process.py
+++ b/data/datasets/semantics_ws_qna_oa/data_process.py
@@ -1,0 +1,72 @@
+import json
+import random
+from dataclasses import dataclass
+
+import pandas as pd
+import random_stuff
+from datasets import load_dataset
+
+random.seed(42)
+
+
+# format to QnA
+def qna_wrapper():
+    def create_qna(row):
+        # make a random number
+        random_num = random.randint(0, 2)
+
+        # extract rows' vals
+        con_type = row["Type"]
+        lang = row["Language"]
+        word1 = row["Word1"]
+        word2 = row["Word2"]
+
+        score_percent = row["Score"]
+        # 0 - yes; 1 - 50%, 2 - no
+        if con_type == "sim":
+            instruction = random_stuff.random_dict_sim_q[lang][random_num].format(word1=word1, word2=word2)
+        else:
+            instruction = random_stuff.random_dict_rel_q[lang][random_num].format(word1=word1, word2=word2)
+        if score_percent < 3.0 and con_type == "sim":
+            response = random_stuff.random_dict_sim_a[lang][2][random_num].format(word1=word1, word2=word2)
+        elif score_percent < 3.0 and con_type == "rel":
+            response = random_stuff.random_dict_rel_a[lang][2][random_num].format(word1=word1, word2=word2)
+        elif score_percent < 7.86 and con_type == "sim":
+            response = random_stuff.random_dict_sim_a[lang][1][random_num].format(word1=word1, word2=word2)
+        elif score_percent < 7.86 and con_type == "rel":
+            response = random_stuff.random_dict_rel_a[lang][1][random_num].format(word1=word1, word2=word2)
+        elif score_percent >= 7.86 and con_type == "sim":
+            response = random_stuff.random_dict_sim_a[lang][0][random_num].format(word1=word1, word2=word2)
+        elif score_percent >= 7.86 and con_type == "rel":
+            response = random_stuff.random_dict_rel_a[lang][0][random_num].format(word1=word1, word2=word2)
+
+        source = "WordSim353"
+        metadata = {
+            "language": lang,
+            "score": score_percent,
+            "type": con_type,
+        }
+        metadata_str = json.dumps(metadata)
+        return QnA(instruction, response, source, metadata_str)
+
+    return create_qna
+
+
+@dataclass
+class QnA:
+    INSTRUCTION: str
+    RESPONSE: str
+    SOURCE: str
+    METADATA: str
+
+
+# load ws dataset
+ws_dataset = load_dataset("0x22almostEvil/ws-semantics-simnrel", split="train")
+print(ws_dataset)
+
+# convert the dataset to a pandas dataframe & apply the create_qna function to each row of the dataframe to create QnA objects
+qna_list = pd.DataFrame(ws_dataset).apply(qna_wrapper(), axis=1).tolist()
+
+# export to parquet
+qna_df = pd.DataFrame(qna_list, columns=["INSTRUCTION", "RESPONSE", "SOURCE", "METADATA"])
+qna_df.to_parquet("semantics-ws-qna-oa.parquet", row_group_size=100, engine="pyarrow", index=False)

--- a/data/datasets/semantics_ws_qna_oa/data_process.py
+++ b/data/datasets/semantics_ws_qna_oa/data_process.py
@@ -31,13 +31,13 @@ def qna_wrapper():
             response = random_stuff.random_dict_sim_a[lang][2][random_num].format(word1=word1, word2=word2)
         elif score_percent < 3.0 and con_type == "rel":
             response = random_stuff.random_dict_rel_a[lang][2][random_num].format(word1=word1, word2=word2)
-        elif score_percent < 7.86 and con_type == "sim":
+        elif score_percent < 8.25 and con_type == "sim":
             response = random_stuff.random_dict_sim_a[lang][1][random_num].format(word1=word1, word2=word2)
-        elif score_percent < 7.86 and con_type == "rel":
+        elif score_percent < 8.25 and con_type == "rel":
             response = random_stuff.random_dict_rel_a[lang][1][random_num].format(word1=word1, word2=word2)
-        elif score_percent >= 7.86 and con_type == "sim":
+        elif score_percent >= 8.25 and con_type == "sim":
             response = random_stuff.random_dict_sim_a[lang][0][random_num].format(word1=word1, word2=word2)
-        elif score_percent >= 7.86 and con_type == "rel":
+        elif score_percent >= 8.25 and con_type == "rel":
             response = random_stuff.random_dict_rel_a[lang][0][random_num].format(word1=word1, word2=word2)
 
         source = "WordSim353"

--- a/data/datasets/semantics_ws_qna_oa/data_process.py
+++ b/data/datasets/semantics_ws_qna_oa/data_process.py
@@ -31,13 +31,13 @@ def qna_wrapper():
             response = random_stuff.random_dict_sim_a[lang][2][random_num].format(word1=word1, word2=word2)
         elif score_percent < 3.0 and con_type == "rel":
             response = random_stuff.random_dict_rel_a[lang][2][random_num].format(word1=word1, word2=word2)
-        elif score_percent < 8.25 and con_type == "sim":
+        elif score_percent < 9 and con_type == "sim":
             response = random_stuff.random_dict_sim_a[lang][1][random_num].format(word1=word1, word2=word2)
-        elif score_percent < 8.25 and con_type == "rel":
+        elif score_percent < 9 and con_type == "rel":
             response = random_stuff.random_dict_rel_a[lang][1][random_num].format(word1=word1, word2=word2)
-        elif score_percent >= 8.25 and con_type == "sim":
+        elif score_percent >= 9 and con_type == "sim":
             response = random_stuff.random_dict_sim_a[lang][0][random_num].format(word1=word1, word2=word2)
-        elif score_percent >= 8.25 and con_type == "rel":
+        elif score_percent >= 9 and con_type == "rel":
             response = random_stuff.random_dict_rel_a[lang][0][random_num].format(word1=word1, word2=word2)
 
         source = "WordSim353"

--- a/data/datasets/semantics_ws_qna_oa/random_stuff.py
+++ b/data/datasets/semantics_ws_qna_oa/random_stuff.py
@@ -1,0 +1,249 @@
+# random lists for ws
+
+# sim_questions
+random_list_sim_en_q = [
+    "Are the words {word1} and {word2} synonymous?",
+    'Are "{word1}" and "{word2}" synonymous?',
+    "Is there any connection between the words '{word1}' and '{word2}'?",
+]
+random_list_sim_ru_q = [
+    "Являются ли слова {word1} и {word2} синонимами?",
+    'Синонимы ли "{word1}" и "{word2}"?',
+    "Есть ли какая-то связь между словами '{word1}' и '{word2}'?",
+]
+random_list_sim_de_q = [
+    "Sind die Wörter {word1} und {word2} Synonyme?",
+    'Sind "{word1}" und "{word2}" Synonyme?',
+    "Gibt es eine Verbindung zwischen den Wörtern '{word1}' und '{word2}'?",
+]
+random_list_sim_it_q = [
+    "Le parole {word1} e {word2} sono sinonimi?",
+    '"{word1}" e "{word2}" sono sinonimi?',
+    "C'è qualche connessione tra le parole '{word1}' e '{word2}'?",
+]
+
+# sim_answers:
+
+# yes;
+random_list_sim_en_a_y = [
+    "Yes, {word1} and {word2} are synonymous.",
+    '"{word1}" and "{word2}" are synonymous.',
+    "Yes. The type of connection between words '{word1}' and '{word2}' is synonymous.",
+]
+random_list_sim_ru_a_y = [
+    "Да, {word1} и {word2} являются синонимами.",
+    '"{word1}" и "{word2}" являются синонимами.',
+    "Да. Тип связи между словами '{word1}' и '{word2}' синонимичен.",
+]
+random_list_sim_de_a_y = [
+    "Ja, {word1} und {word2} sind Synonyme.",
+    '"{word1}" und "{word2}" sind Synonyme.',
+    "Ja. Der Typ der Verbindung zwischen den Wörtern '{word1}' und '{word2}' ist synonym.",
+]
+
+random_list_sim_it_a_y = [
+    "Sì, {word1} e {word2} sono sinonimi.",
+    '"{word1}" e "{word2}" sono sinonimi.',
+    "Sì. Il tipo di connessione tra le parole '{word1}' e '{word2}' è sinonimico.",
+]
+
+# 50%;
+random_list_sim_en_a_50 = [
+    "There is some connection between the words {word1} and {word2}, but they are not full-fledged synonyms.",
+    'No, "{word1}" and "{word2}" are not synonymous, but they do have a slight semantic similarity.',
+    "Yes, there is some connection between '{word1}' and '{word2}', but they cannot be called synonyms.",
+]
+random_list_sim_ru_a_50 = [
+    "Между словами {word1} и {word2} есть некая связь, но они не являются полноценными синонимами.",
+    'Нет, "{word1}" и "{word2}" не синонимы, но у них есть небольшое семантическое сходство.',
+    "Да, между '{word1}' и '{word2}' есть некоторая связь, но их нельзя назвать синонимами.",
+]
+random_list_sim_de_a_50 = [
+    "Es gibt eine gewisse Verbindung zwischen den Wörtern {word1} und {word2}, aber sie sind keine vollwertigen Synonyme.",
+    'Nein, "{word1}" und "{word2}" sind keine Synonyme, aber sie haben eine leichte semantische Ähnlichkeit.',
+    "Ja, es gibt eine Verbindung zwischen '{word1}' und '{word2}', aber man kann sie nicht als Synonyme bezeichnen.",
+]
+random_list_sim_it_a_50 = [
+    "C'è una certa connessione tra le parole {word1} e {word2}, ma non sono sinonimi completi.",
+    'No, "{word1}" e "{word2}" non sono sinonimi, ma hanno una leggera somiglianza semantica.',
+    "Sì, c'è una connessione tra le parole '{word1}' e '{word2}', ma non possono essere chiamate sinonimi.",
+]
+
+# no;
+random_list_sim_en_a_n = [
+    "No, the words {word1} and {word2} are not synonyms.",
+    'No, "{word1}" and "{word2}" are not synonymous.',
+    "There is no direct connection between '{word1}' and '{word2}'.",
+]
+random_list_sim_ru_a_n = [
+    "Нет, слова {word1} и {word2} не являются синонимами.",
+    'Нет, "{word1}" и "{word2}" не синонимы.',
+    "Между словами '{word1}' и '{word2}' нет прямой связи.",
+]
+random_list_sim_de_a_n = [
+    "Nein, die Wörter {word1} und {word2} sind keine Synonyme.",
+    'Nein, "{word1}" und "{word2}" sind keine Synonyme.',
+    "Es besteht keine direkte Verbindung zwischen '{word1}' und '{word2}'.",
+]
+
+random_list_sim_it_a_n = [
+    "No, le parole {word1} e {word2} non sono sinonimi.",
+    'No, "{word1}" e "{word2}" non sono sinonimi.',
+    "Non c'è una connessione diretta tra '{word1}' e '{word2}'.",
+]
+
+# rel_questions:
+random_list_rel_en_q = [
+    "Are there any associations between the words {word1} and {word2}?",
+    'Are the words "{word1}" and "{word2}" related?',
+    "What is the association between '{word1}' and '{word2}'?",
+]
+random_list_rel_ru_q = [
+    "Есть ли ассоциации между словами {word1} и {word2}?",
+    'Связаны ли как-то слова "{word1}" и "{word2}"?',
+    "Насколько ассоциативно значение слов '{word1}' и '{word2}'?",
+]
+random_list_rel_de_q = [
+    "Gibt es Assoziationen zwischen den Wörtern {word1} und {word2}?",
+    'Sind die Wörter "{word1}" und "{word2}" miteinander verwandt?',
+    "Welche Verbindung besteht zwischen '{word1}' und '{word2}'?",
+]
+random_list_rel_it_q = [
+    "Ci sono associazioni tra le parole {word1} e {word2}?",
+    'Esiste una relazione tra le coppie di parole "{word1}" e "{word2}"?',
+    "Qual è l'associazione tra '{word1}' e '{word2}'?",
+]
+
+# rel_answers:
+
+# yes;
+random_list_rel_en_a_y = [
+    "Yes, there is an association between the words {word1} and {word2}.",
+    'Yes, there is an associative relationship between the words "{word1}" and "{word2}".',
+    "There is a direct associative link between the words '{word1}' and '{word2}'.",
+]
+random_list_rel_ru_a_y = [
+    "Да, между словами {word1} и {word2} прослеживается ассоциация.",
+    'Да, между словами "{word1}" и "{word2}" есть ассоциативная связь.',
+    "Есть прямая ассоциативная связь между словами '{word1}' и '{word2}'",
+]
+random_list_rel_de_a_y = [
+    "Ja, es gibt eine Assoziation zwischen den Wörtern {word1} und {word2}.",
+    'Ja, es besteht eine assoziative Beziehung zwischen den Wörtern "{word1}" und "{word2}".',
+    "Es gibt eine direkte assoziative Verbindung zwischen den Wörtern '{word1}' und '{word2}'.",
+]
+random_list_rel_it_a_y = [
+    "Sì, c'è un'associazione tra le parole {word1} e {word2}.",
+    'Sì, c\'è una relazione associativa tra le parole "{word1}" e "{word2}".',
+    "C'è un legame associativo diretto tra le parole '{word1}' e '{word2}'.",
+]
+
+# 50%;
+random_list_rel_en_a_50 = [
+    "There is a slight association between the words {word1} and {word2}.",
+    'There is an indirect semantic similarity between the words "{word1}" and "{word2}".',
+    "There is some association between the words '{word1}' and '{word2}'.",
+]
+random_list_rel_ru_a_50 = [
+    "Есть небольшая ассоциация между словами {word1} и {word2}.",
+    'Между словами "{word1}" и "{word2}" есть непрямое семантическое сходство.',
+    "Есть некоторая ассоциативность между словами '{word1}' и '{word2}'.",
+]
+random_list_rel_de_a_50 = [
+    "Es besteht eine leichte Assoziation zwischen den Wörtern {word1} und {word2}.",
+    'Es gibt eine indirekte semantische Ähnlichkeit zwischen den Wörtern "{word1}" und "{word2}".',
+    "Es besteht eine gewisse Verbindung zwischen den Wörtern '{word1}' und '{word2}'.",
+]
+random_list_rel_it_a_50 = [
+    "C'è una leggera associazione tra le parole {word1} e {word2}.",
+    'C\'è una somiglianza semantica indiretta tra le parole "{word1}" e "{word2}".',
+    "C'è una certa associazione tra le parole '{word1}' e '{word2}'.",
+]
+
+# no;
+random_list_rel_en_a_n = [
+    "No, there is no associative relationship between the words {word1} and {word2}",
+    'No, the words "{word1}" and "{word2}" are not related in any direct associative way.',
+    "There is no direct associative relationship between '{word1}' and '{word2}'.",
+]
+random_list_rel_ru_a_n = [
+    "Нет, между словами {word1} и {word2} нет ассоциативной связи",
+    'Нет, слова "{word1}" и "{word2}" не связаны каким-либо прямым ассоциативным образом.',
+    "Нет никакой прямой ассоциативной связи между '{word1}' и '{word2}'.",
+]
+random_list_rel_de_a_n = [
+    "Nein, es besteht keine Assoziationsbeziehung zwischen den Wörtern {word1} und {word2}.",
+    'Nein, die Wörter "{word1}" und "{word2}" sind nicht in direkter assoziativer Weise miteinander verbunden.',
+    "Es besteht keine direkte assoziative Beziehung zwischen '{word1}' und '{word2}'.",
+]
+random_list_rel_it_a_n = [
+    "No, non c'è alcuna relazione associativa tra le parole {word1} e {word2}.",
+    'No, le parole "{word1}" e "{word2}" non sono correlate in alcun modo associativo diretto.',
+    "Non c'è una diretta relazione associativa tra '{word1}' e '{word2}'.",
+]
+
+# easy-way to call stuff above
+
+# dicts of q
+# sim
+random_dict_sim_q = {
+    "en": random_list_sim_en_q,
+    "ru": random_list_sim_ru_q,
+    "de": random_list_sim_de_q,
+    "it": random_list_sim_it_q,
+}
+# rel
+random_dict_rel_q = {
+    "en": random_list_rel_en_q,
+    "ru": random_list_rel_ru_q,
+    "de": random_list_rel_de_q,
+    "it": random_list_rel_it_q,
+}
+
+# dicts for a
+# sim - random_dict_sim_a["ru"][0]  # returns the list of "yes" answers for Russian
+random_dict_sim_a = {
+    "en": {
+        0: random_list_sim_en_a_y,
+        1: random_list_sim_en_a_50,
+        2: random_list_sim_en_a_n,
+    },
+    "ru": {
+        0: random_list_sim_ru_a_y,
+        1: random_list_sim_ru_a_50,
+        2: random_list_sim_ru_a_n,
+    },
+    "de": {
+        0: random_list_sim_de_a_y,
+        1: random_list_sim_de_a_50,
+        2: random_list_sim_de_a_n,
+    },
+    "it": {
+        0: random_list_sim_it_a_y,
+        1: random_list_sim_it_a_50,
+        2: random_list_sim_it_a_n,
+    },
+}
+# rel
+random_dict_rel_a = {
+    "en": {
+        0: random_list_rel_en_a_y,
+        1: random_list_rel_en_a_50,
+        2: random_list_rel_en_a_n,
+    },
+    "ru": {
+        0: random_list_rel_ru_a_y,
+        1: random_list_rel_ru_a_50,
+        2: random_list_rel_ru_a_n,
+    },
+    "de": {
+        0: random_list_rel_de_a_y,
+        1: random_list_rel_de_a_50,
+        2: random_list_rel_de_a_n,
+    },
+    "it": {
+        0: random_list_rel_it_a_y,
+        1: random_list_rel_it_a_50,
+        2: random_list_rel_it_a_n,
+    },
+}


### PR DESCRIPTION
Dataset Card for semantics-ws-qna-oa with ~2K entries.
Dataset Summary
License: Apache-2.0. Contains parquet of INSTRUCTION, RESPONSE, SOURCE and METADATA.

Original Datasets are available here:
https://leviants.com/multilingual-simlex999-and-wordsim353/

Paper of original Dataset:
https://arxiv.org/pdf/1508.00106v5.pdf

HF link:
https://huggingface.co/datasets/0x22almostEvil/semantics-ws-qna-oa