### PR TITLE
Update export.py

### DIFF
--- a/inference/server/export.py
+++ b/inference/server/export.py
@@ -27,19 +27,17 @@ from oasst_inference_server.models import DbChat, DbMessage
 from oasst_shared.utils import Anonymizer
 
 
-# see https://stackoverflow.com/questions/17602878/how-to-handle-both-with-open-and-sys-stdout-nicely
-@contextlib.contextmanager
-def smart_open(filename: str = None) -> TextIO:
-    if filename and filename != "-":
-        fh = open(filename, "wt", encoding="UTF-8")
-    else:
-        fh = sys.stdout
+import contextlib
 
-    try:
-        yield fh
-    finally:
-        if fh is not sys.stdout:
-            fh.close()
+@contextlib.contextmanager
+def smart_open(filename: str = None):
+    if filename and filename != "-":
+        with open(filename, "wt", encoding="UTF-8") as fh:
+            yield fh
+    else:
+        with contextlib.redirect_stdout(sys.stdout):
+            yield sys.stdout
+
 
 
 def maybe_anonymize(anonymizer: Anonymizer | None, collection: str, key: str) -> str:


### PR DESCRIPTION
With this approach, you don't need to manually open and close the file or standard output. Instead, you use the redirect_stdout context manager to temporarily redirect the standard output to the desired target (either a file or sys.stdout), and it will automatically handle the cleanup when the context exits.