### PR TITLE
Update the disclaimer warning with plugin access information

### DIFF
--- a/website/public/locales/en/chat.json
+++ b/website/public/locales/en/chat.json
@@ -48,7 +48,7 @@
   "verified_plugin_description": "This plugin has been verified by the Open Assistant team.",
   "view_plugin": "View Plugin",
   "visible_hidden": "Visible & hidden",
-  "warning": "This Assistant is a demonstration version with limited internet access. It may generate incorrect or misleading information. It is not suitable for important use cases or for giving advice.",
+  "warning": "This Assistant is a demonstration without full internet access. It may generate incorrect or misleading information. It is not suitable for important use cases or giving advice.",
   "you_are_logged_in": "You are logged in to the chat service",
   "your_chats": "Your Chats",
   "save_preset": "Save this preset",

--- a/website/public/locales/en/chat.json
+++ b/website/public/locales/en/chat.json
@@ -48,7 +48,7 @@
   "verified_plugin_description": "This plugin has been verified by the Open Assistant team.",
   "view_plugin": "View Plugin",
   "visible_hidden": "Visible & hidden",
-  "warning": "This Assistant is a demonstration version that does not have internet access. It may generate incorrect or misleading information. It is not suitable for important use cases or for giving advice.",
+  "warning": "This Assistant is a demonstration version with limited internet access. It may generate incorrect or misleading information. It is not suitable for important use cases or for giving advice.",
   "you_are_logged_in": "You are logged in to the chat service",
   "your_chats": "Your Chats",
   "save_preset": "Save this preset",


### PR DESCRIPTION
The models now have limited internet access and thus the previous disclaimer is inaccurate.