### PR TITLE
Add: option to view plaintext chat message. Issue/2508

### DIFF
--- a/website/public/locales/en/common.json
+++ b/website/public/locales/en/common.json
@@ -36,6 +36,7 @@
   "no": "No",
   "output": "Output",
   "parameters": "Parameters",
+  "plain_text": "Plain Text",
   "privacy_policy": "Privacy Policy",
   "prompt": "Prompt",
   "report_a_bug": "Report a Bug",

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -94,6 +94,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
   const [isEditing, setIsEditing] = useBoolean(false);
   const [isPlainText, setIsPlainText] = useState<boolean>(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const memoIsPlainText = useMemo(() => isPlainText, [isPlainText]);
 
   const handleEditSubmit = useCallback(() => {
     if (onEditPrompt && inputRef.current?.value && parentId !== null) {
@@ -131,7 +132,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
         isAssistant={isAssistant}
         usedPlugin={used_plugin}
         content={isEditing ? "" : content!}
-        isPlainText={isPlainText}
+        isPlainText={memoIsPlainText}
       >
         {!isAssistant && parentId !== null && (
           <Box position="absolute" top={{ base: "4", md: 0 }} style={{ insetInlineEnd: `0.5rem` }}>
@@ -179,7 +180,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
                   <>
                     <BaseMessageEmojiButton
                       emoji={FileText}
-                      onClick={() => setIsPlainText(!isPlainText)}
+                      onClick={() => setIsPlainText(!memoIsPlainText)}
                       label={t("plain_text")}
                     />
 
@@ -242,6 +243,8 @@ export const PendingMessageEntry = forwardRef<HTMLDivElement, PendingMessageEntr
     () => ({ src: isAssistant ? `/images/logos/logo.png` : image ?? "/images/temp-avatars/av1.jpg" }),
     [isAssistant, image]
   );
+
+  console.log("rendered");
 
   return (
     <BaseMessageEntry

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -11,11 +11,11 @@ import {
   useColorModeValue,
   useOutsideClick,
 } from "@chakra-ui/react";
-import { Check, Copy, Edit, RotateCcw, ThumbsUp, X, XCircle } from "lucide-react";
+import { Check, Copy, Edit, FileText, RotateCcw, ThumbsUp, X, XCircle } from "lucide-react";
 import { ThumbsDown } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
-import { forwardRef, KeyboardEvent, memo, ReactNode, useCallback, useMemo, useRef } from "react";
+import { forwardRef, KeyboardEvent, memo, ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import { InferenceMessage } from "src/types/Chat";
 
 import { BaseMessageEntry } from "../Messages/BaseMessageEntry";
@@ -92,6 +92,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
 
   const isAssistant = message.role === "assistant";
   const [isEditing, setIsEditing] = useBoolean(false);
+  const [isPlainText, setIsPlainText] = useState<boolean>(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
   const handleEditSubmit = useCallback(() => {
@@ -130,6 +131,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
         isAssistant={isAssistant}
         usedPlugin={used_plugin}
         content={isEditing ? "" : content!}
+        isPlainText={isPlainText}
       >
         {!isAssistant && parentId !== null && (
           <Box position="absolute" top={{ base: "4", md: 0 }} style={{ insetInlineEnd: `0.5rem` }}>
@@ -175,6 +177,12 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
                 )}
                 {state === "complete" && (
                   <>
+                    <BaseMessageEmojiButton
+                      emoji={FileText}
+                      onClick={() => setIsPlainText(!isPlainText)}
+                      label={t("plain_text")}
+                    />
+
                     {canRetry && <BaseMessageEmojiButton emoji={RotateCcw} onClick={handleRetry} label={t("retry")} />}
                     {!hasCopied ? (
                       <BaseMessageEmojiButton emoji={Copy} onClick={onCopy} label={t("copy")} />
@@ -213,6 +221,7 @@ type PendingMessageEntryProps = {
   id?: string;
   "data-id"?: string;
   usedPlugin?: object;
+  isPlainText?: boolean;
 };
 
 export const messageEntryContainerProps = {
@@ -221,7 +230,7 @@ export const messageEntryContainerProps = {
 };
 
 export const PendingMessageEntry = forwardRef<HTMLDivElement, PendingMessageEntryProps>(function PendingMessageEntry(
-  { content, isAssistant, children, usedPlugin, ...props },
+  { content, isAssistant, children, usedPlugin, isPlainText, ...props },
   ref
 ) {
   const bgUser = "transparent";
@@ -245,6 +254,7 @@ export const PendingMessageEntry = forwardRef<HTMLDivElement, PendingMessageEntr
       isAssistant={isAssistant}
       maxWidth={messageEntryContainerProps.maxWidth}
       containerProps={messageEntryContainerProps}
+      isPlainText={isPlainText}
       {...props}
     >
       {children}

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -180,7 +180,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
                 {state === "complete" && (
                   <>
                     <BaseMessageEmojiButton
-                      emoji={!isPlainText ? MarkdownOffIcon : MarkdownIcon}
+                      emoji={isPlainText ? MarkdownIcon : MarkdownOffIcon}
                       onClick={() => setIsPlainText(!isPlainText)}
                       label={t("plain_text")}
                     />

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -18,6 +18,8 @@ import { useTranslation } from "next-i18next";
 import { forwardRef, KeyboardEvent, memo, ReactNode, useCallback, useMemo, useRef, useState } from "react";
 import { InferenceMessage } from "src/types/Chat";
 
+import { MarkdownIcon } from "../icons/Markdown";
+import { MarkdownOffIcon } from "../icons/MarkdownOff";
 import { BaseMessageEntry } from "../Messages/BaseMessageEntry";
 import { BaseMessageEmojiButton } from "../Messages/MessageEmojiButton";
 import { MessageInlineEmojiRow } from "../Messages/MessageInlineEmojiRow";
@@ -40,48 +42,6 @@ export type ChatMessageEntryProps = {
   onEncourageMessageClose: () => void;
   showFeedbackOptions: boolean;
 };
-
-export const Markdown = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="icon icon-tabler icon-tabler-markdown"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    stroke-width="1"
-    stroke="currentColor"
-    fill="none"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  >
-    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-    <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"></path>
-    <path d="M7 15v-6l2 2l2 -2v6"></path>
-    <path d="M14 13l2 2l2 -2m-2 2v-6"></path>
-  </svg>
-);
-
-export const MarkdownOff = (
-  <svg
-    xmlns="http://www.w3.org/2000/svg"
-    className="icon icon-tabler icon-tabler-markdown-off"
-    width="24"
-    height="24"
-    viewBox="0 0 24 24"
-    stroke-width="1"
-    stroke="currentColor"
-    fill="none"
-    stroke-linecap="round"
-    stroke-linejoin="round"
-  >
-    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
-    <path d="M9 5h10a2 2 0 0 1 2 2v10"></path>
-    <path d="M19 19h-14a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 1.85 -2"></path>
-    <path d="M7 15v-6l2 2l1 -1m1 1v4"></path>
-    <path d="M17.5 13.5l.5 -.5m-2 -1v-3"></path>
-    <path d="M3 3l18 18"></path>
-  </svg>
-);
 
 export const ChatMessageEntry = memo(function ChatMessageEntry({
   onVote,
@@ -220,7 +180,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
                 {state === "complete" && (
                   <>
                     <BaseMessageEmojiButton
-                      svgIcon={isPlainText ? MarkdownOff : Markdown}
+                      emoji={!isPlainText ? MarkdownOffIcon : MarkdownIcon}
                       onClick={() => setIsPlainText(!isPlainText)}
                       label={t("plain_text")}
                     />

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -11,7 +11,7 @@ import {
   useColorModeValue,
   useOutsideClick,
 } from "@chakra-ui/react";
-import { Check, Copy, Edit, FileText, RotateCcw, ThumbsUp, X, XCircle } from "lucide-react";
+import { Check, Copy, Edit, RotateCcw, ThumbsUp, X, XCircle } from "lucide-react";
 import { ThumbsDown } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useTranslation } from "next-i18next";
@@ -40,6 +40,48 @@ export type ChatMessageEntryProps = {
   onEncourageMessageClose: () => void;
   showFeedbackOptions: boolean;
 };
+
+export const Markdown = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="icon icon-tabler icon-tabler-markdown"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    stroke-width="1"
+    stroke="currentColor"
+    fill="none"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"></path>
+    <path d="M7 15v-6l2 2l2 -2v6"></path>
+    <path d="M14 13l2 2l2 -2m-2 2v-6"></path>
+  </svg>
+);
+
+export const MarkdownOff = (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    className="icon icon-tabler icon-tabler-markdown-off"
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    stroke-width="1"
+    stroke="currentColor"
+    fill="none"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  >
+    <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+    <path d="M9 5h10a2 2 0 0 1 2 2v10"></path>
+    <path d="M19 19h-14a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 1.85 -2"></path>
+    <path d="M7 15v-6l2 2l1 -1m1 1v4"></path>
+    <path d="M17.5 13.5l.5 -.5m-2 -1v-3"></path>
+    <path d="M3 3l18 18"></path>
+  </svg>
+);
 
 export const ChatMessageEntry = memo(function ChatMessageEntry({
   onVote,
@@ -178,7 +220,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
                 {state === "complete" && (
                   <>
                     <BaseMessageEmojiButton
-                      emoji={FileText}
+                      svgIcon={isPlainText ? MarkdownOff : Markdown}
                       onClick={() => setIsPlainText(!isPlainText)}
                       label={t("plain_text")}
                     />

--- a/website/src/components/Chat/ChatMessageEntry.tsx
+++ b/website/src/components/Chat/ChatMessageEntry.tsx
@@ -94,7 +94,6 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
   const [isEditing, setIsEditing] = useBoolean(false);
   const [isPlainText, setIsPlainText] = useState<boolean>(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const memoIsPlainText = useMemo(() => isPlainText, [isPlainText]);
 
   const handleEditSubmit = useCallback(() => {
     if (onEditPrompt && inputRef.current?.value && parentId !== null) {
@@ -132,7 +131,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
         isAssistant={isAssistant}
         usedPlugin={used_plugin}
         content={isEditing ? "" : content!}
-        isPlainText={memoIsPlainText}
+        isPlainText={isPlainText}
       >
         {!isAssistant && parentId !== null && (
           <Box position="absolute" top={{ base: "4", md: 0 }} style={{ insetInlineEnd: `0.5rem` }}>
@@ -180,7 +179,7 @@ export const ChatMessageEntry = memo(function ChatMessageEntry({
                   <>
                     <BaseMessageEmojiButton
                       emoji={FileText}
-                      onClick={() => setIsPlainText(!memoIsPlainText)}
+                      onClick={() => setIsPlainText(!isPlainText)}
                       label={t("plain_text")}
                     />
 
@@ -243,8 +242,6 @@ export const PendingMessageEntry = forwardRef<HTMLDivElement, PendingMessageEntr
     () => ({ src: isAssistant ? `/images/logos/logo.png` : image ?? "/images/temp-avatars/av1.jpg" }),
     [isAssistant, image]
   );
-
-  console.log("rendered");
 
   return (
     <BaseMessageEntry

--- a/website/src/components/Messages/BaseMessageEntry.tsx
+++ b/website/src/components/Messages/BaseMessageEntry.tsx
@@ -14,10 +14,11 @@ export type BaseMessageEntryProps = StrictOmit<BoxProps, "bg" | "backgroundColor
   usedPlugin?: object;
   isAssistant?: boolean;
   containerProps?: BoxProps;
+  isPlainText?: boolean;
 };
 
 export const BaseMessageEntry = forwardRef<HTMLDivElement, BaseMessageEntryProps>(function BaseMessageEntry(
-  { content, avatarProps, children, highlight, usedPlugin, isAssistant, containerProps, ...props },
+  { content, avatarProps, children, highlight, usedPlugin, isAssistant, containerProps, isPlainText, ...props },
   ref
 ) {
   const bg = useColorModeValue("#DFE8F1", "#42536B");
@@ -63,10 +64,14 @@ export const BaseMessageEntry = forwardRef<HTMLDivElement, BaseMessageEntryProps
         {...props}
         _dark={{ outlineColor: { md: colors.dark.active }, ...props._dark }}
       >
-        <Suspense fallback={content}>
-          {isAssistant ? <PluginUsageDetails usedPlugin={usedPlugin} /> : null}
-          <RenderedMarkdown markdown={content} disallowedElements={[]}></RenderedMarkdown>
-        </Suspense>
+        {!isPlainText ? (
+          <Suspense fallback={content}>
+            {isAssistant ? <PluginUsageDetails usedPlugin={usedPlugin} /> : null}
+            <RenderedMarkdown markdown={content} disallowedElements={[]}></RenderedMarkdown>
+          </Suspense>
+        ) : (
+          content
+        )}
         {children}
       </Box>
     </Flex>

--- a/website/src/components/Messages/MessageEmojiButton.tsx
+++ b/website/src/components/Messages/MessageEmojiButton.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonProps, Tooltip, useColorModeValue } from "@chakra-ui/react";
-import { ElementType, PropsWithChildren } from "react";
+import { ElementType, PropsWithChildren, ReactElement } from "react";
 import { useHasAnyRole } from "src/hooks/auth/useHasAnyRole";
 import { MessageEmoji } from "src/types/Conversation";
 import { emojiIcons } from "src/types/Emoji";
@@ -39,8 +39,9 @@ export const MessageEmojiButton = ({
   );
 };
 
-type BaseMessageEmojiButtonProps = PropsWithChildren<{
+type BaseMessageEmojiButtonPropsEmoji = PropsWithChildren<{
   emoji: ElementType<any>;
+  svgIcon?: never;
   checked?: boolean;
   onClick?: () => void;
   isDisabled?: boolean;
@@ -48,8 +49,21 @@ type BaseMessageEmojiButtonProps = PropsWithChildren<{
   label?: string;
 }>;
 
+type BaseMessageEmojiButtonPropsSVG = PropsWithChildren<{
+  emoji?: never;
+  svgIcon?: ReactElement;
+  checked?: boolean;
+  onClick?: () => void;
+  isDisabled?: boolean;
+  sx?: ButtonProps["sx"];
+  label?: string;
+}>;
+
+type BaseMessageEmojiButtonProps = BaseMessageEmojiButtonPropsEmoji | BaseMessageEmojiButtonPropsSVG;
+
 export const BaseMessageEmojiButton = ({
   emoji: Emoji,
+  svgIcon,
   checked,
   onClick,
   isDisabled,
@@ -76,7 +90,7 @@ export const BaseMessageEmojiButton = ({
       }}
       color={isDisabled ? (checked ? "gray.700" : disabledColor) : undefined}
     >
-      <Emoji style={{ height: "1em" }} />
+      {Emoji ? <Emoji style={{ height: "1em" }} /> : svgIcon}
       {children}
     </Button>
   );

--- a/website/src/components/Messages/MessageEmojiButton.tsx
+++ b/website/src/components/Messages/MessageEmojiButton.tsx
@@ -39,7 +39,7 @@ export const MessageEmojiButton = ({
   );
 };
 
-type BaseMessageEmojiButtonPropsEmoji = PropsWithChildren<{
+type BaseMessageEmojiButtonProps = PropsWithChildren<{
   emoji: ElementType<any>;
   checked?: boolean;
   onClick?: () => void;
@@ -47,8 +47,6 @@ type BaseMessageEmojiButtonPropsEmoji = PropsWithChildren<{
   sx?: ButtonProps["sx"];
   label?: string;
 }>;
-
-type BaseMessageEmojiButtonProps = BaseMessageEmojiButtonPropsEmoji;
 
 export const BaseMessageEmojiButton = ({
   emoji: Emoji,

--- a/website/src/components/Messages/MessageEmojiButton.tsx
+++ b/website/src/components/Messages/MessageEmojiButton.tsx
@@ -1,5 +1,5 @@
 import { Button, ButtonProps, Tooltip, useColorModeValue } from "@chakra-ui/react";
-import { ElementType, PropsWithChildren, ReactElement } from "react";
+import { ElementType, PropsWithChildren } from "react";
 import { useHasAnyRole } from "src/hooks/auth/useHasAnyRole";
 import { MessageEmoji } from "src/types/Conversation";
 import { emojiIcons } from "src/types/Emoji";
@@ -41,7 +41,6 @@ export const MessageEmojiButton = ({
 
 type BaseMessageEmojiButtonPropsEmoji = PropsWithChildren<{
   emoji: ElementType<any>;
-  svgIcon?: never;
   checked?: boolean;
   onClick?: () => void;
   isDisabled?: boolean;
@@ -49,21 +48,10 @@ type BaseMessageEmojiButtonPropsEmoji = PropsWithChildren<{
   label?: string;
 }>;
 
-type BaseMessageEmojiButtonPropsSVG = PropsWithChildren<{
-  emoji?: never;
-  svgIcon?: ReactElement;
-  checked?: boolean;
-  onClick?: () => void;
-  isDisabled?: boolean;
-  sx?: ButtonProps["sx"];
-  label?: string;
-}>;
-
-type BaseMessageEmojiButtonProps = BaseMessageEmojiButtonPropsEmoji | BaseMessageEmojiButtonPropsSVG;
+type BaseMessageEmojiButtonProps = BaseMessageEmojiButtonPropsEmoji;
 
 export const BaseMessageEmojiButton = ({
   emoji: Emoji,
-  svgIcon,
   checked,
   onClick,
   isDisabled,
@@ -90,7 +78,7 @@ export const BaseMessageEmojiButton = ({
       }}
       color={isDisabled ? (checked ? "gray.700" : disabledColor) : undefined}
     >
-      {Emoji ? <Emoji style={{ height: "1em" }} /> : svgIcon}
+      <Emoji style={{ height: "1em" }} />
       {children}
     </Button>
   );

--- a/website/src/components/icons/Markdown.tsx
+++ b/website/src/components/icons/Markdown.tsx
@@ -1,0 +1,24 @@
+import { LucideProps } from "lucide-react";
+
+export const MarkdownIcon = (props: LucideProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="icon icon-tabler icon-tabler-markdown"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      strokeWidth="2"
+      stroke="currentColor"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+      <path d="M3 5m0 2a2 2 0 0 1 2 -2h14a2 2 0 0 1 2 2v10a2 2 0 0 1 -2 2h-14a2 2 0 0 1 -2 -2z"></path>
+      <path d="M7 15v-6l2 2l2 -2v6"></path>
+      <path d="M14 13l2 2l2 -2m-2 2v-6"></path>
+    </svg>
+  );
+};

--- a/website/src/components/icons/MarkdownOff.tsx
+++ b/website/src/components/icons/MarkdownOff.tsx
@@ -1,0 +1,26 @@
+import { LucideProps } from "lucide-react";
+
+export const MarkdownOffIcon = (props: LucideProps) => {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className="icon icon-tabler icon-tabler-markdown-off"
+      width={24}
+      height={24}
+      viewBox="0 0 24 24"
+      strokeWidth="2"
+      stroke="currentColor"
+      fill="none"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+      <path d="M9 5h10a2 2 0 0 1 2 2v10"></path>
+      <path d="M19 19h-14a2 2 0 0 1 -2 -2v-10a2 2 0 0 1 1.85 -2"></path>
+      <path d="M7 15v-6l2 2l1 -1m1 1v4"></path>
+      <path d="M17.5 13.5l.5 -.5m-2 -1v-3"></path>
+      <path d="M3 3l18 18"></path>
+    </svg>
+  );
+};


### PR DESCRIPTION
Fixes: #2508 

Rendered by suspense
<img width="537" alt="image" src="https://github.com/LAION-AI/Open-Assistant/assets/61619422/b259d0ad-44bb-4d80-9590-8a7fb9964c66">

Plain text
<img width="587" alt="image" src="https://github.com/LAION-AI/Open-Assistant/assets/61619422/723600ec-cca2-4716-8abf-fde3ea2e63db">

I am not sure whether using memo on isPlainText has any performance gain. I need your opinions. 