### PR TITLE
Custom instructions feature

### DIFF
--- a/inference/server/oasst_inference_server/routes/chats.py
+++ b/inference/server/oasst_inference_server/routes/chats.py
@@ -153,6 +153,8 @@ async def create_assistant_message(
                 system_prompt=request.system_prompt,
                 plugins=request.plugins,
                 plugin_max_depth=settings.plugin_max_depth,
+                user_profile=request.user_profile,
+                user_response_instructions=request.user_response_instructions,
             )
             assistant_message = await ucr.initiate_assistant_message(
                 parent_id=request.parent_id,

--- a/inference/server/oasst_inference_server/schemas/chat.py
+++ b/inference/server/oasst_inference_server/schemas/chat.py
@@ -15,6 +15,8 @@ class CreateAssistantMessageRequest(pydantic.BaseModel):
     model_config_name: str
     sampling_parameters: inference.SamplingParameters = pydantic.Field(default_factory=inference.SamplingParameters)
     system_prompt: str | None = None
+    user_profile: str | None = None
+    user_response_instructions: str | None = None
     plugins: list[inference.PluginEntry] = pydantic.Field(default_factory=list[inference.PluginEntry])
     used_plugin: inference.PluginUsed | None = None
 

--- a/inference/worker/chat_chain.py
+++ b/inference/worker/chat_chain.py
@@ -6,6 +6,7 @@ import utils
 import websocket
 from chat_chain_prompts import (
     ASSISTANT_PREFIX,
+    CUSTOM_INSTRUCTIONS_PREFIX,
     HUMAN_PREFIX,
     JSON_FORMAT_NO_PAYLOAD,
     JSON_FORMAT_PAYLOAD,
@@ -56,6 +57,7 @@ class PromptedLLM:
         tool_names: list[str],
         language: str,
         action_input_format: str,
+        custom_instructions: str = "",
     ):
         self.tokenizer = tokenizer
         self.worker_config = worker_config
@@ -66,6 +68,7 @@ class PromptedLLM:
         self.language = language
         self.action_input_format = action_input_format
         self.current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        self.custom_instructions = custom_instructions
 
     def call(self, prompt: str) -> tuple[str, str]:
         """Prepares and truncates prompt, calls LLM, returns used prompt and response."""
@@ -79,6 +82,7 @@ class PromptedLLM:
             self.tokenizer,
             self.worker_config,
             self.action_input_format,
+            self.custom_instructions,
         )
 
         # We do not strip() outputs as it seems to degrade instruction-following abilities of the model
@@ -111,6 +115,7 @@ def handle_plugin_usage(
     plugin_max_depth: int,
     ws: websocket.WebSocket,
     work_request_id: str,
+    custom_instructions: str = "",
 ) -> tuple[str, inference.PluginUsed]:
     execution_details = inference.PluginExecutionDetails(
         inner_monologue=[],
@@ -142,7 +147,15 @@ def handle_plugin_usage(
     tool_names = [tool.name for tool in tools]
 
     chain = PromptedLLM(
-        tokenizer, worker_config, parameters, prompt_template, memory, tool_names, language, action_input_format
+        tokenizer,
+        worker_config,
+        parameters,
+        prompt_template,
+        memory,
+        tool_names,
+        language,
+        action_input_format,
+        custom_instructions,
     )
 
     # send "thinking..." intermediate step to UI (This will discard queue position 0) immediately
@@ -245,6 +258,7 @@ def handle_plugin_usage(
                 tokenizer,
                 worker_config,
                 action_input_format,
+                custom_instructions,
             )
 
             inner_prompt = f"{inner_prompt}\n{THOUGHT_SEQ} I now know the final answer\n{ASSISTANT_PREFIX}:  "
@@ -296,6 +310,7 @@ def handle_standard_usage(
     memory: ConversationBufferMemory,
     worker_config: inference.WorkerConfig,
     tokenizer: transformers.PreTrainedTokenizer,
+    custom_instructions: str = "",
 ):
     eos_token = tokenizer.eos_token if hasattr(tokenizer, "eos_token") else ""
     current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -306,7 +321,16 @@ def handle_standard_usage(
     )
     input = f"{original_prompt}{eos_token}{V2_ASST_PREFIX}"
     init_prompt = prepare_prompt(
-        input, prompt_template, memory, None, current_time, language, tokenizer, worker_config, action_input_format
+        input,
+        prompt_template,
+        memory,
+        None,
+        current_time,
+        language,
+        tokenizer,
+        worker_config,
+        action_input_format,
+        custom_instructions,
     )
     return init_prompt, None
 
@@ -355,10 +379,16 @@ def handle_conversation(
             "language",
             "current_time",
             "action_input_format",
+            "custom_instructions",
         ] + (["tools_names"] if plugin_enabled else [])
 
         # TODO: Consider passing language from the UI here
         prompt_template = PromptTemplate(input_variables=input_variables, template=TEMPLATE)
+
+        custom_instructions = f"""\n{CUSTOM_INSTRUCTIONS_PREFIX.format(
+            user_profile=work_request.parameters.user_profile,
+            user_response_instructions=work_request.parameters.user_response_instructions,
+        )}"""
 
         if plugin_enabled:
             return handle_plugin_usage(
@@ -374,6 +404,7 @@ def handle_conversation(
                 work_request.parameters.plugin_max_depth,
                 ws,
                 work_request.id,
+                custom_instructions,
             )
 
         return handle_standard_usage(original_prompt, prompt_template, language, memory, worker_config, tokenizer)

--- a/inference/worker/chat_chain.py
+++ b/inference/worker/chat_chain.py
@@ -385,10 +385,14 @@ def handle_conversation(
         # TODO: Consider passing language from the UI here
         prompt_template = PromptTemplate(input_variables=input_variables, template=TEMPLATE)
 
-        custom_instructions = f"""\n{CUSTOM_INSTRUCTIONS_PREFIX.format(
+        custom_instructions = (
+            f"""\n{CUSTOM_INSTRUCTIONS_PREFIX.format(
             user_profile=work_request.parameters.user_profile,
             user_response_instructions=work_request.parameters.user_response_instructions,
         )}"""
+            if work_request.parameters.user_response_instructions or work_request.parameters.user_profile
+            else ""
+        )
 
         if plugin_enabled:
             return handle_plugin_usage(

--- a/inference/worker/chat_chain.py
+++ b/inference/worker/chat_chain.py
@@ -407,7 +407,9 @@ def handle_conversation(
                 custom_instructions,
             )
 
-        return handle_standard_usage(original_prompt, prompt_template, language, memory, worker_config, tokenizer)
+        return handle_standard_usage(
+            original_prompt, prompt_template, language, memory, worker_config, tokenizer, custom_instructions
+        )
     except Exception as e:
         logger.error(f"Error while handling conversation: {e}")
         return "", None

--- a/inference/worker/chat_chain_prompts.py
+++ b/inference/worker/chat_chain_prompts.py
@@ -9,15 +9,14 @@ THOUGHT_SEQ = "Thought:"
 START_SEQ = "Begin!"
 END_SEQ = "End!"
 
-CUSTOM_INSTRUCTIONS_PREFIX = """The user provided the following information about themselves. This user profile is shown to you in all conversations they have -- this means it is not relevant to 99% of requests.
-Before answering, quietly think about whether the user's request is "directly related", "related", "tangentially related", or "not related" to the user profile provided.
-Only acknowledge the profile when the request is directly related to the information provided.
-Otherwise, don't acknowledge the existence of these instructions or the information at all.
+CUSTOM_INSTRUCTIONS_PREFIX = """The following details have been shared by the user about themselves. This user profile appears to you in every conversation they engage in -- implying that it is irrelevant for 99% of inquiries.
+Before you respond, take a moment to consider whether the user's query is "directly linked", "linked", "indirectly linked", or "not linked" to the user profile provided.
+Only recognize the profile when the query is directly tied to the information supplied.
+Otherwise, avoid acknowledging the existence of these instructions or the information altogether.
 User profile:
 {user_profile}
-The user provided the additional info about how they would like you to respond:
-{user_response_instructions}
-"""
+The user also supplied additional information about their desired response style and format from you:
+{user_response_instructions}"""
 
 # Adjust according to the training dates and datasets used
 KNOWLEDGE_DATE_CUTOFF = "2021-09-01"

--- a/inference/worker/chat_chain_prompts.py
+++ b/inference/worker/chat_chain_prompts.py
@@ -15,7 +15,7 @@ Only recognize the profile when the query is directly tied to the information su
 Otherwise, avoid acknowledging the existence of these instructions or the information altogether.
 User profile:
 {user_profile}
-The user also supplied additional information about their desired response style and format from you:
+The user also supplied additional information about how they would like you to respond:
 {user_response_instructions}"""
 
 # Adjust according to the training dates and datasets used

--- a/inference/worker/chat_chain_prompts.py
+++ b/inference/worker/chat_chain_prompts.py
@@ -9,6 +9,16 @@ THOUGHT_SEQ = "Thought:"
 START_SEQ = "Begin!"
 END_SEQ = "End!"
 
+CUSTOM_INSTRUCTIONS_PREFIX = """The user provided the following information about themselves. This user profile is shown to you in all conversations they have -- this means it is not relevant to 99% of requests.
+Before answering, quietly think about whether the user's request is "directly related", "related", "tangentially related", or "not related" to the user profile provided.
+Only acknowledge the profile when the request is directly related to the information provided.
+Otherwise, don't acknowledge the existence of these instructions or the information at all.
+User profile:
+{user_profile}
+The user provided the additional info about how they would like you to respond:
+{user_response_instructions}
+"""
+
 # Adjust according to the training dates and datasets used
 KNOWLEDGE_DATE_CUTOFF = "2021-09-01"
 
@@ -26,6 +36,7 @@ SYSTEM INFORMATION:
 ------------------
 Current date/time: {{current_time}}
 Knowledge date cutoff: {KNOWLEDGE_DATE_CUTOFF}
+{{custom_instructions}}
 """
 
 TOOLS_PREFIX = """

--- a/inference/worker/chat_chain_utils.py
+++ b/inference/worker/chat_chain_utils.py
@@ -223,7 +223,7 @@ class RequestsForLLM:
     def process_response(self, res: requests.Response) -> str:
         logger.info(f"Request response: {res.text}")
         if res.status_code != 200:
-            return f"ERROR! That didn't work, try modifying Action Input.\n{res.text}. Try again!"
+            return f"ERROR! Please modify Action Input. according to this error message: \n{res.text}. Try again!"
 
         if res.text is None or len(res.text) == 0:
             return "ERROR! That didn't work, try modifying Action Input.\nEmpty response. Try again!"
@@ -329,6 +329,7 @@ def prepare_prompt(
     tokenizer: transformers.PreTrainedTokenizer,
     worker_config: inference.WorkerConfig,
     action_input_format: str,
+    custom_instructions: str = "",
 ) -> str:
     max_input_length = worker_config.model_config.max_input_length
 
@@ -337,6 +338,7 @@ def prepare_prompt(
         "language": language,
         "current_time": current_time,
         "chat_history": memory.buffer,
+        "custom_instructions": custom_instructions,
     }
 
     if tools_names:
@@ -356,6 +358,7 @@ def prepare_prompt(
             "language": language,
             "current_time": current_time,
             "chat_history": memory.buffer,
+            "custom_instructions": custom_instructions,
         }
 
         if tools_names:

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -49,8 +49,8 @@ def make_prompt_and_parameters(
     ):
         pre_prompt = f"""{V2_SYSTEM_PREFIX}{work_request.parameters.system_prompt if work_request.parameters.system_prompt else ""}\n{
         CUSTOM_INSTRUCTIONS_PREFIX.format(
-            user_profile=work_request.parameters.user_profile,
-            user_response_instructions=work_request.parameters.user_response_instructions,
+            user_profile=work_request.parameters.user_profile if work_request.parameters.user_profile else "",
+            user_response_instructions=work_request.parameters.user_response_instructions if work_request.parameters.user_response_instructions else "",
         )}{eos_token}"""
         messages = [pre_prompt] + messages
 
@@ -114,7 +114,7 @@ def handle_work_request(
             # When using plugins and final prompt is truncated due to length limit
             # LLaMA has tendency to leak internal prompts and generate bad continuations
             # So we add keywords/sequences to the stop sequences to reduce this
-            parameters.stop.extend([THOUGHT_SEQ, f"{ASSISTANT_PREFIX}:"])
+            parameters.stop.extend([END_SEQ, START_SEQ, THOUGHT_SEQ, f"{ASSISTANT_PREFIX}:"])
             break
 
     if not used_plugin:

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -47,11 +47,14 @@ def make_prompt_and_parameters(
         or work_request.parameters.user_profile
         or work_request.parameters.user_response_instructions
     ):
-        pre_prompt = f"""{V2_SYSTEM_PREFIX}{work_request.parameters.system_prompt if work_request.parameters.system_prompt else ""}\n{
-        CUSTOM_INSTRUCTIONS_PREFIX.format(
-            user_profile=work_request.parameters.user_profile if work_request.parameters.user_profile else "",
-            user_response_instructions=work_request.parameters.user_response_instructions if work_request.parameters.user_response_instructions else "",
-        )}{eos_token}"""
+        work_params = work_request.parameters
+        if work_params.system_prompt or work_params.user_profile or work_params.user_response_instructions:
+            pre_prompt = V2_SYSTEM_PREFIX + (work_params.system_prompt or "")
+
+        if work_params.user_profile or work_params.user_response_instructions:
+            pre_prompt = f"""{pre_prompt}\n{CUSTOM_INSTRUCTIONS_PREFIX.format(user_profile=work_params.user_profile or "", user_response_instructions=work_params.user_response_instructions or "")}"""
+
+        pre_prompt = pre_prompt + eos_token
         messages = [pre_prompt] + messages
 
     # Stringify and append assistant prefix to signify start of generation

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -56,7 +56,6 @@ def make_prompt_and_parameters(
 
     # Stringify and append assistant prefix to signify start of generation
     prompt = "".join(messages) + V2_ASST_PREFIX
-    print(prompt)
 
     parameters = interface.GenerateStreamParameters.from_work_parameters(work_request.parameters)
     if settings.use_stop_sequences:

--- a/inference/worker/work.py
+++ b/inference/worker/work.py
@@ -42,14 +42,9 @@ def make_prompt_and_parameters(
     messages = [_prepare_message(message) for message in work_request.thread.messages]
 
     # Prepend system prompt and custom_instructions if it was specified in work parameters
-    if (
-        work_request.parameters.system_prompt
-        or work_request.parameters.user_profile
-        or work_request.parameters.user_response_instructions
-    ):
-        work_params = work_request.parameters
-        if work_params.system_prompt or work_params.user_profile or work_params.user_response_instructions:
-            pre_prompt = V2_SYSTEM_PREFIX + (work_params.system_prompt or "")
+    work_params = work_request.parameters
+    if work_params.system_prompt or work_params.user_profile or work_params.user_response_instructions:
+        pre_prompt = V2_SYSTEM_PREFIX + (work_params.system_prompt or "")
 
         if work_params.user_profile or work_params.user_response_instructions:
             pre_prompt = f"""{pre_prompt}\n{CUSTOM_INSTRUCTIONS_PREFIX.format(user_profile=work_params.user_profile or "", user_response_instructions=work_params.user_response_instructions or "")}"""

--- a/oasst-shared/oasst_shared/schemas/inference.py
+++ b/oasst-shared/oasst_shared/schemas/inference.py
@@ -208,6 +208,8 @@ class WorkParameters(pydantic.BaseModel):
         default_factory=make_seed,
     )
     system_prompt: str | None = None
+    user_profile: str | None = None
+    user_response_instructions: str | None = None
     plugins: list[PluginEntry] = pydantic.Field(default_factory=list[PluginEntry])
     plugin_max_depth: int = 4
 

--- a/website/public/locales/en/chat.json
+++ b/website/public/locales/en/chat.json
@@ -60,5 +60,10 @@
   "preset_name_placeholder": "Enter name",
   "feedback_message": "How did I do? Your feedback will make me better!",
   "feedback_action_great": "Good",
-  "feedback_action_poor": "Could be better"
+  "feedback_action_poor": "Could be better",
+  "custom_instructions": "Custom instructions",
+  "custom_instructions_user_profile": "What info should Open-Assistant have about you to make its replies even better?",
+  "custom_instructions_response_instructions": "How do you want Open-Assistant to chat with you?",
+  "custom_instructions_user_profile_placeholder": "List some of your aspirations.\nDescribe your hobbies and interests.\nShare your location.\nWhat is your occupation?\nWhich topics could you discuss extensively?",
+  "custom_instructions_response_instructions_placeholder": "Should Open-Assistant express opinions or maintain neutrality?\nSpecify the desired formality level for Open-Assistant's responses.\nHow should Open-Assistant address you?\nDetermine the preferred length of responses."
 }

--- a/website/src/components/Chat/ChatConfigSaver.tsx
+++ b/website/src/components/Chat/ChatConfigSaver.tsx
@@ -1,6 +1,6 @@
 import { MutableRefObject, useEffect } from "react";
 import { useFormContext } from "react-hook-form";
-import { ChatConfigFormData, PluginEntry } from "src/types/Chat";
+import { ChatConfigFormData, PluginEntry, CustomInstructionsType } from "src/types/Chat";
 import { CachedChatConfig, CustomPreset, setConfigCache } from "src/utils/chat";
 
 export const ChatConfigSaver = ({
@@ -8,11 +8,13 @@ export const ChatConfigSaver = ({
   hyrated,
   plugins,
   customPresets,
+  customInstructions,
 }: {
   selectedPresetName: string;
   hyrated: MutableRefObject<boolean>;
   plugins: PluginEntry[];
   customPresets: CustomPreset[];
+  customInstructions: CustomInstructionsType;
 }) => {
   const { getValues, watch } = useFormContext<ChatConfigFormData>();
   const { model_config_name, plugins: selectedPlugins, ...preset_config } = { ...watch(), ...getValues() };
@@ -25,10 +27,20 @@ export const ChatConfigSaver = ({
         custom_presets: customPresets,
         custom_preset_config: preset_config,
         selectedPlugins: selectedPlugins,
+        custom_instructions: customInstructions,
       };
       setConfigCache(config);
     }
-  }, [customPresets, hyrated, model_config_name, plugins, preset_config, selectedPlugins, selectedPresetName]);
+  }, [
+    customPresets,
+    hyrated,
+    model_config_name,
+    plugins,
+    preset_config,
+    selectedPlugins,
+    selectedPresetName,
+    customInstructions,
+  ]);
 
   return null;
 };

--- a/website/src/components/Chat/ChatConversation.tsx
+++ b/website/src/components/Chat/ChatConversation.tsx
@@ -75,13 +75,15 @@ export const ChatConversation = memo(function ChatConversation({ chatId, getConf
 
   const createAndFetchAssistantMessage = useCallback(
     async ({ parentId, chatId }: { parentId: string; chatId: string }) => {
-      const { model_config_name, plugins, ...sampling_parameters } = getConfigValues();
+      const { model_config_name, plugins, custom_instructions, ...sampling_parameters } = getConfigValues();
       const assistant_arg: InferencePostAssistantMessageParams = {
         chat_id: chatId,
         parent_id: parentId,
         model_config_name,
         sampling_parameters,
         plugins,
+        user_profile: custom_instructions?.user_profile,
+        user_response_instructions: custom_instructions?.user_response_instructions,
       };
 
       let assistant_message: InferenceMessage;
@@ -140,7 +142,7 @@ export const ChatConversation = memo(function ChatConversation({ chatId, getConf
   );
   const createAssistantDrafts = useCallback(
     async ({ parentId, chatId }: { parentId: string; chatId: string }) => {
-      const { model_config_name, plugins, ...sampling_parameters } = getConfigValues();
+      const { model_config_name, plugins, custom_instructions, ...sampling_parameters } = getConfigValues();
 
       const assistant_arg: InferencePostAssistantMessageParams = {
         chat_id: chatId,
@@ -148,6 +150,8 @@ export const ChatConversation = memo(function ChatConversation({ chatId, getConf
         model_config_name: model_config_name,
         sampling_parameters: sampling_parameters,
         plugins: plugins,
+        user_profile: custom_instructions?.user_profile,
+        user_response_instructions: custom_instructions?.user_response_instructions,
       };
 
       let draft_messages: InferenceMessage[];

--- a/website/src/components/Chat/CustomInstructions.tsx
+++ b/website/src/components/Chat/CustomInstructions.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from "react";
+import {
+  Button,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalBody,
+  ModalFooter,
+  FormControl,
+  FormLabel,
+  Input,
+  Text,
+  Textarea,
+} from "@chakra-ui/react";
+import { BookOpen } from "lucide-react";
+import { useTranslation } from "next-i18next";
+import { CustomInstructionsType } from "src/types/Chat";
+
+const CHAR_LIMIT = 256;
+
+const CustomInstructions = ({ onChange, savedCustomInstructions }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [customInstructions, setCustomInstructions] = useState<CustomInstructionsType>({
+    user_profile: "",
+    user_response_instructions: "",
+  });
+  const { t } = useTranslation("chat");
+
+  const handleOpen = () => {
+    setCustomInstructions(savedCustomInstructions);
+    setIsOpen(true);
+  };
+  const handleClose = () => setIsOpen(false);
+  const handleSave = () => {
+    setIsOpen(false);
+    onChange(customInstructions);
+  };
+
+  function createChangeHandler(key: string) {
+    return function handleInputChange(event: React.ChangeEvent<HTMLTextAreaElement>) {
+      const { value } = event.target;
+      if (value.length <= CHAR_LIMIT) {
+        setCustomInstructions((prevInstructions) => ({
+          ...prevInstructions,
+          [key]: value,
+        }));
+      }
+    };
+  }
+
+  const handleUserProfileChange = createChangeHandler("user_profile");
+  const handleUserResponseInstructionsChange = createChangeHandler("user_response_instructions");
+
+  return (
+    <>
+      <Button leftIcon={<BookOpen />} onClick={handleOpen}>
+        {t("custom_instructions")}
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={handleClose} size="xl">
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>{t("custom_instructions")}</ModalHeader>
+          <ModalBody>
+            <FormControl>
+              <FormLabel>{t("custom_instructions_user_profile")}</FormLabel>
+              <Textarea
+                rows={6}
+                resize="none"
+                height="auto"
+                value={customInstructions?.user_profile}
+                onChange={handleUserProfileChange}
+                placeholder={t("custom_instructions_user_profile_placeholder")}
+              />
+              <Text fontSize="sm">{`${customInstructions?.user_profile?.length}/${CHAR_LIMIT}`}</Text>
+            </FormControl>
+            <FormControl mt={4}>
+              <FormLabel>{t("custom_instructions_response_instructions")}</FormLabel>
+              <Textarea
+                rows={6}
+                height="auto"
+                resize="none"
+                value={customInstructions?.user_response_instructions}
+                onChange={handleUserResponseInstructionsChange}
+                placeholder={t("custom_instructions_response_instructions_placeholder")}
+              />
+              <Text fontSize="sm">{`${customInstructions?.user_response_instructions?.length}/${CHAR_LIMIT}`}</Text>
+            </FormControl>
+          </ModalBody>
+
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={handleSave}>
+              Save
+            </Button>
+            <Button variant="ghost" onClick={handleClose}>
+              Cancel
+            </Button>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default CustomInstructions;

--- a/website/src/types/Chat.ts
+++ b/website/src/types/Chat.ts
@@ -43,6 +43,8 @@ export interface InferenceMessage {
     do_sample: boolean;
     seed: number;
     sampling_parameters: SamplingParameters;
+    user_profile: string;
+    user_response_instructions: string;
     model_config: {
       model_id: string;
       max_input_length: number;
@@ -109,6 +111,11 @@ export type ModelParameterConfig = {
   sampling_parameters: SamplingParameters;
 };
 
+export type CustomInstructionsType = {
+  user_profile: string;
+  user_response_instructions: string;
+};
+
 export interface SamplingParameters {
   max_new_tokens: number | null;
   repetition_penalty: number | null;
@@ -121,6 +128,7 @@ export interface SamplingParameters {
 export interface ChatConfigFormData extends SamplingParameters {
   model_config_name: string; // this is the same as ModelParameterConfig.name
   plugins: PluginEntry[];
+  custom_instructions: CustomInstructionsType;
 }
 
 export interface InferencePostPrompterMessageParams {
@@ -134,6 +142,8 @@ export interface InferencePostAssistantMessageParams {
   parent_id: string;
   model_config_name: string;
   sampling_parameters: SamplingParameters;
+  user_profile: string;
+  user_response_instructions: string;
   plugins: PluginEntry[];
 }
 

--- a/website/src/utils/chat.ts
+++ b/website/src/utils/chat.ts
@@ -1,5 +1,5 @@
 import { PluginEntry } from "src/types/Chat";
-import { SamplingParameters } from "src/types/Chat";
+import { SamplingParameters, CustomInstructionsType } from "src/types/Chat";
 
 const CHAT_CONFIG_KEY = "CHAT_CONFIG_V2";
 
@@ -12,6 +12,7 @@ export type CachedChatConfig = {
   custom_presets: CustomPreset[];
   selectedPlugins: PluginEntry[];
   plugins: PluginEntry[]; // all plugins user added
+  custom_instructions: CustomInstructionsType;
 };
 
 export const setConfigCache = (config: CachedChatConfig) => {


### PR DESCRIPTION
Added basic functionality of "custom-instructions"

It utilises two additional fields in work_parameters:
- user_profile (here user would describe what he wants to share with
  llm, for chat session)
- user_response_instructions (here user would describe how they want llm to
  respond to questions and queries, like format, style, length, etc...)
  
Here are some of the current UI changes introduced with this PR.
<details>
  <summary>Custom instructions</summary>
<img width="1243" alt="Screenshot 2023-07-23 at 21 46 36" src="https://github.com/LAION-AI/Open-Assistant/assets/13547364/ecf66109-3136-4e4b-8510-f6746422b4a9">
<img width="1220" alt="Screenshot 2023-07-23 at 21 46 42" src="https://github.com/LAION-AI/Open-Assistant/assets/13547364/ca860b86-8da3-4d33-a50d-649021ba083c">
<img width="1318" alt="Screenshot 2023-07-23 at 21 47 16" src="https://github.com/LAION-AI/Open-Assistant/assets/13547364/c060fd36-d676-4505-8625-9614199d27db">
<img width="1340" alt="Screenshot 2023-07-23 at 21 48 21" src="https://github.com/LAION-AI/Open-Assistant/assets/13547364/5cb36263-66ba-4421-b1c9-54b09e54f145">
<img width="1337" alt="Screenshot 2023-07-23 at 21 48 29" src="https://github.com/LAION-AI/Open-Assistant/assets/13547364/2f42d7d7-f014-4b6b-8c80-87c17811370d">
</details>

