### PR TITLE
Make sure eval subset is sampled without replacing

### DIFF
--- a/model/model_training/custom_datasets/__init__.py
+++ b/model/model_training/custom_datasets/__init__.py
@@ -196,7 +196,7 @@ def get_one_dataset(
         train, eval = train_val_dataset(dataset, val_split=val_split)
 
     if eval and max_val_set and len(eval) > max_val_set:
-        subset_indices = np.random.choice(len(eval), max_val_set)
+        subset_indices = np.random.choice(len(eval), size=max_val_set, replace=False)
         eval = Subset(eval, subset_indices)
 
     return train, eval


### PR DESCRIPTION
Explicitly specify `replace=False` for [numpy.random.choice](https://numpy.org/doc/stable/reference/random/generated/numpy.random.choice.html) (it was missing and default is `replace=True` which could lead to duplicate examples in the evaluation set). 