### PR TITLE
3517 - Send reports to discord via celery task

### DIFF
--- a/backend/oasst_backend/utils/discord.py
+++ b/backend/oasst_backend/utils/discord.py
@@ -2,18 +2,21 @@ from uuid import UUID
 
 import requests
 from loguru import logger
+from oasst_backend.celery_worker import app as celery_app
 from oasst_backend.config import settings
-from oasst_backend.models.message import Message
 
 ROOT_ENDPOINT = "https://discord.com/api/v10"
 
 
-def send_new_report_message(message: Message, label_text: str, user_id: UUID):
+@celery_app.task(name="send_new_report_message")
+def send_new_report_message(message_details: dict, label_text: str, user_id: UUID):
     """
     Send a message to the Discord channel when a new message is flagged.
+    Note: this is a Celery task.
 
     Args:
-        message (Message): the flagged message
+        message_details (dict): some of the attributes of a Message instance that we will use to compose the discord
+        message.
         label_text (str): the label text
         user_id (UUID): the user ID
     """
@@ -22,14 +25,19 @@ def send_new_report_message(message: Message, label_text: str, user_id: UUID):
 
     try:
         logger.debug("Sending flagged message to Discord")
-        message_text = message.text[:500] + "..." if len(message.text) > 500 else message.text
         label_text = label_text[:4096]  # 4096 is the max length of discord embed description
         message_content_embed = {
             "title": "Message content",
-            "description": f"{message_text}",
+            "description": message_details["message_text"],
             "color": 0x3498DB,  # Blue
             "footer": {
-                "text": f"Role: {message.role.upper()}\t Lang: {message.lang.upper()}\t 👍{message.emojis.get('+1') or 0} 👎{message.emojis.get('-1') or 0} 🚩{message.emojis.get('red_flag') or 0}"
+                "text": (
+                    f"Role: {message_details['role']}\t "
+                    f"Lang: {message_details['lang']}\t "
+                    f"👍{message_details['thumbs_up']} "
+                    f"👎{message_details['thumbs_down']} "
+                    f"🚩{message_details['red_flag']}"
+                )
             },
         }
         label_text_embed = {
@@ -48,7 +56,7 @@ def send_new_report_message(message: Message, label_text: str, user_id: UUID):
                 "authorization": f"Bot {settings.DISCORD_API_KEY}",
             },
             json={
-                "content": f"New flagged message https://open-assistant.io/admin/messages/{message.id}",
+                "content": f"New flagged message https://open-assistant.io/admin/messages/{message_details['message_id']}",
                 "embeds": [message_content_embed, label_text_embed],
             },
         )


### PR DESCRIPTION
It should fix: https://github.com/LAION-AI/Open-Assistant/issues/3517

In debeb353cc0104a0a330637d078b9b0bc41afe84 we reverted the original implementation of the task as it broke the production environment. The problem was that celery tasks need objects that could be JSON serializable and we were passing a `Message` instance, so just passing the details fixed the issue.

![Screenshot from 2023-07-13 08-04-49](https://github.com/LAION-AI/Open-Assistant/assets/33068707/1e76d71f-7182-49ec-8e94-38ef2fce56a2)

A few things that I noticed:
- There's no `pre-commit` version pinned in the requirements.txt so I just used the latest one (3.3.3). In the past I had experienced issues with this so it might be a good idea to pin it.
- There are a few automated tests, I was about to write them but found no installation of `pytest` or similar, if you consider so, I'm happy to write them and install the necessary libraries as eventually that will make the codebase more robust.