### PR TITLE
Update requirements.txt

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -2,7 +2,7 @@ aiohttp==3.8.3
 alembic==1.8.1
 asgiref==3.6.0
 Celery==5.2.0
-cryptography==39.0.0
+cryptography==41.0.0
 fastapi==0.88.0
 fastapi-limiter==0.1.5
 fastapi-utils==0.2.1
@@ -15,7 +15,7 @@ pydantic[email]==1.10.4
 python-dotenv==0.21.0
 python-jose[cryptography]==3.3.0
 redis==4.5.5
-requests==2.30.0
+requests==2.31.0
 scipy==1.8.1
 SQLAlchemy==1.4.41
 sqlmodel==0.0.8


### PR DESCRIPTION
updating packages to resolve vulnerabilities
![image](https://github.com/LAION-AI/Open-Assistant/assets/81183603/41d35d73-a850-4ac0-980c-c2723c8f872b)


pyca/cryptography's wheels include a statically linked copy of OpenSSL. The versions of OpenSSL included in cryptography 0.5-40.0.2 are vulnerable to a security issue. More details about the vulnerability itself can be found in https://www.openssl.org/news/secadv/20230530.txt.


Refer to Github security advisory [GHSA-5cpq-8wj7-hf2v](https://github.com/advisories/GHSA-5cpq-8wj7-hf2v) for updates and patch information.