### PR TITLE
Support reward model training from user feedback

### DIFF
--- a/model/model_training/configs/config_rm.yaml
+++ b/model/model_training/configs/config_rm.yaml
@@ -176,3 +176,23 @@ oasst-rm-1-pythia-1.4b:
   num_train_epochs: 2
   eval_steps: 500
   save_steps: 1000
+
+test-entailment:
+  entailment: true
+  loss_fn: BCELoss
+  model_name: EleutherAI/pythia-410m-deduped
+  cache_dir: .cache
+  datasets:
+    - oasst_chat_scoring:
+        input_file_path: 2023-05-19_chats_scored.jsonl.gz
+        val_split: 0.05
+  gradient_accumulation_steps: 4
+  per_device_train_batch_size: 4
+  per_device_eval_batch_size: 5
+  num_train_epochs: 2
+  eval_steps: 10
+  save_steps: 1000
+  use_system_tag: false
+  system_property_dropout: 0.5
+  system_add_length: false
+  metrics: ["accuracy"]

--- a/model/model_training/custom_datasets/__init__.py
+++ b/model/model_training/custom_datasets/__init__.py
@@ -6,7 +6,7 @@ from typing import Optional
 import numpy as np
 from model_training.custom_datasets.extra_rm_datasets import load_anthropic_rlhf, load_hellaswag, load_shp
 from model_training.custom_datasets.instruction import INSTRUCTION_DATASETS, InstructionDataset
-from model_training.custom_datasets.oasst_dataset import load_oasst_export
+from model_training.custom_datasets.oasst_dataset import load_oasst_export, load_oasst_response_export
 from model_training.custom_datasets.pretrain_datasets import RedPajama
 from model_training.custom_datasets.prompt_dialogue import Gpt4All, load_oig_file
 from model_training.custom_datasets.qa_datasets import (
@@ -61,6 +61,7 @@ RL_DATASETS = [
 
 RM_DATASETS = [
     "oasst_export",
+    "oasst_chat_scoring",
     "augment_oasst",
     "anthropic_rlhf",
     "hf_summary",
@@ -156,6 +157,8 @@ def get_one_dataset(
         assert mode == "rm"
         train = AugmentedOA(data_path + "/" + kwargs["input_file_path"], split="train")
         eval = AugmentedOA(data_path + "/" + kwargs["input_file_path"], split="val")
+    elif dataset_name == "oasst_chat_scoring":
+        train, eval = load_oasst_response_export(data_path=data_path, val_split=val_split, mode=mode, **kwargs)
     elif dataset_name == "oig_file":
         train, eval = load_oig_file(val_split=val_split, **kwargs)
     elif dataset_name == "anthropic_rlhf":

--- a/model/model_training/utils/utils.py
+++ b/model/model_training/utils/utils.py
@@ -16,9 +16,10 @@ from model_training.models import freeze_top_n_layers, get_specific_model
 from model_training.models.patching import patch_model
 from model_training.models.reward_model import GPTNeoXRewardModel
 from sklearn.model_selection import train_test_split
-from tokenizers import pre_tokenizers
 from torch.utils.data import ConcatDataset, Dataset, Subset
 from torch.utils.data.distributed import DistributedSampler
+
+from tokenizers import pre_tokenizers
 
 from .losses import CrossEntropyLoss, PolyLoss, RMCLSLoss, RMLoss
 
@@ -383,6 +384,8 @@ def get_loss(loss, poly_eps: float = 1.0, score_l2_reg: float = 0.001):
         return RMLoss(beta=score_l2_reg)
     elif loss == "RMCLSLoss":
         return RMCLSLoss()
+    elif loss == "BCELoss":
+        return torch.nn.BCEWithLogitsLoss()
     else:
         raise ValueError(f"Loss {loss} not supported")
 

--- a/oasst-data/oasst_data/schemas.py
+++ b/oasst-data/oasst_data/schemas.py
@@ -17,6 +17,7 @@ LabelValues = dict[str, LabelAvgValue]
 class ExportMessageEvent(BaseModel):
     type: str
     user_id: str | None
+    score: int | None
 
 
 class ExportMessageEventEmoji(ExportMessageEvent):


### PR DESCRIPTION
Working code for training reward model to distinguish whether the response is good (1) or bad (0) using binary crossentropy loss

config setup requires 2 change in parameters : loss_fn and entailment
```
test-entailment:
  entailment: true
  loss_fn: BCELoss
  model_name: EleutherAI/pythia-410m-deduped
  cache_dir: .cache
  datasets:
    - oasst_chat_scoring:
        input_file_path: 2023-05-28_chats_scored.jsonl.gz
        val_split: 0.05
  gradient_accumulation_steps: 48
  per_device_train_batch_size: 1
  per_device_eval_batch_size: 2
  num_train_epochs: 2
  eval_steps: 500
  max_length: 1280
  save_steps: 1000
  use_system_tag: false
  system_property_dropout: 0.5
  system_add_length: false
  metrics: ["accuracy"]
```
note kendall correlation is not supported due to the nature of the learning objective

the merged datasets from 05-19 and 05-27 (recovered chat), can be found here: (OpenAssistant/oasst-chat-export-merged)[https://huggingface.co/datasets/OpenAssistant/oasst-chat-export-merged]

Experiment results can be found here : https://wandb.ai/open-assistant/reward-model by using the entailment tag

Currently using a pythia-410m model we could reach accuracy of > 85%. 

I have checked both original datasets contain no shared dataset and are quite balance in labels, the statistic count for each labels are shown as below:

1 : 88,555
0 : 73,513



