### PR TITLE
fix: batch or partition DB access and commits for user streak updation

### DIFF
--- a/backend/oasst_backend/config.py
+++ b/backend/oasst_backend/config.py
@@ -277,6 +277,8 @@ class Settings(BaseSettings):
     DISCORD_API_KEY: str | None = None
     DISCORD_CHANNEL_ID: str | None = None
 
+    USER_STREAK_BATCH_SIZE: int = 1000
+
     class Config:
         env_file = ".env"
         env_file_encoding = "utf-8"


### PR DESCRIPTION
Partitioned the access to list of users  and updated the same
Tested on a small batch of Fake users

What is the best USER_STREAK_BATCH_SIZE ?
