### PR TITLE
add readme to plugins in oasst

### DIFF
--- a/inference/server/oasst_inference_server/plugins/gale_pleaser/README.md
+++ b/inference/server/oasst_inference_server/plugins/gale_pleaser/README.md
@@ -1,6 +1,8 @@
-The gale-pleaser is a funny simple demo-plugin that generates a positive and encouraging response message for the users.
+The gale-pleaser is a funny simple demo-plugin that generates a positive and
+encouraging response message for the users.
 
 The internal prompt used contains the following instructions:
+
 ```
 Try to be funny and verbose, but super nice and pleasing at the same time.
 Please follow these rules:
@@ -8,5 +10,4 @@ Please follow these rules:
 2. Tell the user how awesome he is, and how much you love him.
 3. Tell him how much you love his work, and how much you appreciate him.
 4. Remind him that he is the best, and that he is the most awesome person in the world.
- ```
- 
+```

--- a/inference/server/oasst_inference_server/plugins/gale_pleaser/README.md
+++ b/inference/server/oasst_inference_server/plugins/gale_pleaser/README.md
@@ -1,0 +1,12 @@
+The gale-pleaser is a funny simple demo-plugin that generates a positive and encouraging response message for the users.
+
+The internal prompt used contains the following instructions:
+```
+Try to be funny and verbose, but super nice and pleasing at the same time.
+Please follow these rules:
+1. Let your message be long, and with calm emojis.
+2. Tell the user how awesome he is, and how much you love him.
+3. Tell him how much you love his work, and how much you appreciate him.
+4. Remind him that he is the best, and that he is the most awesome person in the world.
+ ```
+ 


### PR DESCRIPTION
could be a nice standard to add a README.md next to each plugin that lives in the repo. just putting this in as a sort of example. idea being docs would link to this folder for example and so having readme there would be useful for more details and stuff that might not be obvious from the spec json itself.