### PR TITLE
To support pip install for model_training package.

### DIFF
--- a/model/pyproject.toml
+++ b/model/pyproject.toml
@@ -42,7 +42,7 @@ tests = [
 ]
 
 [tool.setuptools]
-py-modules = ["model_training"]
+packages = ["model_training"]
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
For the Python module: model_training, the original package management file pyproject.toml was configured with "py-modules = ["model_training"]". However, "py-modules" is typically used for setting up single file modules, not for Python packages. The original configuration could possibly cause "pip install ." to fail to install model_training in the Python environment (only model_training-1.0.0.dist-info is available under /usr/local/lib/python/).