### PR TITLE
test: add unit tests for task_repository

### DIFF
--- a/backend/tests/test_task_repository.py
+++ b/backend/tests/test_task_repository.py
@@ -1,4 +1,3 @@
-
 import pytest
 from oasst_backend.task_repository import validate_frontend_message_id
 from oasst_shared.exceptions.oasst_api_error import OasstError, OasstErrorCode
@@ -8,6 +7,7 @@ def test_validate_frontend_message_id_valid():
     """Test that a valid string ID passes validation."""
     validate_frontend_message_id("valid-id-123")
 
+
 def test_validate_frontend_message_id_empty():
     """Test that an empty string raises an error."""
     with pytest.raises(OasstError) as excinfo:
@@ -16,6 +16,7 @@ def test_validate_frontend_message_id_empty():
     assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
     assert "message_id must not be empty" in str(excinfo.value)
 
+
 def test_validate_frontend_message_id_none():
     """Test that None raises an error."""
     with pytest.raises(OasstError) as excinfo:
@@ -23,6 +24,7 @@ def test_validate_frontend_message_id_none():
 
     assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
     assert "message_id must be string" in str(excinfo.value)
+
 
 def test_validate_frontend_message_id_wrong_type():
     """Test that a non-string type raises an error."""

--- a/backend/tests/test_task_repository.py
+++ b/backend/tests/test_task_repository.py
@@ -3,6 +3,7 @@ import pytest
 from oasst_backend.task_repository import validate_frontend_message_id
 from oasst_shared.exceptions.oasst_api_error import OasstError, OasstErrorCode
 
+
 def test_validate_frontend_message_id_valid():
     """Test that a valid string ID passes validation."""
     validate_frontend_message_id("valid-id-123")
@@ -11,7 +12,7 @@ def test_validate_frontend_message_id_empty():
     """Test that an empty string raises an error."""
     with pytest.raises(OasstError) as excinfo:
         validate_frontend_message_id("")
-    
+
     assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
     assert "message_id must not be empty" in str(excinfo.value)
 
@@ -19,7 +20,7 @@ def test_validate_frontend_message_id_none():
     """Test that None raises an error."""
     with pytest.raises(OasstError) as excinfo:
         validate_frontend_message_id(None)
-    
+
     assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
     assert "message_id must be string" in str(excinfo.value)
 
@@ -27,6 +28,6 @@ def test_validate_frontend_message_id_wrong_type():
     """Test that a non-string type raises an error."""
     with pytest.raises(OasstError) as excinfo:
         validate_frontend_message_id(12345)
-    
+
     assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
     assert "message_id must be string" in str(excinfo.value)

--- a/backend/tests/test_task_repository.py
+++ b/backend/tests/test_task_repository.py
@@ -1,0 +1,32 @@
+
+import pytest
+from oasst_backend.task_repository import validate_frontend_message_id
+from oasst_shared.exceptions.oasst_api_error import OasstError, OasstErrorCode
+
+def test_validate_frontend_message_id_valid():
+    """Test that a valid string ID passes validation."""
+    validate_frontend_message_id("valid-id-123")
+
+def test_validate_frontend_message_id_empty():
+    """Test that an empty string raises an error."""
+    with pytest.raises(OasstError) as excinfo:
+        validate_frontend_message_id("")
+    
+    assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
+    assert "message_id must not be empty" in str(excinfo.value)
+
+def test_validate_frontend_message_id_none():
+    """Test that None raises an error."""
+    with pytest.raises(OasstError) as excinfo:
+        validate_frontend_message_id(None)
+    
+    assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
+    assert "message_id must be string" in str(excinfo.value)
+
+def test_validate_frontend_message_id_wrong_type():
+    """Test that a non-string type raises an error."""
+    with pytest.raises(OasstError) as excinfo:
+        validate_frontend_message_id(12345)
+    
+    assert excinfo.value.error_code == OasstErrorCode.INVALID_FRONTEND_MESSAGE_ID
+    assert "message_id must be string" in str(excinfo.value)


### PR DESCRIPTION
## Description
This PR adds unit tests for `backend/oasst_backend/task_repository.py`.
Specifically, it adds test coverage for the `validate_frontend_message_id` function to ensure robustness against invalid inputs.

## Changes
- Added `backend/tests/test_task_repository.py`
- Added tests for:
    - Valid message IDs
    - Empty message IDs
    - None values
    - Invalid types

## Verification
- Ran tests locally using `pytest`.
- All tests passed.