### PR TITLE
Update Flash Attention forward for Llama 2: 

### DIFF
--- a/model/model_training/models/patching_llama.py
+++ b/model/model_training/models/patching_llama.py
@@ -4,7 +4,8 @@ from typing import Optional, Tuple
 
 import torch
 import torch.nn as nn
-from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb
+import torch.nn.functional as F
+from transformers.models.llama.modeling_llama import LlamaAttention, apply_rotary_pos_emb, repeat_kv
 
 from .patching_utils import compute_flash_attention
 
@@ -20,21 +21,39 @@ def llama_forward_with_flash_attn(
     output_attentions: bool = False,
     use_cache: bool = False,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    # self: transformers.models.llama.modeling_llama.LlamaAttention
-    if output_attentions:
-        warnings.warn("Output attentions is not supported for patched `LlamaAttention`, returning `None` instead.")
     bsz, q_len, _ = hidden_states.size()
 
-    query_states = self.q_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-    key_states = self.k_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-    value_states = self.v_proj(hidden_states).view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    if output_attentions:
+        warnings.warn("Output attentions is not supported for patched `LlamaAttention`, returning `None` instead.")
+    if self.config.pretraining_tp > 1:
+        key_value_slicing = (self.num_key_value_heads * self.head_dim) // self.config.pretraining_tp
+        query_slices = self.q_proj.weight.split((self.num_heads * self.head_dim) // self.config.pretraining_tp, dim=0)
+        key_slices = self.k_proj.weight.split(key_value_slicing, dim=0)
+        value_slices = self.v_proj.weight.split(key_value_slicing, dim=0)
+
+        query_states = [F.linear(hidden_states, query_slices[i]) for i in range(self.config.pretraining_tp)]
+        query_states = torch.cat(query_states, dim=-1)
+
+        key_states = [F.linear(hidden_states, key_slices[i]) for i in range(self.config.pretraining_tp)]
+        key_states = torch.cat(key_states, dim=-1)
+
+        value_states = [F.linear(hidden_states, value_slices[i]) for i in range(self.config.pretraining_tp)]
+        value_states = torch.cat(value_states, dim=-1)
+
+    else:
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+    query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+    key_states = key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+    value_states = value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
     if past_key_value is not None:
         kv_seq_len += past_key_value[0].shape[-2]
     cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
     query_states, key_states = apply_rotary_pos_emb(query_states, key_states, cos, sin, position_ids)
-    # [bsz, nh, t, hd]
 
     if past_key_value is not None:
         # reuse k, v, self_attention
@@ -43,11 +62,9 @@ def llama_forward_with_flash_attn(
 
     past_key_value = (key_states, value_states) if use_cache else None
 
-    if attention_mask is not None:
-        if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
-            raise ValueError(
-                f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
-            )
+    # repeat k/v heads if n_kv_heads < n_heads
+    key_states = repeat_kv(key_states, self.num_key_value_groups)
+    value_states = repeat_kv(value_states, self.num_key_value_groups)
 
     if (
         query_states.shape == key_states.shape
@@ -57,7 +74,11 @@ def llama_forward_with_flash_attn(
 
         flash_attn.train(self.training)
         out_dtype = value_states.dtype
-        q, k, v = query_states.transpose(1, 2), key_states.transpose(1, 2), value_states.transpose(1, 2)
+        q, k, v = (
+            query_states.transpose(1, 2),
+            key_states.transpose(1, 2),
+            value_states.transpose(1, 2),
+        )
         attn_output = compute_flash_attention(flash_attn, q, k, v, attention_mask)
         attn_output = attn_output.transpose(1, 2).to(out_dtype)
 
@@ -71,21 +92,35 @@ def llama_forward_with_flash_attn(
 
         if attn_weights.size() != (bsz, self.num_heads, q_len, kv_seq_len):
             raise ValueError(
-                f"Attention weights should be of size {(bsz * self.num_heads, q_len, kv_seq_len)}, but is"
+                f"Attention weights should be of size {(bsz, self.num_heads, q_len, kv_seq_len)}, but is"
                 f" {attn_weights.size()}"
             )
 
         if attention_mask is not None:
+            if attention_mask.size() != (bsz, 1, q_len, kv_seq_len):
+                raise ValueError(
+                    f"Attention mask should be of size {(bsz, 1, q_len, kv_seq_len)}, but is {attention_mask.size()}"
+                )
             attn_weights = attn_weights + attention_mask
-            attn_weights = torch.max(attn_weights, torch.tensor(torch.finfo(attn_weights.dtype).min))
 
         # upcast attention to fp32
         attn_weights = nn.functional.softmax(attn_weights, dim=-1, dtype=torch.float32).to(query_states.dtype)
         attn_output = torch.matmul(attn_weights, value_states)
 
-    attn_output = attn_output.transpose(1, 2)
+        if attn_output.size() != (bsz, self.num_heads, q_len, self.head_dim):
+            raise ValueError(
+                f"`attn_output` should be of size {(bsz, self.num_heads, q_len, self.head_dim)}, but is"
+                f" {attn_output.size()}"
+            )
+
+    attn_output = attn_output.transpose(1, 2).contiguous()
     attn_output = attn_output.reshape(bsz, q_len, self.hidden_size)
 
-    attn_output = self.o_proj(attn_output)
+    if self.config.pretraining_tp > 1:
+        attn_output = attn_output.split(self.hidden_size // self.config.pretraining_tp, dim=2)
+        o_proj_slices = self.o_proj.weight.split(self.hidden_size // self.config.pretraining_tp, dim=1)
+        attn_output = sum([F.linear(attn_output[i], o_proj_slices[i]) for i in range(self.config.pretraining_tp)])
+    else:
+        attn_output = self.o_proj(attn_output)
 
     return attn_output, None, past_key_value

--- a/model/model_training/tests/test_patched_llama.py
+++ b/model/model_training/tests/test_patched_llama.py
@@ -3,7 +3,7 @@ from model_training.models.patching import patch_model
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
-def test_flash_attention_patch(dtype=torch.float16, device="cuda:0", llama_path="meta-llama/Llama-2-7b-hf"):
+def test_flash_attention_patch(dtype=torch.float16, device="cuda:0", llama_path="/mnt/data/llama2/Llama-2-7b"):
     tokenizer = AutoTokenizer.from_pretrained(llama_path)
     tokenizer.add_special_tokens({"pad_token": "</s>", "eos_token": "</s>", "sep_token": "<s>"})
 

--- a/model/model_training/tests/test_patched_llama.py
+++ b/model/model_training/tests/test_patched_llama.py
@@ -3,12 +3,12 @@ from model_training.models.patching import patch_model
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 
-def test_flash_attention_patch(dtype=torch.float16, device="cuda:0"):
-    tokenizer = AutoTokenizer.from_pretrained("/home/ubuntu/llama_hf/7B")
+def test_flash_attention_patch(dtype=torch.float16, device="cuda:0", llama_path="meta-llama/Llama-2-7b-hf"):
+    tokenizer = AutoTokenizer.from_pretrained(llama_path)
     tokenizer.add_special_tokens({"pad_token": "</s>", "eos_token": "</s>", "sep_token": "<s>"})
 
-    model = AutoModelForCausalLM.from_pretrained("/home/ubuntu/llama_hf/7B", torch_dtype=dtype).to(device)
-    patched_model = AutoModelForCausalLM.from_pretrained("/home/ubuntu/llama_hf/7B", torch_dtype=dtype).to(device)
+    model = AutoModelForCausalLM.from_pretrained(llama_path, torch_dtype=dtype).to(device)
+    patched_model = AutoModelForCausalLM.from_pretrained(llama_path, torch_dtype=dtype).to(device)
     patch_model(patched_model, resid_pdrop=None, flash_attention=True)
 
     device = model.device


### PR DESCRIPTION
GQA for 34B and 70B and tp have been [added ](https://github.com/huggingface/transformers/blob/main/src/transformers/models/llama/modeling_llama.py#L281)

The current flash attn patch forward is for the old transformers' attention forward.