### PR TITLE
Fix out of bound index in chat paging

### DIFF
--- a/website/src/components/Chat/ChatConversationTree.tsx
+++ b/website/src/components/Chat/ChatConversationTree.tsx
@@ -56,7 +56,7 @@ const TreeChildren = ({
 } & StrictOmit<ChatMessageEntryProps, "message" | "canRetry">) => {
   const sortedTrees = useMemo(() => trees.sort((a, b) => Date.parse(a.created_at) - Date.parse(b.created_at)), [trees]);
   const [index, setIndex] = useState(0);
-  const currentTree = sortedTrees[index];
+  const currentTree = sortedTrees[Math.min(index, trees.length - 1)];
 
   const length = trees.length;
   const hasSibling = length > 1;


### PR DESCRIPTION
closes #3478 

`useIsomorphicLayoutEffect` wasn't being called until the first render meaning if the index could be out of bounds if the parent message was changed to a tree with less siblings than the previous. A simple min against the number of siblings prevents the out of bound index and then `useIsomorphicLayoutEffect ` is called the next frame, setting the correct thread.