### PR TITLE
Add debug setup for inference server & worker

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -106,6 +106,38 @@
         "CUDA_VISIBLE_DEVICES": "1,2,3,4,5",
         "OMP_NUM_THREADS": "1"
       }
-    }
+    },
+    {
+      "name": "Debug: Inference Server",
+      "type": "python",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5678
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/inference/server",
+          "remoteRoot": "/opt/inference/server"
+        }
+      ],
+      "justMyCode": false
+    },
+    {
+      "name": "Debug: Worker",
+      "type": "python",
+      "request": "attach",
+      "connect": {
+        "host": "localhost",
+        "port": 5679
+      },
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/inference/worker",
+          "remoteRoot": "/opt/inference/worker"
+        }
+      ],
+      "justMyCode": false
+    },
   ]
 }

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -237,6 +237,7 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000"
+      - "5678:5678"  # Port to attach debugger
     depends_on:
       inference-redis:
         condition: service_healthy
@@ -257,6 +258,8 @@ services:
     volumes:
       - "./oasst-shared:/opt/inference/lib/oasst-shared"
       - "./inference/worker:/opt/inference/worker"
+    ports:
+      - "5679:5679"  # Port to attach debugger
     deploy:
       replicas: 1
     profiles: ["inference"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -231,6 +231,7 @@ services:
       TRUSTED_CLIENT_KEYS: "6969"
       ALLOW_DEBUG_AUTH: "True"
       API_ROOT: "http://localhost:8000"
+      DEBUG: "True"
     volumes:
       - "./oasst-shared:/opt/inference/lib/oasst-shared"
       - "./inference/server:/opt/inference/server"
@@ -255,6 +256,7 @@ services:
       MODEL_CONFIG_NAME: ${MODEL_CONFIG_NAME:-distilgpt2}
       BACKEND_URL: "ws://inference-server:8000"
       PARALLELISM: 2
+      DEBUG: "True"
     volumes:
       - "./oasst-shared:/opt/inference/lib/oasst-shared"
       - "./inference/worker:/opt/inference/worker"

--- a/docker/inference/Dockerfile.server
+++ b/docker/inference/Dockerfile.server
@@ -78,9 +78,8 @@ USER ${APP_USER}
 VOLUME [ "${APP_BASE}/lib/oasst-shared" ]
 VOLUME [ "${APP_BASE}/lib/oasst-data" ]
 
-# Start the server within pydebug to allow attaching a debugger; add "--wait-for-client" if you want to halt execution
-# until the debugger has been attached
-CMD python -m pydebug --listen 0.0.0.0:5678 main.py
+# In the dev image, we start uvicorn from Python so that we can attach the debugger
+CMD python main.py
 
 
 

--- a/docker/inference/Dockerfile.server
+++ b/docker/inference/Dockerfile.server
@@ -78,8 +78,9 @@ USER ${APP_USER}
 VOLUME [ "${APP_BASE}/lib/oasst-shared" ]
 VOLUME [ "${APP_BASE}/lib/oasst-data" ]
 
-
-CMD uvicorn main:app --reload --host 0.0.0.0 --port "${PORT}"
+# Start the server within pydebug to allow attaching a debugger; add "--wait-for-client" if you want to halt execution
+# until the debugger has been attached
+CMD python -m pydebug --listen 0.0.0.0:5678 main.py
 
 
 

--- a/inference/server/main.py
+++ b/inference/server/main.py
@@ -148,3 +148,12 @@ for app_prefix, sub_app in plugins.plugin_apps.items():
 async def welcome_message():
     logger.warning("Inference server started")
     logger.warning("To stop the server, press Ctrl+C")
+
+
+if __name__ == "__main__":
+    # Entrypoint for the server in dev environments
+    # pydebug needs a Python process to attach to, so we start uvicorn from Python instead of invoking it directly
+    import uvicorn
+    import os
+    port = int(os.getenv('PORT', "8000"))
+    uvicorn.run("main:app", host="0.0.0.0", port=port, reload=True)

--- a/inference/server/main.py
+++ b/inference/server/main.py
@@ -151,9 +151,16 @@ async def welcome_message():
 
 
 if __name__ == "__main__":
-    # Entrypoint for the server in dev environments
-    # pydebug needs a Python process to attach to, so we start uvicorn from Python instead of invoking it directly
     import uvicorn
     import os
+
     port = int(os.getenv('PORT', "8000"))
-    uvicorn.run("main:app", host="0.0.0.0", port=port, reload=True)
+    is_debug = bool(os.getenv("DEBUG", "False"))
+
+    if is_debug:
+        import debugpy
+        debugpy.listen(("0.0.0.0", "5679"))
+        # Uncomment to wait here until a debugger is attached
+        # debugpy.wait_for_client()
+    
+    uvicorn.run("main:app", host="0.0.0.0", port=port, reload=is_debug)

--- a/inference/server/requirements.txt
+++ b/inference/server/requirements.txt
@@ -4,6 +4,7 @@ asyncpg
 authlib
 beautifulsoup4 # web_retriever plugin
 cryptography==39.0.0
+debugpy
 fastapi-limiter
 fastapi[all]==0.88.0
 google-api-python-client

--- a/inference/worker/__main__.py
+++ b/inference/worker/__main__.py
@@ -4,6 +4,8 @@ import sys
 import time
 from contextlib import closing
 
+import os
+
 import pydantic
 import transformers
 import utils
@@ -130,4 +132,12 @@ def main():
 
 
 if __name__ == "__main__":
+    is_debug = bool(os.getenv("DEBUG", "False"))
+
+    if is_debug:
+        import debugpy
+        debugpy.listen(("0.0.0.0", "5679"))
+        # Uncomment to wait here until a debugger is attached
+        # debugpy.wait_for_client()
+    
     main()

--- a/inference/worker/requirements.txt
+++ b/inference/worker/requirements.txt
@@ -1,4 +1,5 @@
 aiohttp
+debugpy
 hf_transfer
 huggingface_hub
 langchain==0.0.142


### PR DESCRIPTION
I couldn't find an existing way to attach a debugger to the inference server or worker. In this PR, I enable both to be debugged using [debugpy](https://github.com/microsoft/debugpy), the Python debugger that integrates easily with VS Code.

Open issues:
- [ ] add documentation