### PR TITLE
Add Alpaca Persian Dataset

### DIFF
--- a/data/datasets/__init__.py
+++ b/data/datasets/__init__.py
@@ -34,6 +34,7 @@ INSTRUCTION_DATASETS = {
     "reasoning_bg_oa": "0x22almostEvil/reasoning_bg_oa",
     "reasoning_gsm_qna_oa": "0x22almostEvil/reasoning-gsm-qna-oa",
     "semantics_ws_qna_oa": "0x22almostEvil/semantics-ws-qna-oa",
+    "alpaca-fa-instruction": "pourmand1376/alpaca-fa-instruction",
 }
 
 SAFETY_DATASETS = {

--- a/data/datasets/alpaca-fa-instruction/README.md
+++ b/data/datasets/alpaca-fa-instruction/README.md
@@ -1,0 +1,2 @@
+This is a persian instruction dataset. The dataset is uploaded
+[here](https://huggingface.co/datasets/pourmand1376/alpaca-fa-instruction).

--- a/data/datasets/alpaca-fa-multi/README.md
+++ b/data/datasets/alpaca-fa-multi/README.md
@@ -1,0 +1,4 @@
+This is an multi-turn persian dataset which is in
+[orca-chat](https://huggingface.co/datasets/shahules786/orca-chat) format. It is
+published in
+[huggingface](https://huggingface.co/datasets/pourmand1376/alpaca-fa-multi).

--- a/model/model_training/custom_datasets/instruction.py
+++ b/model/model_training/custom_datasets/instruction.py
@@ -32,6 +32,7 @@ INSTRUCTION_DATASETS = {
     "evol_instruct_code": "nickrosh/Evol-Instruct-Code-80k-v1",
     "evol-codealpaca-v1": "theblackcat102/evol-codealpaca-v1",
     "cot_submix_original": "conceptofmind/cot_submix_original",
+    "alpaca-fa-instruction": "pourmand1376/alpaca-fa-instruction",
 }
 
 


### PR DESCRIPTION
Hi, 
In the last two days, I have been working on translating alpaca into Persian (Farsi) and this is the result. I have reviewed the translations and they are in my opinion pretty good. 

Also, the dataset is still translating on Kaggle and will be finished in a couple of days. I will update the datasets accordingly when the translation is complete. 

I have added two datasets. One is instruction-based and one is [orca-style](https://huggingface.co/datasets/shahules786/orca-chat) dataset. For the first one, I knew how to add it. But I don't know how to add the orca dataset to your datasets. 

Thank you for your attention.
