### PR TITLE
Add return value in prepare_tensor

### DIFF
--- a/model/model_training/utils/utils_rl.py
+++ b/model/model_training/utils/utils_rl.py
@@ -5,3 +5,4 @@ from tritonclient.utils import np_to_triton_dtype
 def prepare_tensor(name: str, input):
     t = client_util.InferInput(name, input.shape, np_to_triton_dtype(input.dtype))
     t.set_data_from_numpy(input)
+    return t


### PR DESCRIPTION
There is no return value in `prepare_tensor`

https://github.com/LAION-AI/Open-Assistant/blob/0fcf3e08fe62295d4696e590005b0f33383342ea/model/model_training/utils/utils_rl.py#L5-L7

so it will cause None type error while RLHF training

https://github.com/LAION-AI/Open-Assistant/blob/0fcf3e08fe62295d4696e590005b0f33383342ea/model/model_training/utils/ppo_utils.py#L553-L561

https://github.com/LAION-AI/Open-Assistant/blob/0fcf3e08fe62295d4696e590005b0f33383342ea/model/model_training/trainer_rl.py#L93-L99