### PR TITLE
Modify: Default Height on Chat List

### DIFF
--- a/website/src/components/Chat/ChatListBase.tsx
+++ b/website/src/components/Chat/ChatListBase.tsx
@@ -12,7 +12,11 @@ import { CreateChatButton } from "./CreateChatButton";
 import { InferencePoweredBy } from "./InferencePoweredBy";
 import { ChatListViewSelection, useListChatPagination } from "./useListChatPagination";
 
-export const ChatListBase = memo(function ChatListBase({ allowViews, ...props }: CardProps & { allowViews?: boolean }) {
+export const ChatListBase = memo(function ChatListBase({
+  allowViews,
+  minHeight,
+  ...props
+}: CardProps & { allowViews?: boolean; minHeight?: string }) {
   const [view, setView] = useState<ChatListViewSelection>("visible");
   const { loadMoreRef, responses, mutateChatResponses } = useListChatPagination(view);
   const chats = responses?.flatMap((response) => response.chats) || [];
@@ -92,12 +96,7 @@ export const ChatListBase = memo(function ChatListBase({ allowViews, ...props }:
           <ChatViewSelection w={["full", "auto"]} onChange={(e) => setView(e.target.value as ChatListViewSelection)} />
         )}
       </Flex>
-      <SimpleBar
-        style={{ padding: "8px", maxHeight: "100%", height: "100%", minHeight: "0" }}
-        classNames={{
-          contentEl: "space-y-2 flex flex-col overflow-y-auto",
-        }}
-      >
+      <SimpleBar style={{ padding: "8px", height: "100%", minHeight: chats.length && minHeight ? minHeight : "0" }}>
         {chats.map((chat) => (
           <ChatListItem
             key={chat.id}

--- a/website/src/pages/chat/index.tsx
+++ b/website/src/pages/chat/index.tsx
@@ -27,6 +27,7 @@ const ChatList = () => {
           bg: "gray.700",
         }}
         shadow="md"
+        minHeight="300px"
       />
     </>
   );


### PR DESCRIPTION
Fixes: #3305 

/chat
I thought that it was intuitive to set height to of chat list to zero when there is no chats on the list. 
But, as soon as a chat has been added to the list, I have set the default height.

/chat/{id}
I thought it is counter-intuitive to set default height to zero on this page. I have set default height to hundered percent.

![ezgif com-video-to-gif](https://github.com/LAION-AI/Open-Assistant/assets/61619422/66193754-36fb-42da-bc38-38e4abc7a86c)

