### PR TITLE
Add missing build-backend-worker dependency to deploy-to-node

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -94,6 +94,7 @@ jobs:
   deploy-to-node:
     needs:
       - build-backend
+      - build-backend-worker
       - build-web
       - build-bot
       - build-inference-server


### PR DESCRIPTION
The backend-worker container needs to be built before deploy-to-node runs.