### PR TITLE
Add pretokenizer utility

### DIFF
--- a/model/pretokenizer/README.md
+++ b/model/pretokenizer/README.md
@@ -1,0 +1,34 @@
+# OA pretokenizer
+
+The pretokenizer allows to tokenize datasets before training with the
+[epfLLM/Megatron-LLM](https://github.com/epfLLM/Megatron-LLM) fork.
+
+### Configuration
+
+The datamix to proces can be configured with one or multiple sections in the
+`configs/pretokenize.yaml` file.
+
+### Example usage
+
+```
+python __main__.py --output_dir output--configs oasst_top1 llama2 --compress --write_json
+```
+
+### Help message
+
+```
+usage: pretokenizer [-h] --configs CONFIGS [CONFIGS ...] [--output_dir OUTPUT_DIR] [--write_json] [--compress]
+
+Tokenize datamixes for LLama2/Falcon fine-tuning with Megatron-LLM.
+
+options:
+  -h, --help            show this help message and exit
+
+configuration:
+  --configs CONFIGS [CONFIGS ...]
+                        Configurations sections to apply (read from YAML, multiple can be specified).
+  --output_dir OUTPUT_DIR
+                        Path to output directory
+  --write_json          Generate a JSONL file with the formatted dialogues (key='text').
+  --compress            Generate a .tar.gz file of the output directory.
+```

--- a/model/pretokenizer/README.md
+++ b/model/pretokenizer/README.md
@@ -1,7 +1,21 @@
-# OA pretokenizer
+# OA Pretokenizer Utility
 
 The pretokenizer allows to tokenize datasets before training with the
 [epfLLM/Megatron-LLM](https://github.com/epfLLM/Megatron-LLM) fork.
+
+## Requirements
+
+1. make sure the `model_training` module is installed:
+
+```bash
+pip install -e ..
+```
+
+2. Make sure the `oasst_data` module is installed:
+
+```bash
+python -m pip install ../../oasst-data/
+```
 
 ### Configuration
 
@@ -11,13 +25,13 @@ The datamix to proces can be configured with one or multiple sections in the
 ### Example usage
 
 ```
-python __main__.py --output_dir output--configs oasst_top1 llama2 --compress --write_json
+python pretokenize.py --output_dir output--configs oasst_top1 llama2 --compress --write_json
 ```
 
 ### Help message
 
 ```
-usage: pretokenizer [-h] --configs CONFIGS [CONFIGS ...] [--output_dir OUTPUT_DIR] [--write_json] [--compress]
+usage: pretokenize.py [-h] --configs CONFIGS [CONFIGS ...] [--output_dir OUTPUT_DIR] [--write_json] [--compress]
 
 Tokenize datamixes for LLama2/Falcon fine-tuning with Megatron-LLM.
 

--- a/model/pretokenizer/__main__.py
+++ b/model/pretokenizer/__main__.py
@@ -1,0 +1,421 @@
+import argparse
+import json
+import random
+from enum import IntEnum
+from pathlib import Path
+from subprocess import run
+
+import indexed_dataset
+import numpy as np
+import torch
+from model_training.custom_datasets.formatting import DatasetEntryLm, DatasetEntrySft, Role
+from model_training.utils.utils import _strtobool, get_dataset, get_dataset_fractions, read_yamls
+from tokenizer import build_tokenizer
+from torch.utils.data import ConcatDataset, Dataset, Subset
+from tqdm import tqdm
+
+
+class IntRole(IntEnum):
+    System = 0
+    Prompter = 1
+    Assistant = 2
+
+
+class Encoder(object):
+    def __init__(self, args):
+        self.args = args
+        self.tokenizer = build_tokenizer(self.args)
+
+    def encode_text(self, text: str) -> list[int]:
+        return self.tokenizer.tokenize(text)
+
+    def decode(self, tokens: list[int]) -> str:
+        return self.tokenizer.detokenize(tokens)
+
+    @property
+    def special_tokens(self) -> dict:
+        return self.tokenizer._special_tokens
+
+
+class DatasetWriter:
+    def __init__(
+        self,
+        filename_prefix: str,
+        vocab_size: int,
+        dataset_impl: str = "mmap",
+        feature: str = "text",
+    ):
+        self.bin_filename = f"{filename_prefix}-{feature}.bin"
+        self.idx_filename = f"{filename_prefix}-{feature}.idx"
+        self.builder = indexed_dataset.make_builder(self.bin_filename, impl=dataset_impl, vocab_size=vocab_size)
+
+    def add_item(self, tokenized_item):
+        self.builder.add_item(torch.IntTensor(tokenized_item))
+
+    def finalize(self):
+        self.builder.finalize(self.idx_filename)
+
+
+def format_pairs(pairs: list[str] | tuple[str]) -> tuple[list[str], list[int]]:
+    assert isinstance(pairs, list) or isinstance(pairs, tuple)
+    role_names = ("user", "assistant")
+    role_ids = (1, 2)
+    return [f"<|im_start|>{role_names[i%2]}\n{pairs[i]}<|im_end|>\n" for i in range(len(pairs))], [
+        role_ids[i % 2] for i in range(len(pairs))
+    ]
+
+
+def format_sft_entry(entry: DatasetEntrySft) -> tuple[list[str], list[int]]:
+    turns = []
+    roles = []
+    if entry.system_message and len(entry.system_message) > 0:
+        turns.append(f"<|im_start|>system\n{entry.system_message}<|im_end|>\n")
+        roles.append(IntRole.System.value)  # 0
+    for m in entry.conversation:
+        if m.role == Role.prompter:
+            turns.append(f"<|im_start|>user\n{m.text}<|im_end|>\n")
+            roles.append(IntRole.Prompter.value)  # 1
+        elif m.role == Role.assistant:
+            turns.append(f"<|im_start|>assistant\n{m.text}<|im_end|>\n")
+            roles.append(IntRole.Assistant.value)  # 2
+    return turns, roles
+
+
+def format_conversation(messages) -> str:
+    if isinstance(messages, DatasetEntrySft):
+        return format_sft_entry(messages)
+    elif isinstance(messages, DatasetEntryLm):
+        return messages.text, [3]
+    else:
+        return format_pairs(messages)
+
+
+class TokenStats:
+    def __init__(self, name: str, total_samples: int, fraction: float = 1):
+        self.name = name
+        self.skipped_samples = 0
+        self.skipped_tokens = 0
+        self.total_samples = total_samples
+        self.min_tokens = None
+        self.max_tokens = 0
+        self.accepted_samples = 0
+        self.accepted_tokens = 0
+        self.fraction = fraction
+
+    @property
+    def processed_samples(self) -> int:
+        return self.accepted_samples + self.skipped_samples
+
+    def skip(self, tokens: list[int]) -> None:
+        self.skipped_samples += 1
+        self.skipped_tokens = len(tokens)
+
+    def add(self, tokens: list[int]) -> None:
+        l = len(tokens)
+        self.accepted_samples += 1
+        self.accepted_tokens += l
+        if self.min_tokens is None or self.min_tokens > l:
+            self.min_tokens = l
+        if self.max_tokens < l:
+            self.max_tokens = l
+
+
+def tokenize_dataset(
+    output_dir: Path,
+    filename_prefix: str,
+    dataset: Dataset,
+    encoder: Encoder,
+    dataset_impl: str,
+    datasets_config: dict,
+    max_count: int | None = None,
+    min_assistant_tokens: int | None = None,
+    check_tokenization: bool = True,
+    write_json: bool = False,
+    seed: int = 42,
+):
+    full_prefix = str(output_dir / filename_prefix)
+
+    token_writer = None
+    role_writer = None
+    jsonl_file = None
+
+    per_dataset_stats: list[TokenStats] = []
+    cumulative_sizes: list[int] = []
+
+    rng = np.random.RandomState(seed=seed)
+
+    if isinstance(dataset, ConcatDataset):
+        datasets = list(dataset.datasets)
+
+        if datasets_config:
+            dataset_sizes = [len(x) for x in datasets]
+            fractions = get_dataset_fractions(datasets_config, dataset_sizes, False)
+            dataset_target_sizes = [int(size * frac) for size, frac in zip(dataset_sizes, fractions)]
+        else:
+            dataset_target_sizes = None
+
+        for i in range(len(datasets)):
+            d = datasets[i]
+            if isinstance(d, Subset):
+                if hasattr(d.dataset, "name"):
+                    name = d.dataset.name
+                else:
+                    name = f"Subset of {type(d.dataset).__name__}"
+            else:
+                if hasattr(d, "name"):
+                    name = d.name
+                else:
+                    name = type(d).__name__
+
+            frac = 1
+            if dataset_target_sizes:
+                frac = fractions[i]
+                if dataset_target_sizes[i] < len(d):
+                    # sample subset of dataset
+                    subset_indices = rng.choice(len(d), size=dataset_target_sizes[i], replace=False)
+                    d = Subset(d, subset_indices)
+                    datasets[i] = d
+
+            per_dataset_stats.append(TokenStats(name, len(d), frac))
+
+        dataset = ConcatDataset(datasets)
+        cumulative_sizes = dataset.cumulative_sizes
+    else:
+        cumulative_sizes = [len(dataset)]
+
+    total_stats = TokenStats("total", len(dataset))
+
+    try:
+        token_writer = DatasetWriter(
+            filename_prefix=full_prefix,
+            dataset_impl=dataset_impl,
+            vocab_size=encoder.tokenizer.vocab_size,
+            feature="text",
+        )
+
+        role_writer = DatasetWriter(
+            filename_prefix=full_prefix,
+            dataset_impl=dataset_impl,
+            vocab_size=16,
+            feature="role",
+        )
+
+        jsonl_path = Path(full_prefix + ".jsonl")
+        if write_json:
+            jsonl_file = jsonl_path.open("w", encoding="UTF-8")
+
+        subset_index = 0
+        for i, messages in enumerate(tqdm(dataset)):
+            if i >= cumulative_sizes[subset_index]:
+                subset_index += 1
+
+            if i > 0 and i % 10000 == 0:
+                print(
+                    f"Accepted: {total_stats.accepted_samples}/{total_stats.processed_samples} ({total_stats.accepted_samples/total_stats.processed_samples:.1%})"
+                )
+
+            turns, turn_roles = format_conversation(messages)
+
+            tokens = []
+            role_lables = []
+            num_assistant_tokens = 0
+            for t, r in zip(turns, turn_roles):
+                turn_tokens = encoder.encode_text(t)
+                turn_role = [r] * len(turn_tokens)
+                tokens.extend(turn_tokens)
+                if r == IntRole.Assistant:
+                    num_assistant_tokens += len(turn_tokens)
+                role_lables.extend(turn_role)
+
+            if min_assistant_tokens is not None and num_assistant_tokens < min_assistant_tokens:
+                total_stats.skip(tokens)
+                per_dataset_stats[subset_index].skip(tokens)
+                continue
+
+            if check_tokenization:
+                x = encoder.encode_text("".join(turns))
+                assert x == tokens and len(tokens) == len(role_lables)
+
+            token_writer.add_item(tokens)
+            role_writer.add_item(role_lables)
+
+            # update stats
+            total_stats.add(tokens)
+            per_dataset_stats[subset_index].add(tokens)
+
+            if jsonl_file:
+                json.dump({"text": "".join(turns)}, jsonl_file)
+                jsonl_file.write("\n")
+
+            if max_count and total_stats.accepted_samples >= max_count:
+                break
+    finally:
+        if token_writer:
+            token_writer.finalize()
+        if role_writer:
+            role_writer.finalize()
+        if jsonl_file:
+            jsonl_file.close()
+
+    print(f"\n# Stats for {full_prefix}*\n")
+
+    for stats in per_dataset_stats:
+        print(f"## Stats for '{stats.name}' ({stats.total_samples} samples ({stats.fraction:.1%}))")
+        print("-----------------")
+        print(
+            f"  Accepted: {stats.accepted_samples}/{stats.processed_samples} ({stats.accepted_samples/stats.processed_samples:.1%})"
+        )
+        print(f"  Accepted tokens: {stats.accepted_tokens}")
+        print(f"  Skipped: {stats.skipped_samples} ({stats.skipped_samples/stats.processed_samples:.1%})")
+        print(f"  Min tokens per sample: {stats.min_tokens}")
+        print(f"  Max tokens per sample: {stats.max_tokens}")
+        print(f"  Avg tokens per sample: {stats.accepted_tokens/stats.accepted_samples}")
+        print("-----------------\n")
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        prog="pretokenizer", description="Tokenize datamixes for LLama2/Falcon fine-tuning with Megatron-LLM."
+    )
+    group = parser.add_argument_group(title="configuration")
+    group.add_argument(
+        "--configs",
+        nargs="+",
+        required=True,
+        help="Configurations sections to apply (read from YAML, multiple can be specified).",
+    )
+    group.add_argument(
+        "--output_dir",
+        type=str,
+        help="Path to output directory",
+    )
+    group.add_argument(
+        "--write_json",
+        action="store_true",
+        help="Generate a JSONL file with the formatted dialogues (key='text').",
+    )
+    group.add_argument(
+        "--compress",
+        action="store_true",
+        help="Generate a .tar.gz file of the output directory.",
+    )
+
+    args, remaining = parser.parse_known_args()
+
+    # load yaml configurations
+    conf = {}
+    configs = read_yamls("./configs")
+    conf.update(configs["defaults"])
+    try:
+        for name in args.configs:
+            if "," in name:
+                for n in name.split(","):
+                    conf.update(configs[n])
+            else:
+                conf.update(configs[name])
+    except KeyError as e:
+        print(f'Error: Section "{e.args[0]}" not found in YAML configuration files.')
+        exit(1)
+
+    # override yaml args
+    for k, v in vars(args).items():
+        if k == "configs" or v is None:
+            continue
+        conf[k] = v
+
+    parser = argparse.ArgumentParser()
+    for key, value in conf.items():
+        type_ = type(value) if value is not None else str
+        if type_ == bool:
+            type_ = _strtobool
+        parser.add_argument(f"--{key}", type=type_, default=value)
+        # Allow --no-{key}  to remove a configuration value
+        parser.add_argument(f"--no-{key}", dest=key, action="store_const", const=None)
+    parser.add_argument(
+        "--max_count",
+        type=int,
+        help="Limit number of train/eval examples to process (debug)",
+    )
+
+    args = parser.parse_args(remaining)
+    args.keep_empty = False
+    args.rank = 0
+    args.vocab_extra_ids = 0
+    args.make_vocab_size_divisible_by = 128
+    args.tensor_model_parallel_size = 1
+    args.new_tokens = True
+
+    return args
+
+
+def main():
+    """
+    Example usage: `python __main__.py --output_dir output--configs oasst_top1 llama2`
+    """
+    args = parse_args()
+    print("Configuration:")
+    for k, v in vars(args).items():
+        print(f"{k}: {v}")
+
+    # initialize random states for reproducibility
+    random.seed(args.rng_seed)
+    np.random.seed(args.rng_seed)
+    torch.manual_seed(args.rng_seed)
+
+    print("Building encoder")
+    encoder = Encoder(args)
+
+    tokenizer_check_input = "<|im_start|>system\nsystem message<|im_end|>\n<|im_start|>user\nprompt<|im_end|><|im_start|>assistant\nreply<|im_end|>\n"
+    tokenizer_check_output = encoder.encode_text(tokenizer_check_input)
+    print("Tokenizer check:")
+    print("Input:", tokenizer_check_input.replace("\n", r"\n"))
+    print("Output:", tokenizer_check_output)
+    print(f"Vocab size: {encoder.tokenizer.vocab_size}")
+
+    output_dir = Path(args.output_dir + args.output_dir_suffix)
+    print(f"Output dir: {output_dir} (exists: {output_dir.exists()})")
+
+    train, evals = get_dataset(args)
+
+    # show dataset stats
+    print("Training dataset sizes (before sampling):")
+    total = len(train)
+    for d in train.datasets:
+        if isinstance(d, Subset):
+            name = f"Subset of {type(d.dataset).__name__}"
+            if hasattr(d.dataset, "name"):
+                name += f" ({d.dataset.name})"
+        else:
+            name = type(d).__name__
+            if hasattr(d, "name"):
+                name += f" ({d.name})"
+        print(f"{name}: {len(d)} ({len(d) / total:.2%})")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    fn = output_dir / "special_tokens.json"
+    with fn.open("w") as f:
+        json.dump(encoder.special_tokens, f)
+
+    val = ConcatDataset(evals.values())
+    for split_name, ds in zip(["train", "val"], [train, val]):
+        datasets_config = args.datasets if split_name == "train" else None
+        tokenize_dataset(
+            output_dir=output_dir,
+            filename_prefix=f"{args.filename_prefix}-{split_name}",
+            dataset=ds,
+            encoder=encoder,
+            dataset_impl=args.dataset_impl,
+            datasets_config=datasets_config,
+            max_count=args.max_count,
+            min_assistant_tokens=args.min_assistant_tokens,
+            write_json=args.write_json,
+            seed=args.rng_seed,
+        )
+
+    if args.compress:
+        run(f"tar -czvf {output_dir}.tar.gz {output_dir}", shell=True, check=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/model/pretokenizer/configs/pretokenize.yaml
+++ b/model/pretokenizer/configs/pretokenize.yaml
@@ -1,0 +1,58 @@
+defaults:
+  rng_seed: 42
+  cache_dir: .cache
+  use_system_prefix: false
+  datasets_extra: [] # For config options to add additional datasets, since yaml doesn't let us extend arrays
+  eval_size:
+  tokenizer_type:
+  vocab_extra_ids_list: "<|im_start|>,<|im_end|>"
+  dataset_impl: "mmap"
+  min_assistant_tokens:
+  output_dir_suffix: ""
+
+llama2:
+  vocab_file: "/home/ubuntu/megatron-data/llama2-7b/tokenizer.model"
+  tokenizer_type: "SentencePieceTokenizer"
+  output_dir_suffix: "_llama2"
+
+falcon:
+  tokenizer_type: "FalconTokenizer"
+  output_dir_suffix: "_falcon"
+
+oasst_top1:
+  datasets:
+    - oasst_export:
+        lang: "bg,ca,cs,da,de,en,es,fr,hr,hu,it,nl,pl,pt,ro,ru,sl,sr,sv,uk"
+        #hf_dataset_name: OpenAssistant/oasst1
+        input_file_path: 2023-07-23_oasst_ready.tar.gz
+        top_k: 1
+        val_split: 0.05
+  output_dir: "output/oasst_top1_2023-07-23"
+  filename_prefix: "oasst_top1"
+
+megacode2_min100:
+  datasets:
+    - megacode2:
+        val_split: 0.01
+        max_val_set: 1000
+  output_dir: "output/megacode2_min100"
+  filename_prefix: "megacode2"
+  min_assistant_tokens: 100
+
+megacode2_min50:
+  datasets:
+    - megacode2:
+        val_split: 0.01
+        max_val_set: 1000
+  output_dir: "output/megacode2_min50"
+  filename_prefix: "megacode2"
+  min_assistant_tokens: 100
+
+megacode2_frac05:
+  datasets:
+    - megacode2:
+        fraction: 0.5
+        val_split: 0.01
+        max_val_set: 1000
+  output_dir: "output/megacode2_frac05"
+  filename_prefix: "megacode2"

--- a/model/pretokenizer/configs/pretokenize.yaml
+++ b/model/pretokenizer/configs/pretokenize.yaml
@@ -46,7 +46,7 @@ megacode2_min50:
         max_val_set: 1000
   output_dir: "output/megacode2_min50"
   filename_prefix: "megacode2"
-  min_assistant_tokens: 100
+  min_assistant_tokens: 50
 
 megacode2_frac05:
   datasets:

--- a/model/pretokenizer/create_hf_tokenizer_config.py
+++ b/model/pretokenizer/create_hf_tokenizer_config.py
@@ -1,0 +1,112 @@
+import argparse
+from distutils.util import strtobool as strtoboolint
+
+import transformers
+from tokenizer import build_tokenizer
+from transformers.utils import cached_file
+
+
+def strtobool(s: str) -> bool:
+    return bool(strtoboolint(s))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tokenizer_type", type=str, default="SentencePieceTokenizer", help="SentencePieceTokenizer or FalconTokenizer"
+    )
+    parser.add_argument(
+        "--vocab_file", type=str, help="[optional] vocab file for SentencePiece (get from HF cache by default)"
+    )
+    parser.add_argument(
+        "--tokenizer_name",
+        type=str,
+        default="meta-llama/Llama-2-7b-hf",
+        help="HuggingFace repo name or path, e.g. 'meta-llama/Llama-2-7b-hf' or 'tiiuae/falcon-40b'",
+    )
+    parser.add_argument("--cache_dir", type=str, default=None, help="Huggingface cache directory ")
+    parser.add_argument(
+        "--vocab_extra_ids_list",
+        type=str,
+        default="<|im_start|>,<|im_end|>",
+        help='Comma separated list of additional tokens (e.g. "<|im_start|>,<|im_end|>")',
+    )
+    parser.add_argument("--output_dir", type=str, default="output", help="Path of output directory")
+    return parser.parse_args()
+
+
+def main():
+    """
+    Usage examples:
+    python create_hf_tokenizer_config.py --tokenizer_type SentencePieceTokenizer --tokenizer_name meta-llama/Llama-2-7b-hf --output_dir output
+    python create_hf_tokenizer_config.py --tokenizer_type FalconTokenizer --tokenizer_name tiiuae/falcon-40b --output_dir output
+    """
+    args = parse_args()
+    print("Configuration:")
+    for k, v in vars(args).items():
+        print(f"{k}: {v}")
+
+    hf_tokenizer = transformers.AutoTokenizer.from_pretrained(args.tokenizer_name, cache_dir=args.cache_dir)
+
+    print("tokenizer.vocab_files_names", hf_tokenizer.vocab_files_names)
+
+    if args.tokenizer_type == "FalconTokenizer":
+        args.vocab_file = ""
+    elif args.vocab_file is None:
+        args.vocab_file = cached_file(
+            args.tokenizer_name, hf_tokenizer.vocab_files_names["vocab_file"], cache_dir=args.cache_dir
+        )
+
+    # add default args for megatron tokenizer
+    args.rank = 0
+    args.vocab_extra_ids = 0
+    args.new_tokens = True
+    args.make_vocab_size_divisible_by = 128
+    args.tensor_model_parallel_size = 1
+    mt_tokenizer = build_tokenizer(args)
+
+    if args.tokenizer_type == "SentencePieceTokenizer":
+        print("_special_tokens", mt_tokenizer._special_tokens)
+        print("additional_special_tokens_ids", mt_tokenizer.additional_special_tokens_ids)
+
+        hf_tokenizer.add_tokens("<CLS>", special_tokens=True)
+        hf_tokenizer.add_tokens("<SEP>", special_tokens=True)
+        hf_tokenizer.add_tokens("<EOD>", special_tokens=True)
+        hf_tokenizer.add_tokens("<MASK>", special_tokens=True)
+        hf_tokenizer.add_tokens("<PAD>", special_tokens=True)
+        hf_tokenizer.cls_token_id = mt_tokenizer.cls
+        hf_tokenizer.sep_token_id = mt_tokenizer.sep
+        hf_tokenizer.mask_token_id = mt_tokenizer.mask
+        hf_tokenizer.pad_token_id = mt_tokenizer.pad
+
+        additional_special_tokens = hf_tokenizer.additional_special_tokens
+        special_tokens = {"additional_special_tokens": additional_special_tokens}
+        if args.vocab_extra_ids_list:
+            additional_special_tokens.extend(args.vocab_extra_ids_list.split(","))
+
+        hf_tokenizer.add_special_tokens(special_tokens_dict=special_tokens, replace_additional_special_tokens=True)
+
+        additional_special_tokens_ids = [mt_tokenizer.vocab.get(t) for t in additional_special_tokens]
+        hf_tokenizer.additional_special_tokens_ids = additional_special_tokens_ids
+
+        tokens_to_check = [
+            v for k, v in hf_tokenizer.special_tokens_map.items() if k != "additional_special_tokens"
+        ] + additional_special_tokens
+        print("checking token ids:")
+        for t in tokens_to_check:
+            a = mt_tokenizer.vocab.get(t)
+            b = hf_tokenizer.vocab.get(t)
+            print(f"{t}: {a} (mt) == {b} (hf)")
+            assert a == b, "Mismatch between megatron and huggingface tokenizer vocabularies"
+    elif args.tokenizer_type == "FalconTokenizer":
+        hf_tokenizer = mt_tokenizer.tokenizer
+    else:
+        raise RuntimeError(f"Unsupported tokenizer type: {args.tokenizer_type}")
+
+    print("special_tokens_map:", hf_tokenizer.special_tokens_map)
+
+    hf_tokenizer.save_pretrained(args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/model/pretokenizer/indexed_dataset.py
+++ b/model/pretokenizer/indexed_dataset.py
@@ -1,0 +1,565 @@
+# copied from https://github.com/epfLLM/Megatron-LLM/blob/main/megatron/data/indexed_dataset.py
+
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+
+# copied from fairseq/fairseq/data/indexed_dataset.py
+# Removed IndexedRawTextDataset since it relied on Fairseq dictionary
+# other slight modifications to remove fairseq dependencies
+# Added document index to index file and made it accessible.
+#    An empty sentence no longer separates documents.
+
+import os
+import shutil
+import struct
+from functools import lru_cache
+from itertools import accumulate
+
+import numpy as np
+import torch
+
+# from megatron import print_rank_0
+
+print_rank_0 = print  # avoid dependency
+
+
+def __best_fitting_dtype(vocab_size=None):
+    if vocab_size is not None and vocab_size < 65500:
+        return np.uint16
+    else:
+        return np.int32
+
+
+def get_available_dataset_impl():
+    return ["lazy", "cached", "mmap"]
+
+
+def infer_dataset_impl(path):
+    if IndexedDataset.exists(path):
+        with open(index_file_path(path), "rb") as f:
+            magic = f.read(8)
+            if magic == IndexedDataset._HDR_MAGIC:
+                return "cached"
+            elif magic == MMapIndexedDataset.Index._HDR_MAGIC[:8]:
+                return "mmap"
+            else:
+                return None
+    else:
+        print(f"Dataset does not exist: {path}")
+        print("Path should be a basename that both .idx and .bin can be appended to get full filenames.")
+        return None
+
+
+def make_builder(out_file, impl, vocab_size=None):
+    if impl == "mmap":
+        return MMapIndexedDatasetBuilder(out_file, dtype=__best_fitting_dtype(vocab_size))
+    else:
+        return IndexedDatasetBuilder(out_file)
+
+
+def make_dataset(path, impl: str, skip_warmup=False):
+    if not IndexedDataset.exists(path):
+        print(f"Dataset does not exist: {path}")
+        print("Path should be a basename that both .idx and .bin can be appended to get full filenames.")
+        return None
+
+    if impl == "infer":
+        impl = infer_dataset_impl(path)
+    if impl == "lazy" and IndexedDataset.exists(path):
+        return IndexedDataset(path)
+    elif impl == "cached" and IndexedDataset.exists(path):
+        return IndexedCachedDataset(path)
+    elif impl == "mmap" and MMapIndexedDataset.exists(path):
+        return MMapIndexedDataset(path, skip_warmup)
+    print(f"Unknown dataset implementation: {impl}")
+    return None
+
+
+def dataset_exists(path, impl):
+    if impl == "mmap":
+        return MMapIndexedDataset.exists(path)
+    else:
+        return IndexedDataset.exists(path)
+
+
+def read_longs(f, n):
+    a = np.empty(n, dtype=np.int64)
+    f.readinto(a)
+    return a
+
+
+def write_longs(f, a):
+    f.write(np.array(a, dtype=np.int64))
+
+
+dtypes = {1: np.uint8, 2: np.int8, 3: np.int16, 4: np.int32, 5: np.int64, 6: float, 7: np.double, 8: np.uint16}
+
+
+def code(dtype):
+    for k in dtypes.keys():
+        if dtypes[k] == dtype:
+            return k
+    raise ValueError(dtype)
+
+
+def index_file_path(prefix_path):
+    return prefix_path + ".idx"
+
+
+def data_file_path(prefix_path):
+    return prefix_path + ".bin"
+
+
+def create_doc_idx(sizes):
+    doc_idx = [0]
+    for i, s in enumerate(sizes):
+        if s == 0:
+            doc_idx.append(i + 1)
+    return doc_idx
+
+
+class IndexedDataset(torch.utils.data.Dataset):
+    """Loader for IndexedDataset"""
+
+    _HDR_MAGIC = b"TNTIDX\x00\x00"
+
+    def __init__(self, path):
+        super().__init__()
+        self.path = path
+        self.data_file = None
+        self.read_index(path)
+
+    def read_index(self, path):
+        with open(index_file_path(path), "rb") as f:
+            magic = f.read(8)
+            assert magic == self._HDR_MAGIC, (
+                "Index file doesn't match expected format. " "Make sure that --dataset_impl is configured properly."
+            )
+            version = f.read(8)
+            assert struct.unpack("<Q", version) == (1,)
+            code, self.element_size = struct.unpack("<QQ", f.read(16))
+            self.dtype = dtypes[code]
+            self._len, self.s = struct.unpack("<QQ", f.read(16))
+            self.doc_count = struct.unpack("<Q", f.read(8))
+            self.dim_offsets = read_longs(f, self._len + 1)
+            self.data_offsets = read_longs(f, self._len + 1)
+            self.sizes = read_longs(f, self.s)
+            self.doc_idx = read_longs(f, self.doc_count)
+
+    def read_data(self, path):
+        self.data_file = open(data_file_path(path), "rb", buffering=0)
+
+    def check_index(self, i):
+        if i < 0 or i >= self._len:
+            raise IndexError("index out of range")
+
+    def __del__(self):
+        if self.data_file:
+            self.data_file.close()
+
+    # @lru_cache(maxsize=8)
+    def __getitem__(self, idx):
+        if not self.data_file:
+            self.read_data(self.path)
+        if isinstance(idx, int):
+            i = idx
+            self.check_index(i)
+            tensor_size = self.sizes[self.dim_offsets[i] : self.dim_offsets[i + 1]]
+            a = np.empty(tensor_size, dtype=self.dtype)
+            self.data_file.seek(self.data_offsets[i] * self.element_size)
+            self.data_file.readinto(a)
+            return a
+        elif isinstance(idx, slice):
+            start, stop, step = idx.indices(len(self))
+            if step != 1:
+                raise ValueError("Slices into indexed_dataset must be contiguous")
+            sizes = self.sizes[self.dim_offsets[start] : self.dim_offsets[stop]]
+            size = sum(sizes)
+            a = np.empty(size, dtype=self.dtype)
+            self.data_file.seek(self.data_offsets[start] * self.element_size)
+            self.data_file.readinto(a)
+            offsets = list(accumulate(sizes))
+            sents = np.split(a, offsets[:-1])
+            return sents
+
+    def __len__(self):
+        return self._len
+
+    def num_tokens(self, index):
+        return self.sizes[index]
+
+    def size(self, index):
+        return self.sizes[index]
+
+    @staticmethod
+    def exists(path):
+        return os.path.exists(index_file_path(path)) and os.path.exists(data_file_path(path))
+
+    @property
+    def supports_prefetch(self):
+        return False  # avoid prefetching to save memory
+
+
+class IndexedCachedDataset(IndexedDataset):
+    def __init__(self, path):
+        super().__init__(path)
+        self.cache = None
+        self.cache_index = {}
+
+    @property
+    def supports_prefetch(self):
+        return True
+
+    def prefetch(self, indices):
+        if all(i in self.cache_index for i in indices):
+            return
+        if not self.data_file:
+            self.read_data(self.path)
+        indices = sorted(set(indices))
+        total_size = 0
+        for i in indices:
+            total_size += self.data_offsets[i + 1] - self.data_offsets[i]
+        self.cache = np.empty(total_size, dtype=self.dtype)
+        ptx = 0
+        self.cache_index.clear()
+        for i in indices:
+            self.cache_index[i] = ptx
+            size = self.data_offsets[i + 1] - self.data_offsets[i]
+            a = self.cache[ptx : ptx + size]
+            self.data_file.seek(self.data_offsets[i] * self.element_size)
+            self.data_file.readinto(a)
+            ptx += size
+        if self.data_file:
+            # close and delete data file after prefetch so we can pickle
+            self.data_file.close()
+            self.data_file = None
+
+    # @lru_cache(maxsize=8)
+    def __getitem__(self, idx):
+        if isinstance(idx, int):
+            i = idx
+            self.check_index(i)
+            tensor_size = self.sizes[self.dim_offsets[i] : self.dim_offsets[i + 1]]
+            a = np.empty(tensor_size, dtype=self.dtype)
+            ptx = self.cache_index[i]
+            np.copyto(a, self.cache[ptx : ptx + a.size])
+            return a
+        elif isinstance(idx, slice):
+            # Hack just to make this work, can optimizer later if necessary
+            sents = []
+            for i in range(*idx.indices(len(self))):
+                sents.append(self[i])
+            return sents
+
+
+class IndexedDatasetBuilder(object):
+    element_sizes = {np.uint8: 1, np.int8: 1, np.int16: 2, np.int32: 4, np.int64: 8, float: 4, np.double: 8}
+
+    def __init__(self, out_file, dtype=np.int32):
+        self.out_file = open(out_file, "wb")
+        self.dtype = dtype
+        self.data_offsets = [0]
+        self.dim_offsets = [0]
+        self.sizes = []
+        self.element_size = self.element_sizes[self.dtype]
+        self.doc_idx = [0]
+
+    def add_item(self, tensor):
+        bytes = self.out_file.write(np.array(tensor.numpy(), dtype=self.dtype))
+        self.data_offsets.append(self.data_offsets[-1] + bytes / self.element_size)
+        for s in tensor.size():
+            self.sizes.append(s)
+        self.dim_offsets.append(self.dim_offsets[-1] + len(tensor.size()))
+
+    def end_document(self):
+        self.doc_idx.append(len(self.sizes))
+
+    def merge_file_(self, another_file):
+        index = IndexedDataset(another_file)
+        assert index.dtype == self.dtype
+
+        doc_offset = len(self.sizes)
+
+        begin = self.data_offsets[-1]
+        for data_offset in index.data_offsets[1:]:
+            self.data_offsets.append(begin + data_offset)
+        self.sizes.extend(index.sizes)
+
+        begin = self.dim_offsets[-1]
+        for dim_offset in index.dim_offsets[1:]:
+            self.dim_offsets.append(begin + dim_offset)
+
+        self.doc_idx.extend((doc_offset + index.doc_idx)[1:])
+
+        with open(data_file_path(another_file), "rb") as f:
+            while True:
+                data = f.read(1024)
+                if data:
+                    self.out_file.write(data)
+                else:
+                    break
+
+    def finalize(self, index_file):
+        self.out_file.close()
+        index = open(index_file, "wb")
+        index.write(b"TNTIDX\x00\x00")
+        index.write(struct.pack("<Q", 1))
+        index.write(struct.pack("<QQ", code(self.dtype), self.element_size))
+        index.write(struct.pack("<QQ", len(self.data_offsets) - 1, len(self.sizes)))
+        index.write(struct.pack("<Q", len(self.doc_idx)))
+        write_longs(index, self.dim_offsets)
+        write_longs(index, self.data_offsets)
+        write_longs(index, self.sizes)
+        write_longs(index, self.doc_idx)
+        index.close()
+
+
+def _warmup_mmap_file(path):
+    with open(path, "rb") as stream:
+        while stream.read(100 * 1024 * 1024):
+            pass
+
+
+class MMapIndexedDataset(torch.utils.data.Dataset):
+    class Index(object):
+        _HDR_MAGIC = b"MMIDIDX\x00\x00"
+
+        @classmethod
+        def writer(cls, path, dtype):
+            class _Writer(object):
+                def __enter__(self):
+                    self._file = open(path, "wb")
+
+                    self._file.write(cls._HDR_MAGIC)
+                    self._file.write(struct.pack("<Q", 1))
+                    self._file.write(struct.pack("<B", code(dtype)))
+
+                    return self
+
+                @staticmethod
+                def _get_pointers(sizes):
+                    dtype_size = dtype().itemsize
+                    address = 0
+                    pointers = []
+
+                    for size in sizes:
+                        pointers.append(address)
+                        address += size * dtype_size
+
+                    return pointers
+
+                def write(self, sizes, doc_idx):
+                    pointers = self._get_pointers(sizes)
+
+                    self._file.write(struct.pack("<Q", len(sizes)))
+                    self._file.write(struct.pack("<Q", len(doc_idx)))
+
+                    sizes = np.array(sizes, dtype=np.int32)
+                    self._file.write(sizes.tobytes(order="C"))
+                    del sizes
+
+                    pointers = np.array(pointers, dtype=np.int64)
+                    self._file.write(pointers.tobytes(order="C"))
+                    del pointers
+
+                    doc_idx = np.array(doc_idx, dtype=np.int64)
+                    self._file.write(doc_idx.tobytes(order="C"))
+
+                def __exit__(self, exc_type, exc_val, exc_tb):
+                    self._file.close()
+
+            return _Writer()
+
+        def __init__(self, path, skip_warmup=False):
+            with open(path, "rb") as stream:
+                magic_test = stream.read(9)
+                assert self._HDR_MAGIC == magic_test, (
+                    "Index file doesn't match expected format. " "Make sure that --dataset_impl is configured properly."
+                )
+                version = struct.unpack("<Q", stream.read(8))
+                assert (1,) == version
+
+                (dtype_code,) = struct.unpack("<B", stream.read(1))
+                self._dtype = dtypes[dtype_code]
+                self._dtype_size = self._dtype().itemsize
+
+                self._len = struct.unpack("<Q", stream.read(8))[0]
+                self._doc_count = struct.unpack("<Q", stream.read(8))[0]
+                offset = stream.tell()
+
+            if not skip_warmup:
+                print_rank_0("    warming up index mmap file...")
+                _warmup_mmap_file(path)
+
+            self._bin_buffer_mmap = np.memmap(path, mode="r", order="C")
+            self._bin_buffer = memoryview(self._bin_buffer_mmap)
+            print_rank_0("    reading sizes...")
+            self._sizes = np.frombuffer(self._bin_buffer, dtype=np.int32, count=self._len, offset=offset)
+            print_rank_0("    reading pointers...")
+            self._pointers = np.frombuffer(
+                self._bin_buffer, dtype=np.int64, count=self._len, offset=offset + self._sizes.nbytes
+            )
+            print_rank_0("    reading document index...")
+            self._doc_idx = np.frombuffer(
+                self._bin_buffer,
+                dtype=np.int64,
+                count=self._doc_count,
+                offset=offset + self._sizes.nbytes + self._pointers.nbytes,
+            )
+
+        def __del__(self):
+            self._bin_buffer_mmap._mmap.close()
+            del self._bin_buffer_mmap
+
+        @property
+        def dtype(self):
+            return self._dtype
+
+        @property
+        def sizes(self):
+            return self._sizes
+
+        @property
+        def doc_idx(self):
+            return self._doc_idx
+
+        @lru_cache(maxsize=8)
+        def __getitem__(self, i):
+            return self._pointers[i], self._sizes[i]
+
+        def __len__(self):
+            return self._len
+
+    def __init__(self, path, skip_warmup=False):
+        super().__init__()
+
+        self._path = None
+        self._index = None
+        self._bin_buffer = None
+
+        self._do_init(path, skip_warmup)
+
+    def __getstate__(self):
+        return self._path
+
+    def __setstate__(self, state):
+        self._do_init(state)
+
+    def _do_init(self, path, skip_warmup):
+        self._path = path
+        self._index = self.Index(index_file_path(self._path), skip_warmup)
+
+        if not skip_warmup:
+            print_rank_0("    warming up data mmap file...")
+            _warmup_mmap_file(data_file_path(self._path))
+        print_rank_0("    creating numpy buffer of mmap...")
+        self._bin_buffer_mmap = np.memmap(data_file_path(self._path), mode="r", order="C")
+        print_rank_0("    creating memory view of numpy buffer...")
+        self._bin_buffer = memoryview(self._bin_buffer_mmap)
+
+    def __del__(self):
+        self._bin_buffer_mmap._mmap.close()
+        del self._bin_buffer_mmap
+        del self._index
+
+    def __len__(self):
+        return len(self._index)
+
+    # @lru_cache(maxsize=8)
+    def __getitem__(self, idx):
+        if isinstance(idx, (int, np.integer)):
+            ptr, size = self._index[idx]
+            np_array = np.frombuffer(self._bin_buffer, dtype=self._index.dtype, count=size, offset=ptr)
+            return np_array
+        elif isinstance(idx, slice):
+            start, stop, step = idx.indices(len(self))
+            if step != 1:
+                raise ValueError("Slices into indexed_dataset must be contiguous")
+            ptr = self._index._pointers[start]
+            sizes = self._index._sizes[idx]
+            offsets = list(accumulate(sizes))
+            total_size = sum(sizes)
+            np_array = np.frombuffer(self._bin_buffer, dtype=self._index.dtype, count=total_size, offset=ptr)
+            sents = np.split(np_array, offsets[:-1])
+            return sents
+        else:
+            raise TypeError("Unexpected type received for idx: {}".format(type(idx)))
+
+    def get(self, idx, offset=0, length=None):
+        """Retrieves a single item from the dataset with the option to only
+        return a portion of the item.
+
+        get(idx) is the same as [idx] but get() does not support slicing.
+        """
+        ptr, size = self._index[idx]
+        if length is None:
+            length = size - offset
+        ptr += offset * np.dtype(self._index.dtype).itemsize
+        np_array = np.frombuffer(self._bin_buffer, dtype=self._index.dtype, count=length, offset=ptr)
+        return np_array
+
+    @property
+    def sizes(self):
+        return self._index.sizes
+
+    @property
+    def doc_idx(self):
+        return self._index.doc_idx
+
+    def get_doc_idx(self):
+        return self._index._doc_idx
+
+    def set_doc_idx(self, doc_idx_):
+        self._index._doc_idx = doc_idx_
+
+    @property
+    def supports_prefetch(self):
+        return False
+
+    @staticmethod
+    def exists(path):
+        return os.path.exists(index_file_path(path)) and os.path.exists(data_file_path(path))
+
+
+class MMapIndexedDatasetBuilder(object):
+    def __init__(self, out_file, dtype=np.int64):
+        self._data_file = open(out_file, "wb")
+        self._dtype = dtype
+        self._sizes = []
+        self._doc_idx = [0]
+
+    def add_item(self, tensor):
+        np_array = np.array(tensor.numpy(), dtype=self._dtype)
+        self._data_file.write(np_array.tobytes(order="C"))
+        self._sizes.append(np_array.size)
+
+    def add_doc(self, tensor, sizes):
+        np_array = np.array(tensor, dtype=self._dtype)
+        self._data_file.write(np_array.tobytes(order="C"))
+        self._sizes.extend(sizes)
+        self._doc_idx.append(len(self._sizes))
+
+    def end_document(self):
+        self._doc_idx.append(len(self._sizes))
+
+    def merge_file_(self, another_file):
+        # Concatenate index
+        index = MMapIndexedDataset.Index(index_file_path(another_file))
+        assert index.dtype == self._dtype
+
+        offset = len(self._sizes)
+        self._sizes.extend(index.sizes)
+        self._doc_idx.extend((offset + index.doc_idx)[1:])
+
+        # Concatenate data
+        with open(data_file_path(another_file), "rb") as f:
+            shutil.copyfileobj(f, self._data_file)
+
+    def finalize(self, index_file):
+        self._data_file.close()
+
+        with MMapIndexedDataset.Index.writer(index_file, self._dtype) as index:
+            index.write(self._sizes, self._doc_idx)

--- a/model/pretokenizer/pretokenize.py
+++ b/model/pretokenizer/pretokenize.py
@@ -275,7 +275,7 @@ def tokenize_dataset(
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        prog="pretokenizer", description="Tokenize datamixes for LLama2/Falcon fine-tuning with Megatron-LLM."
+        prog="pretokenize.py", description="Tokenize datamixes for LLama2/Falcon fine-tuning with Megatron-LLM."
     )
     group = parser.add_argument_group(title="configuration")
     group.add_argument(

--- a/model/pretokenizer/requirements.txt
+++ b/model/pretokenizer/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.22.4
+sentencepiece==0.1.99
+torch>=2.0.0
+tqdm==4.65.0
+transformers==4.31.0

--- a/model/pretokenizer/tokenizer.py
+++ b/model/pretokenizer/tokenizer.py
@@ -1,0 +1,331 @@
+# copied from https://github.com/epfLLM/Megatron-LLM/blob/main/megatron/tokenizer/tokenizer.py
+# (only keeping _FalconTokenizer & _SentencePieceTokenizer)
+
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+
+"""Megatron tokenizers."""
+
+from abc import ABC, abstractmethod
+
+
+def build_tokenizer(args):
+    """Initialize tokenizer."""
+    if args.rank == 0:
+        print("> building {} tokenizer ...".format(args.tokenizer_type), flush=True)
+
+    if args.tokenizer_type not in {"SentencePieceTokenizer", "FalconTokenizer"}:
+        assert args.vocab_file is not None
+
+    # Select and instantiate the tokenizer.
+    if args.tokenizer_type == "SentencePieceTokenizer":
+        assert args.vocab_file is not None
+        tokenizer = _SentencePieceTokenizer(
+            args.vocab_file,
+            vocab_extra_ids=args.vocab_extra_ids,
+            vocab_extra_ids_list=args.vocab_extra_ids_list,
+            new_tokens=args.new_tokens,
+        )
+    elif args.tokenizer_type == "FalconTokenizer":
+        tokenizer = _FalconTokenizer(vocab_extra_ids_list=args.vocab_extra_ids_list, new_tokens=args.new_tokens)
+    else:
+        raise NotImplementedError("{} tokenizer is not " "implemented.".format(args.tokenizer_type))
+
+    # Add vocab size.
+    args.padded_vocab_size = _vocab_size_with_padding(tokenizer.vocab_size, args)
+
+    return tokenizer
+
+
+def _vocab_size_with_padding(orig_vocab_size, args):
+    """Pad vocab size so it is divisible by model parallel size and
+    still having GPU friendly size."""
+
+    after = orig_vocab_size
+    multiple = args.make_vocab_size_divisible_by * args.tensor_model_parallel_size
+    while (after % multiple) != 0:
+        after += 1
+    if args.rank == 0:
+        print(
+            " > padded vocab (size: {}) with {} dummy tokens "
+            "(new size: {})".format(orig_vocab_size, after - orig_vocab_size, after),
+            flush=True,
+        )
+    return after
+
+
+class AbstractTokenizer(ABC):
+    """Abstract class for tokenizer."""
+
+    def __init__(self, name):
+        self.name = name
+        super().__init__()
+
+    @property
+    @abstractmethod
+    def vocab_size(self):
+        pass
+
+    @property
+    @abstractmethod
+    def vocab(self):
+        """Dictionary from vocab text token to id token."""
+        pass
+
+    @property
+    @abstractmethod
+    def inv_vocab(self):
+        """Dictionary from vocab id token to text token."""
+        pass
+
+    @abstractmethod
+    def tokenize(self, text):
+        pass
+
+    def detokenize(self, token_ids):
+        raise NotImplementedError("detokenizer is not implemented for {} " "tokenizer".format(self.name))
+
+    @property
+    def cls(self):
+        raise NotImplementedError("CLS is not provided for {} " "tokenizer".format(self.name))
+
+    @property
+    def sep(self):
+        raise NotImplementedError("SEP is not provided for {} " "tokenizer".format(self.name))
+
+    @property
+    def pad(self):
+        raise NotImplementedError("PAD is not provided for {} " "tokenizer".format(self.name))
+
+    @property
+    def eod(self):
+        raise NotImplementedError("EOD is not provided for {} " "tokenizer".format(self.name))
+
+    @property
+    def mask(self):
+        raise NotImplementedError("MASK is not provided for {} " "tokenizer".format(self.name))
+
+
+class _FalconTokenizer(AbstractTokenizer):
+    """Wrapper of huggingface tokenizer."""
+
+    def __init__(self, vocab_extra_ids_list=None, new_tokens=True):
+        name = "FalconTokenizer"
+        super().__init__(name)
+        from transformers import AutoTokenizer
+
+        self.tokenizer = AutoTokenizer.from_pretrained("tiiuae/falcon-40b")
+
+        if vocab_extra_ids_list and new_tokens:
+            special_tokens = self.tokenizer.additional_special_tokens + vocab_extra_ids_list.split(",")
+            self.tokenizer.add_special_tokens({"additional_special_tokens": special_tokens})
+            self._special_tokens = {tok: self.vocab[tok] for tok in special_tokens}
+        else:
+            self._special_tokens = {}
+
+        self._inv_vocab = {idx: token for token, idx in self.tokenizer.vocab.items()}
+
+    @property
+    def vocab_size(self):
+        return len(self.tokenizer.vocab)
+
+    @property
+    def vocab(self):
+        return self.tokenizer.vocab
+
+    def tokenize(self, text):
+        return self.tokenizer.encode(text)
+
+    def detokenize(self, token_ids):
+        return self.tokenizer.decode(token_ids)
+
+    @property
+    def inv_vocab(self):
+        return self._inv_vocab
+
+    @property
+    def eod(self):
+        return self.eos_token_id
+
+    @property
+    def pad(self):
+        return self.eos_token_id
+
+    @property
+    def eos_token_id(self):
+        return self.tokenizer.eos_token_id
+
+
+class _SentencePieceTokenizer(AbstractTokenizer):
+    """SentencePieceTokenizer-Megatron wrapper"""
+
+    def __init__(self, model_file, vocab_extra_ids=0, vocab_extra_ids_list=None, new_tokens=True):
+        name = "SentencePieceTokenizer"
+        super().__init__(name)
+
+        import sentencepiece
+
+        self._tokenizer = sentencepiece.SentencePieceProcessor(model_file=model_file)
+
+        self._initalize(vocab_extra_ids, vocab_extra_ids_list, new_tokens)
+
+    def _initalize(self, vocab_extra_ids, vocab_extra_ids_list, new_tokens):
+        self._vocab = {}
+        self._inv_vocab = {}
+
+        self._special_tokens = {}
+        self._inv_special_tokens = {}
+
+        self._t5_tokens = []
+
+        for i in range(len(self._tokenizer)):
+            t = self._tokenizer.id_to_piece(i)
+            self._inv_vocab[i] = t
+            self._vocab[t] = i
+
+        def _add_special_token(t):
+            if t not in self.vocab and not new_tokens:
+                return
+            if t not in self._vocab:
+                next_id = len(self._vocab)
+                self._vocab[t] = next_id
+                self._inv_vocab[next_id] = t
+            self._special_tokens[t] = self._vocab[t]
+            self._inv_special_tokens[self._vocab[t]] = t
+
+        _add_special_token("<CLS>")
+        self._cls_id = self._vocab.get("<CLS>")
+        _add_special_token("<SEP>")
+        self._sep_id = self._vocab.get("<SEP>")
+        _add_special_token("<EOD>")
+        self._eod_id = self._vocab.get("<EOD>")
+        _add_special_token("<MASK>")
+        self._mask_id = self._vocab.get("<MASK>")
+
+        pad_id = self._tokenizer.pad_id()
+        try:
+            pad_token = self._tokenizer.id_to_piece(pad_id)
+        except IndexError:
+            pad_token = "<PAD>"
+        _add_special_token(pad_token)
+        self._pad_id = self._vocab.get(pad_token)
+
+        bos_id = self._tokenizer.bos_id()
+        try:
+            bos_token = self._tokenizer.id_to_piece(bos_id)
+        except IndexError:
+            bos_token = "<BOS>"
+        _add_special_token(bos_token)
+        self._bos_id = self._vocab.get(bos_token)
+
+        eos_id = self._tokenizer.eos_id()
+        try:
+            eos_token = self._tokenizer.id_to_piece(eos_id)
+        except IndexError:
+            eos_token = "<EOS>"
+        _add_special_token(eos_token)
+        self._eos_id = self._vocab.get(eos_token)
+
+        for i in range(vocab_extra_ids):
+            t = "<extra_id_{}>".format(i)
+            _add_special_token(t)
+            self._t5_tokens += [t]
+        if vocab_extra_ids_list:
+            for t in vocab_extra_ids_list.split(","):
+                _add_special_token(t)
+        print("Special tokens: {}".format(self._special_tokens))
+
+    @property
+    def vocab_size(self):
+        return len(self._vocab)
+
+    @property
+    def vocab(self):
+        return self._vocab
+
+    @property
+    def inv_vocab(self):
+        return self._inv_vocab
+
+    # From:
+    # https://github.com/NVIDIA/NeMo/blob/c8fa217e811d60d11d014827c7f3845ff6c99ae7/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py#L89
+    def tokenize(self, text):
+        ids = []
+        idx = 0
+
+        while 1:
+            indices = {}
+            for token in self._special_tokens:
+                try:
+                    indices[token] = text[idx:].index(token)
+                except ValueError:
+                    continue
+            if len(indices) == 0:
+                break
+
+            next_token = min(indices, key=indices.get)
+            next_idx = idx + indices[next_token]
+
+            ids.extend(self._tokenizer.encode_as_ids(text[idx:next_idx]))
+            ids.append(self._special_tokens[next_token])
+            idx = next_idx + len(next_token)
+
+        ids.extend(self._tokenizer.encode_as_ids(text[idx:]))
+        return ids
+
+    # From:
+    # https://github.com/NVIDIA/NeMo/blob/c8fa217e811d60d11d014827c7f3845ff6c99ae7/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py#L125
+    def detokenize(self, ids):
+        text = ""
+        last_i = 0
+
+        for i, id in enumerate(ids):
+            if id in self._inv_special_tokens:
+                text += self._tokenizer.decode_ids(ids[last_i:i]) + " "
+                text += self._inv_special_tokens[id] + " "
+                last_i = i + 1
+        text += self._tokenizer.decode_ids(ids[last_i:])
+        return text.strip()
+
+    @property
+    def cls(self):
+        return self._cls_id
+
+    @property
+    def sep(self):
+        return self._sep_id
+
+    @property
+    def pad(self):
+        return self._pad_id
+
+    @property
+    def bos_token_id(self):
+        return self._bos_id
+
+    @property
+    def bos(self):
+        return self._bos_id
+
+    @property
+    def eod(self):
+        if self._eod_id is not None:
+            return self._eod_id
+        return self._eos_id  # in case noe eod we can patch this up with an eos
+
+    @property
+    def eos_token_id(self):
+        if self._eod_id is not None:
+            return self._eod_id
+        return self._eos_id
+
+    @property
+    def eos(self):
+        return self._eos_id
+
+    @property
+    def mask(self):
+        return self._mask_id
+
+    @property
+    def additional_special_tokens_ids(self):
+        return [self.vocab[k] for k in self._t5_tokens]


### PR DESCRIPTION
The pretokenizer utility (`pretokenizer/pretokenize.py`) allows to tokenize datamixes in advance for use with the [epfLLM/Megatron-LLM/](https://github.com/epfLLM/Megatron-LLM) trainer.

The datamix configuration can be defined in a yaml file similarly to the classic training configurations of trainer_sft.py. For loading the datasets the functions from `model_training` are used (therefore the model_training module needs to be installed). 