### PR TITLE
Add missing parameters in model_chat.py

### DIFF
--- a/model/model_training/tools/model_chat.py
+++ b/model/model_training/tools/model_chat.py
@@ -86,7 +86,7 @@ def talk(human_input: str, history: List[Tuple[str, str]], sep_token: str, prefi
     return prefix
 
 
-def process_output(output):
+def process_output(output, method, bot_name):
     if method == "v2":
         answer = output.split(QA_SPECIAL_TOKENS["Answer"])[-1]
         answer = answer.split("</s>")[0].replace("<|endoftext|>", "").lstrip().split(QA_SPECIAL_TOKENS["Answer"])[0]


### PR DESCRIPTION
In [model/model_training/tools/model_chat.py](https://github.com/LAION-AI/Open-Assistant/blob/main/model/model_training/tools/model_chat.py),  `process_output` function supposed to have a `method` and `bot_name` parameters 

## Function call line
https://github.com/LAION-AI/Open-Assistant/blob/750c59df4ac2b6976f87a695ea3bc227200997e5/model/model_training/tools/model_chat.py#L144

## Definition
https://github.com/LAION-AI/Open-Assistant/blob/750c59df4ac2b6976f87a695ea3bc227200997e5/model/model_training/tools/model_chat.py#L89-L102

