### PR TITLE
fix CustomPromptPipeline

### DIFF
--- a/model/model_training/utils/ppo_utils.py
+++ b/model/model_training/utils/ppo_utils.py
@@ -577,7 +577,7 @@ class CustomPromptPipeline(BasePipeline):
     Tokenizes prompts, unless they are already tokenized, and truncates them to `max_prompt_length` from the right
     """
 
-    def __init__(self, prompts: List[str], max_prompt_length: int, tokenizer: PreTrainedTokenizer):
+    def __init__(self, prompts: List[str], max_prompt_length: int, tokenizer: PreTrainedTokenizer, **kwargs):
         super().__init__()
 
         if max_prompt_length < 16:  # sanity check


### PR DESCRIPTION
https://github.com/LAION-AI/Open-Assistant/blob/70f30a6d6f23551a5139711f84fd58eefc4fe288/model/model_training/utils/ppo_utils.py#L574-L582

Request to add **kwargs to CustomPromptPipeline init method to be flexible with trlx library version

The following error occurred while trying RLHF using trainer_rl.py
![image](https://github.com/LAION-AI/Open-Assistant/assets/85441953/65da3d61-a6aa-4680-b8e0-1b1eae608fe2)

As a result of analyzing the cause, a parameter called add_special_tokens was added to the get_pipeline function in trlx.py of the main version of the trlx library.
![image](https://github.com/LAION-AI/Open-Assistant/assets/85441953/3a2f6f50-0eb6-4d46-86e8-0bb78bb39785)
https://github.com/CarperAI/trlx/blob/355c9741f2e606de796f5c6f9b682f7dd00f97c5/trlx/trlx.py#L122-L125C6

However, the parameter does not yet exist in the CustomPromptPipeline class of the main branch of OA.

There is an add_speical_token parameter in the get_pipeline method of trlx.py in the main branch of trlx, but that parameter does not exist in the v.0.6.0 version.

So I think we need to add **kwarg to prevent errors in different versions.

The add_speical_tokens parameter is true only when the architecture of the model is a seq2seq model, but previous OA versions always set it to False, so adding it as **kwarg seems to be okay for now.
