### PR TITLE
Add "servers" attribute to openapi spec of demo plug-ins

### DIFF
--- a/inference/server/oasst_inference_server/plugins/gale_pleaser/main.py
+++ b/inference/server/oasst_inference_server/plugins/gale_pleaser/main.py
@@ -43,7 +43,7 @@ async def api_ai_plugin(request: Request):
 @app.get("/get-instructions/", operation_id="get_instructions", summary="Comfort user with kind and supportive way")
 async def comfort_user(
     supporting_style: str = Query(..., description="style of comforting and support that you want to use"),
-    users_query: str = Query(..., description="what user wrote to you"),
+    users_query: str = Query(..., description="what the user wrote to you"),
 ):
     llm_prompt = f"""COMFORTING_INSTRUCTIONS: You need to make user feel awesome, compliment them a lot! Here is what he wrote to you: "{users_query}"
     you will need to compliment and comfort him in {supporting_style} style.
@@ -68,6 +68,7 @@ def custom_openapi():
         title="Super nice and pleasing Assistant",
         version="0.1",
         routes=app.routes,
+        servers=[{"url": "/plugins/gale_pleaser"}],
     )
     openapi_schema["tags"] = [
         {

--- a/inference/server/oasst_inference_server/plugins/gale_roaster/main.py
+++ b/inference/server/oasst_inference_server/plugins/gale_roaster/main.py
@@ -51,6 +51,7 @@ def custom_openapi():
         title="Professional Roaster mockery",
         version="0.1",
         routes=app.routes,
+        servers=[{"url": "/plugins/gale_roaster"}],
     )
     openapi_schema["tags"] = [
         {

--- a/inference/server/oasst_inference_server/plugins/web_retriever/main.py
+++ b/inference/server/oasst_inference_server/plugins/web_retriever/main.py
@@ -245,11 +245,12 @@ def custom_openapi():
         title="Web Retriever",
         version="0.1",
         routes=app.routes,
+        servers=[{"url": "/plugins/web_retriever"}],
     )
     openapi_schema["tags"] = [
         {
             "name": "web-retriever",
-            "description": "",
+            "description": "Use this plugin to retrieve web page and pdf content",
         },
     ]
     openapi_schema.pop("components", None)
@@ -264,7 +265,6 @@ if __name__ == "__main__":
     # simple built-in test
     import asyncio
 
-    # url = "https://arxiv.org/abs/2304.07327"
-    url = "https://arxiv.org/pdf/2304.07327"
+    url = "https://huggingface.co/OpenAssistant/oasst-sft-1-pythia-12b"
     x = asyncio.run(get_url_content(url))
     print(x.status_code, x.body)


### PR DESCRIPTION
Leaving out the servers attribute as Dragan suggested did not work. This restores the servers attribute, plugins now work with the built-in swagger ui.